### PR TITLE
Add protocol lock for v0 schema work

### DIFF
--- a/00-principles.md
+++ b/00-principles.md
@@ -198,7 +198,7 @@ Learning must be proposed, reviewed, scoped, and accepted. Jarvis asks:
 - what did the human learn?
 - what did the agent learn?
 - what did the human-agent pair learn?
-- what should improve next time?
+- what improves next time?
 
 ## Skills Are Procedural Memory
 
@@ -237,7 +237,7 @@ collaboration and learning-loop protocol those systems implement.
 9. Human judgment remains central.
 10. Execution may be delegated; accountability remains attributable.
 11. HumanWorker and AgentWorker both learn.
-12. Every session should improve the next session.
+12. Every completed WorkSession improves the next WorkSession.
 
 ## Non-Goals
 

--- a/01-architecture.md
+++ b/01-architecture.md
@@ -33,8 +33,8 @@ records and state transitions that make the work collaborative, governed,
 reviewable, attributable, and portable.
 
 Compatibility is the architecture goal. A HumanWorker, AgentWorker, product,
-host, or external system should be able to participate without adopting another
-system's execution stack or product model.
+host, or external system can participate without adopting another system's
+execution stack or product model.
 
 ## Core Protocol Contracts
 

--- a/12-30-day-roadmap.md
+++ b/12-30-day-roadmap.md
@@ -2,9 +2,9 @@
 
 This roadmap turns Jarvis from design into a credible protocol proof.
 
-Jarvis is not an agent framework, runtime, agent harness, cloud stack, or
+Jarvis is not an agent framework, runtime, agent wrapper, cloud stack, or
 product UI. Jarvis is the human-agent collaboration and learning-loop
-protocol. The next 30 days must prove that existing agents and products can be
+protocol. The next 30 days prove that existing agents and products can be
 wrapped with Jarvis contracts without replacing their runtime.
 
 ## Thesis
@@ -23,13 +23,13 @@ Jarvis wins by defining the missing standard record for:
 - governed LearningRecords
 - MemoryProposal and SkillProposal loops
 
-The practical proof is simple: a human and an existing agent should complete
-real work through a WorkSession, produce evidence, record who did what, and
-leave behind learning that improves the next WorkSession.
+The practical proof is simple: a human and an existing agent complete real
+work through a WorkSession, produce evidence, record who did what, and leave
+behind learning that improves the next WorkSession.
 
 ## Current Protocol Landscape
 
-Jarvis should position itself beside existing standards:
+Jarvis sits beside existing standards:
 
 - MCP standardizes how LLM apps connect to external tools, resources, and
   prompts. Jarvis can record MCP tool use as protocol evidence, but Jarvis is
@@ -56,7 +56,7 @@ Protocol grounding:
 By the end of 30 days, we must be able to show:
 
 ```txt
-Existing agent or Garden POC
+Existing agent or first host POC
   -> wrapped by Jarvis protocol adapter
   -> HumanWorker starts WorkSession
   -> AgentWorker acts inside Policy
@@ -91,9 +91,9 @@ Done when:
 
 - every document uses the same core object names
 - no document describes Jarvis as a runtime, product, agent framework, or
-  personal agent
+  agent application
 - every core object has a reason to exist
-- we can explain Jarvis in one paragraph without mentioning any host product
+- Jarvis can be explained in one paragraph without mentioning any host product
   or downstream evaluation system
 
 ## Week 2: Schemas, Conformance, And Adapter Surface
@@ -128,15 +128,15 @@ Done when:
   evidence, or learning
 - adapters do not require the agent runtime to be rewritten
 
-## Week 3: Garden POC End-To-End Integration
+## Week 3: First Host POC End-To-End Integration
 
-Goal: use the existing Garden POC as the first host proof, without making
-Jarvis depend on Garden.
+Goal: use the existing host POC as the first proof without making Jarvis depend
+on that host.
 
 Deliverables:
 
-- map Garden POC concepts to Jarvis objects
-- create one Garden-backed WorkSession flow
+- map host POC concepts to Jarvis objects
+- create one host-backed WorkSession flow
 - show HumanWorker objective entry
 - show AgentWorker execution inside policy
 - show Request inbox when the agent needs permission or judgment
@@ -144,13 +144,13 @@ Deliverables:
 - record Contribution entries
 - produce EvidenceManifest export
 - produce LearningRecord and MemoryProposal after review
-- document what belongs to Garden and what belongs to Jarvis
+- document what belongs to the host and what belongs to Jarvis
 
 Done when:
 
-- Garden can demonstrate the Jarvis loop end to end
-- Jarvis protocol records can be exported from the Garden POC
-- the exported records do not contain Garden-private assumptions
+- the host demonstrates the Jarvis loop end to end
+- Jarvis protocol records can be exported from the host POC
+- the exported records do not contain host-private assumptions
 - the demo proves human and agent both improve, not only agent memory
 
 ## Week 4: Interoperability Demo And Public Story
@@ -159,7 +159,7 @@ Goal: prove Jarvis works with existing agents and is worth discussing publicly.
 
 Deliverables:
 
-- one Garden POC demo
+- one host POC demo
 - one CLI-agent wrapper demo
 - one external-agent or simulated-agent wrapper demo
 - public README tightened around protocol positioning
@@ -180,36 +180,36 @@ Done when:
 
 - at least two different host shapes can produce the same Jarvis protocol
   records
-- the Garden POC is one host, not the protocol itself
+- the host POC is one host, not the protocol itself
 - the team can share one URL and one README that explain the point clearly
 - the protocol can be discussed as a standard, not an internal app feature
 
 ## Daily Operating Rhythm
 
-Every day should produce one visible artifact:
+Every day produces one visible artifact:
 
 - spec page
 - schema
 - JSON example
 - conformance test/checklist
 - adapter note
-- Garden POC mapping
+- host POC mapping
 - demo screenshot
 - public docs update
 
 Daily review questions:
 
 1. Did we strengthen the protocol or drift into building a runtime?
-2. Can this work with an existing agent without rewriting the agent?
+2. Does this work with an existing agent without rewriting the agent?
 3. Did we capture human judgment, agent action, contribution, evidence, and
    learning?
-4. Can another host implement this without Garden?
+4. Can another host implement this without host-specific assumptions?
 5. Does this improve the next WorkSession?
 
 ## Non-Negotiables
 
 - Jarvis remains protocol-only.
-- Garden is only the first proof host.
+- The first POC is only a proof host.
 - Existing agents remain first-class.
 - HumanWorker and AgentWorker are both actors.
 - Learning belongs to the human, agent, and pair.
@@ -223,8 +223,8 @@ Daily review questions:
 1. Freeze the object model in `11-core-protocol-objects.md`.
 2. Create JSON examples for one complete WorkSession.
 3. Draft the adapter contract for wrapping an existing agent.
-4. Map Garden POC concepts to Jarvis objects.
-5. Decide the first two proof hosts: Garden POC plus one CLI/external-agent
+4. Map host POC concepts to Jarvis objects.
+5. Decide the first two proof hosts: one product host plus one CLI/external-agent
    wrapper.
 
 If these are clear, the rest of the 30 days becomes execution rather than

--- a/13-protocol-readiness-review.md
+++ b/13-protocol-readiness-review.md
@@ -16,7 +16,7 @@ task marketplace, or cloud stack.
 
 ## Protocol Patterns Reviewed
 
-Jarvis should follow proven protocol habits from existing standards:
+Jarvis follows proven protocol habits from existing standards:
 
 - HTTP separates semantics from implementation and deployment.
 - OAuth separates actors, grants, authorization, and resource access.
@@ -37,9 +37,9 @@ References:
 - A2A: https://a2a-protocol.org/latest/
 - AG-UI: https://docs.ag-ui.com/
 
-## What Jarvis Must Borrow
+## Protocol Disciplines
 
-Jarvis should borrow these protocol disciplines:
+Jarvis uses these protocol disciplines:
 
 - explicit actors and roles
 - lifecycle states
@@ -89,7 +89,7 @@ The review tightened:
 
 - duplicate core contract names in the README
 - duplicate `JarvisEvent` entry in the roadmap
-- stale `harness` wording in policy docs
+- stale agent-wrapper wording in policy docs
 - host integration pseudocode so actor ids and worker ids are not confused
 - WorkSession evidence section headings
 - roadmap wording that tied protocol explanation to named downstream systems

--- a/13-protocol-readiness-review.md
+++ b/13-protocol-readiness-review.md
@@ -1,6 +1,6 @@
 # Protocol Readiness Review
 
-This review checks whether Jarvis is ready to move from design into schemas,
+This review confirms Jarvis is ready to move from design into schemas,
 examples, conformance tests, and host proofs.
 
 ## Review Baseline
@@ -116,6 +116,5 @@ The design is ready to start Week 1 execution.
 The protocol thesis is stable. The boundaries are stable. The object set is
 stable enough to begin schemas and examples.
 
-The next work should not reopen whether Jarvis is a protocol. It should define
-the machine-readable contract, versioning, conformance tests, and the first
-Garden POC mapping.
+The next work is the machine-readable contract, versioning, conformance tests,
+and the first host proof mapping.

--- a/14-protocol-lock.md
+++ b/14-protocol-lock.md
@@ -1,57 +1,82 @@
 # Protocol Lock
 
-This document locks the first implementable shape of Jarvis.
-
-Jarvis is the human-agent collaboration and learning-loop protocol. It defines
-the durable record of how a HumanWorker and AgentWorker collaborate under
-shared goals and human-defined policy, produce reviewable requests, record
-contributions, capture portable evidence, and learn together across
-WorkSessions.
-
-This lock exists so implementation starts from stable protocol meaning instead
-of drifting into another runtime, agent framework, product UI, or internal
-workflow.
-
-## Lock Status
-
-Status: `locked-for-v0-schema-draft`
-
-Meaning:
-
-- the thesis is locked
-- the boundary is locked
-- the core object names are locked
-- the core lifecycle is locked
-- the conformance expectations are locked
-- field-level schemas are not locked yet
-- extension and version negotiation are not locked yet
-
-Schema work may begin after this document is accepted.
-
-## Official Definition
-
 Jarvis is the human-agent collaboration and learning-loop protocol.
 
-It defines how HumanWorkers and AgentWorkers coordinate under shared goals and
-Policy, so they can complete WorkSessions together, create Requests when the
-agent is blocked, capture Reviews and Takeovers from the human, record
-Contributions, export EvidenceManifests, and govern LearningRecords,
-MemoryProposals, and SkillProposals.
+It defines how a HumanWorker and an AgentWorker work together under shared
+goals and human-defined policy. The protocol records the work, requests,
+reviews, takeovers, contributions, evidence, and learning that happen inside a
+WorkSession.
 
-## Locked Thesis
+This is the v0 lock. Schema work starts from here.
+
+## Locked Status
+
+`locked-for-v0-schema-draft`
+
+Locked now:
+
+- thesis
+- boundary
+- vocabulary
+- lifecycle
+- object relationships
+- core states
+- conformance expectations
+- portable export shape
+
+Not locked yet:
+
+- exact JSON fields
+- version negotiation
+- capability negotiation
+- extension format
+- error codes
+- conformance fixtures
+
+## Definition
+
+Jarvis is the protocol for governed human-agent collaboration and shared
+learning.
+
+The HumanWorker brings goals, judgment, context, correction, review, taste, and
+accountability.
+
+The AgentWorker brings execution, research, planning, drafting, tool use,
+memory retrieval, evidence capture, and workflow acceleration.
+
+Jarvis records how both workers collaborate and improve across WorkSessions.
+
+## Thesis
 
 The valuable unit is the human-agent team.
 
-Jarvis does not optimize for an agent alone. Jarvis does not reduce the human
-to a prompt source. Jarvis defines the protocol record of both workers acting,
-reviewing, correcting, producing evidence, and learning together.
+Not the human alone.
+Not the agent alone.
+Not a chatbot.
+Not a runtime.
+Not a product workspace.
 
-The HumanWorker improves. The AgentWorker improves. The pair improves. The
-next WorkSession should benefit from confirmed learning.
+The HumanWorker improves.
+The AgentWorker improves.
+The pair improves.
+The next WorkSession carries confirmed learning forward.
 
-## Locked Non-Goals
+## Boundary
 
-Jarvis MUST NOT define or own:
+Jarvis owns:
+
+- protocol vocabulary
+- object semantics
+- WorkSession lifecycle
+- event envelope
+- policy decision semantics
+- request, review, and takeover semantics
+- contribution semantics
+- evidence export semantics
+- governed learning semantics
+- conformance expectations
+
+Jarvis does not own:
 
 - agent runtime
 - model provider
@@ -60,21 +85,18 @@ Jarvis MUST NOT define or own:
 - database implementation
 - queue implementation
 - product UI
-- authentication system
-- billing system
+- authentication
+- billing
 - task marketplace
-- payment or settlement system
+- payment or settlement
 - organization workspace internals
-- specific agent framework
-- specific local execution stack
+- local execution stack
 
-Products and hosts MAY use any of those systems. Jarvis only defines the
-protocol records and state transitions those systems must preserve to be
-Jarvis-compatible.
+A host implements Jarvis. A host is not Jarvis.
 
-## Locked Core Vocabulary
+## Vocabulary
 
-The v0 protocol vocabulary is:
+The v0 vocabulary is:
 
 ```txt
 Worker
@@ -95,39 +117,31 @@ MemoryProposal
 SkillProposal
 ```
 
-These names are locked for v0 schema drafting.
+These names are stable for the v0 schema draft.
 
-Any later rename MUST include:
+## Relationship Model
 
-- reason for the rename
-- migration impact
-- affected schema names
-- affected conformance tests
-- compatibility policy
-
-## Locked Relationship Model
-
-Jarvis models:
+Jarvis models this:
 
 ```txt
 HumanWorker + AgentWorker
   collaborate inside WorkSession
   under Policy
   through JarvisEvents
-  with Requests, Reviews, and Takeovers
+  using Requests, Reviews, and Takeovers
   producing Contributions and EvidenceManifest
   generating LearningRecords, MemoryProposals, and SkillProposals
 ```
 
-Jarvis does not model:
+Jarvis does not model this:
 
 ```txt
 User -> Assistant -> Answer
 ```
 
-Chat MAY be one interface. The protocol is the collaboration record.
+Chat can be an interface. The protocol is the collaboration record.
 
-## Locked Lifecycle
+## Lifecycle
 
 The v0 lifecycle is:
 
@@ -142,22 +156,25 @@ The v0 lifecycle is:
 8. assemble context and available capabilities
 9. AgentWorker proposes or performs action
 10. Policy produces PolicyDecision
-11. allowed action records JarvisEvent and Evidence
+11. allowed action records JarvisEvent and evidence
 12. denied or review-required action creates Request
 13. HumanWorker responds through Review or Takeover
-14. approved work resumes inside narrowed or confirmed Policy
+14. approved work resumes inside confirmed or narrowed Policy
 15. Contribution records who did what
 16. EvidenceManifest records portable proof
 17. LearningRecord captures human, agent, or pair learning
-18. MemoryProposal and SkillProposal remain governed until reviewed
+18. MemoryProposal and SkillProposal stay governed until reviewed
 19. WorkSession completes, fails, or closes
 20. portable export is produced
 ```
 
-This lifecycle is the minimum standard. A host MAY add more internal steps, but
-it MUST preserve the protocol lifecycle externally.
+Hosts can add internal steps. The external Jarvis lifecycle stays intact.
 
-## Locked WorkSession States
+## WorkSession
+
+WorkSession is the source of truth.
+
+States:
 
 ```txt
 created
@@ -172,14 +189,18 @@ closed
 
 Rules:
 
-- A WorkSession MUST NOT start without HumanWorker, AgentWorker, objective, and
-  Policy.
-- A WorkSession MUST keep an append-only JarvisEvent log.
-- A WorkSession MUST be the source of truth for Requests, Reviews,
-  Contributions, EvidenceManifest, and LearningRecords.
-- A WorkSession export MUST NOT require product-private infrastructure fields.
+- WorkSession starts with HumanWorker, AgentWorker, objective, and Policy.
+- WorkSession keeps an append-only JarvisEvent log.
+- WorkSession owns Requests, Reviews, Takeovers, Contributions,
+  EvidenceManifest, and LearningRecords.
+- WorkSession export stays free of product-private infrastructure fields.
 
-## Locked Request States
+## Request
+
+Request is the structured way the AgentWorker asks for permission, context,
+judgment, review, or takeover.
+
+States:
 
 ```txt
 pending
@@ -195,13 +216,17 @@ cancelled
 
 Rules:
 
-- A Request MUST belong to one WorkSession.
-- A Request MUST identify requester worker and requester actor.
-- A Request MUST state the reason, requested action or missing context, risk
-  class, status, and creation time.
-- A Request MUST NOT resolve without Review or Takeover.
+- Request belongs to one WorkSession.
+- Request identifies requester worker and requester actor.
+- Request states reason, requested action or missing context, risk class,
+  status, and creation time.
+- Request resolves through Review or Takeover.
 
-## Locked Review Decisions
+## Review
+
+Review records human judgment.
+
+Decisions:
 
 ```txt
 approve
@@ -214,13 +239,13 @@ needs_revision
 
 Rules:
 
-- A Review MUST identify reviewer worker and reviewer actor.
-- A Review MUST target a Request, action, contribution, artifact, memory
-  proposal, skill proposal, evidence item, or final outcome.
-- A Review MAY resolve a Request.
-- A Review MAY create LearningRecord, MemoryProposal, or SkillProposal signals.
+- Review identifies reviewer worker and reviewer actor.
+- Review targets a Request, action, contribution, artifact, memory proposal,
+  skill proposal, evidence item, or final outcome.
+- Review can resolve a Request.
+- Review can create learning signals.
 
-## Locked Takeover Model
+## Takeover
 
 Takeover is temporary direct human control.
 
@@ -237,16 +262,16 @@ closed
 
 Rules:
 
-- Takeover MUST create or increment a lock epoch.
-- Agent actions from an old lock epoch MUST be rejected.
-- Resume MUST require reconciliation.
-- Takeover MUST be recorded as a learning signal.
+- Takeover creates or increments a lock epoch.
+- Agent actions from an old lock epoch are stale.
+- Resume requires reconciliation.
+- Takeover is a learning signal.
 
-## Locked Contribution Model
+## Contribution
 
 Contribution answers who did what.
 
-Contribution types include:
+Contribution types:
 
 ```txt
 intent
@@ -264,7 +289,7 @@ skill_proposal
 submission
 ```
 
-Contributor types are:
+Contributor types:
 
 ```txt
 human
@@ -276,16 +301,16 @@ shared
 
 Rules:
 
-- Contributions MUST distinguish human, agent, service, tool, and shared work.
-- Shared contribution MUST NOT erase individual contributing actors.
-- Contribution is not payment or accounting. It is the protocol attribution
-  record downstream systems MAY evaluate.
+- Human, agent, service, tool, and shared contributions stay distinguishable.
+- Shared contribution does not erase individual actors.
+- Contribution is attribution, not payment or accounting.
+- Downstream systems can evaluate Contribution records.
 
-## Locked Evidence Model
+## Evidence
 
 EvidenceManifest is the portable proof package for a WorkSession.
 
-It MUST include references to:
+It references:
 
 - WorkSession
 - event chain root
@@ -300,16 +325,16 @@ It MUST include references to:
 
 Rules:
 
-- Evidence MUST be captured during work.
-- Evidence MUST NOT be reconstructed only at the end.
-- Redacted exports MUST remain derived from the same event chain.
-- EvidenceManifest MUST be portable across compatible products and hosts.
+- Evidence is captured during work.
+- Evidence is not reconstructed only at the end.
+- Redacted exports stay derived from the same event chain.
+- EvidenceManifest is portable across compatible products and hosts.
 
-## Locked Learning Model
+## Learning
 
 LearningRecord captures what improved because of the WorkSession.
 
-Subject types are:
+Subject types:
 
 ```txt
 human
@@ -319,17 +344,16 @@ pair
 
 Rules:
 
-- Learning MUST NOT mean only agent memory.
-- Jarvis MUST record human learning, agent learning, and pair learning.
-- LearningRecord MAY point to MemoryProposal or SkillProposal.
-- Durable memory and active skill behavior MUST require governed review.
+- Learning is not only agent memory.
+- Jarvis records human learning, agent learning, and pair learning.
+- LearningRecord can point to MemoryProposal or SkillProposal.
+- Durable memory and active skill behavior require governed review.
 
-## Locked Compatibility Target
+## Compatibility
 
-Existing agents and products remain first-class.
+Existing agents and products are first-class.
 
-Jarvis-compatible adapters MUST be able to wrap an existing agent without
-rewriting the agent runtime.
+Jarvis wraps existing agents. It does not replace their runtime.
 
 A compatible adapter maps:
 
@@ -346,53 +370,19 @@ trace/artifact/source/output     -> EvidenceManifest entry
 confirmed improvement            -> LearningRecord / MemoryProposal / SkillProposal
 ```
 
-If an adapter cannot expose a native concept, it MUST either:
+If a host cannot expose a native concept, it records the closest valid Jarvis
+object with explicit limitations or marks the capability unsupported.
 
-- produce the closest valid Jarvis record with explicit limitations, or
-- mark the capability unsupported during capability negotiation.
+## Conformance
 
-## Locked Host Boundary
-
-A host implements Jarvis. A host is not Jarvis.
-
-Hosts own:
-
-- UI
-- accounts and identity integration
-- model selection
-- tool execution
-- MCP hosting
-- sandbox choice
-- storage
-- queues
-- deployment
-- observability
-- billing
-- product-specific workflows
-
-Jarvis owns:
-
-- protocol vocabulary
-- object semantics
-- lifecycle states
-- event envelope
-- policy decision semantics
-- request/review/takeover semantics
-- contribution semantics
-- evidence export semantics
-- governed learning semantics
-- conformance expectations
-
-## Locked Conformance Expectations
-
-A v0-compatible host MUST prove:
+A v0-compatible host proves:
 
 - WorkSession is the source of truth.
 - HumanWorker and AgentWorker both exist.
 - Every meaningful JarvisEvent has an Actor.
 - Policy gates autonomous AgentWorker action.
 - Policy-denied or review-required action creates Request.
-- Request cannot resolve without Review or Takeover.
+- Request resolves through Review or Takeover.
 - Review decisions are explicit.
 - Takeover blocks stale autonomous continuation.
 - Contributions are attributable.
@@ -401,9 +391,9 @@ A v0-compatible host MUST prove:
 - MemoryProposal and SkillProposal do not silently become durable behavior.
 - Portable export contains no product-private infrastructure requirement.
 
-## Locked Portable Export
+## Portable Export
 
-A v0 portable export MUST contain:
+A v0 portable export contains:
 
 ```txt
 protocol_version
@@ -423,38 +413,20 @@ SkillProposals
 limitations
 ```
 
-The export MAY contain extension fields only when they are namespaced and do
-not change the meaning of the core protocol fields.
+Extension fields are namespaced. Extensions do not change the meaning of core
+protocol fields.
 
-## Open Before Schema Freeze
+## Schema Work Starts Here
 
-These questions remain open for the schema phase:
+The next work is:
 
-1. Version negotiation shape.
-2. Capability negotiation shape.
-3. Extension namespace format.
-4. Standard error codes.
-5. Required vs optional fields per object.
-6. JSON Schema package layout.
-7. Canonical example WorkSession export.
-8. Passing and failing conformance fixtures.
+1. version negotiation
+2. capability negotiation
+3. extension namespace format
+4. standard error codes
+5. required and optional fields per object
+6. JSON Schema package layout
+7. canonical WorkSession export example
+8. passing and failing conformance fixtures
 
-These are schema questions, not thesis questions.
-
-## Entry Gate For Schemas
-
-Schema drafting can begin when this document is accepted.
-
-Schema drafting MUST use:
-
-- this document for locked meaning
-- `11-core-protocol-objects.md` for object definitions
-- `13-protocol-readiness-review.md` for readiness gaps
-
-Schema drafting MUST NOT reopen:
-
-- whether Jarvis is a protocol
-- whether Jarvis owns runtime
-- whether any host product is the protocol
-- whether human and agent both learn
-- whether WorkSession is the source of truth
+The thesis is locked. The object model is locked. The lifecycle is locked.

--- a/14-protocol-lock.md
+++ b/14-protocol-lock.md
@@ -1,0 +1,460 @@
+# Protocol Lock
+
+This document locks the first implementable shape of Jarvis.
+
+Jarvis is the human-agent collaboration and learning-loop protocol. It defines
+the durable record of how a HumanWorker and AgentWorker collaborate under
+shared goals and human-defined policy, produce reviewable requests, record
+contributions, capture portable evidence, and learn together across
+WorkSessions.
+
+This lock exists so implementation starts from stable protocol meaning instead
+of drifting into another runtime, agent framework, product UI, or internal
+workflow.
+
+## Lock Status
+
+Status: `locked-for-v0-schema-draft`
+
+Meaning:
+
+- the thesis is locked
+- the boundary is locked
+- the core object names are locked
+- the core lifecycle is locked
+- the conformance expectations are locked
+- field-level schemas are not locked yet
+- extension and version negotiation are not locked yet
+
+Schema work may begin after this document is accepted.
+
+## Official Definition
+
+Jarvis is the human-agent collaboration and learning-loop protocol.
+
+It defines how HumanWorkers and AgentWorkers coordinate under shared goals and
+Policy, so they can complete WorkSessions together, create Requests when the
+agent is blocked, capture Reviews and Takeovers from the human, record
+Contributions, export EvidenceManifests, and govern LearningRecords,
+MemoryProposals, and SkillProposals.
+
+## Locked Thesis
+
+The valuable unit is the human-agent team.
+
+Jarvis does not optimize for an agent alone. Jarvis does not reduce the human
+to a prompt source. Jarvis defines the protocol record of both workers acting,
+reviewing, correcting, producing evidence, and learning together.
+
+The HumanWorker improves. The AgentWorker improves. The pair improves. The
+next WorkSession should benefit from confirmed learning.
+
+## Locked Non-Goals
+
+Jarvis MUST NOT define or own:
+
+- agent runtime
+- model provider
+- cloud provider
+- sandbox implementation
+- database implementation
+- queue implementation
+- product UI
+- authentication system
+- billing system
+- task marketplace
+- payment or settlement system
+- organization workspace internals
+- specific agent framework
+- specific local execution stack
+
+Products and hosts MAY use any of those systems. Jarvis only defines the
+protocol records and state transitions those systems must preserve to be
+Jarvis-compatible.
+
+## Locked Core Vocabulary
+
+The v0 protocol vocabulary is:
+
+```txt
+Worker
+Actor
+HumanWorker
+AgentWorker
+WorkSession
+JarvisEvent
+Policy
+PolicyDecision
+Request
+Review
+Takeover
+Contribution
+EvidenceManifest
+LearningRecord
+MemoryProposal
+SkillProposal
+```
+
+These names are locked for v0 schema drafting.
+
+Any later rename MUST include:
+
+- reason for the rename
+- migration impact
+- affected schema names
+- affected conformance tests
+- compatibility policy
+
+## Locked Relationship Model
+
+Jarvis models:
+
+```txt
+HumanWorker + AgentWorker
+  collaborate inside WorkSession
+  under Policy
+  through JarvisEvents
+  with Requests, Reviews, and Takeovers
+  producing Contributions and EvidenceManifest
+  generating LearningRecords, MemoryProposals, and SkillProposals
+```
+
+Jarvis does not model:
+
+```txt
+User -> Assistant -> Answer
+```
+
+Chat MAY be one interface. The protocol is the collaboration record.
+
+## Locked Lifecycle
+
+The v0 lifecycle is:
+
+```txt
+1. create Worker records
+2. create Actor records
+3. create HumanWorker
+4. create AgentWorker
+5. start WorkSession
+6. attach Policy
+7. record objective
+8. assemble context and available capabilities
+9. AgentWorker proposes or performs action
+10. Policy produces PolicyDecision
+11. allowed action records JarvisEvent and Evidence
+12. denied or review-required action creates Request
+13. HumanWorker responds through Review or Takeover
+14. approved work resumes inside narrowed or confirmed Policy
+15. Contribution records who did what
+16. EvidenceManifest records portable proof
+17. LearningRecord captures human, agent, or pair learning
+18. MemoryProposal and SkillProposal remain governed until reviewed
+19. WorkSession completes, fails, or closes
+20. portable export is produced
+```
+
+This lifecycle is the minimum standard. A host MAY add more internal steps, but
+it MUST preserve the protocol lifecycle externally.
+
+## Locked WorkSession States
+
+```txt
+created
+active
+waiting_on_human
+takeover
+reconciling
+completed
+failed
+closed
+```
+
+Rules:
+
+- A WorkSession MUST NOT start without HumanWorker, AgentWorker, objective, and
+  Policy.
+- A WorkSession MUST keep an append-only JarvisEvent log.
+- A WorkSession MUST be the source of truth for Requests, Reviews,
+  Contributions, EvidenceManifest, and LearningRecords.
+- A WorkSession export MUST NOT require product-private infrastructure fields.
+
+## Locked Request States
+
+```txt
+pending
+approved
+denied
+narrowed
+answered
+takeover
+needs_revision
+expired
+cancelled
+```
+
+Rules:
+
+- A Request MUST belong to one WorkSession.
+- A Request MUST identify requester worker and requester actor.
+- A Request MUST state the reason, requested action or missing context, risk
+  class, status, and creation time.
+- A Request MUST NOT resolve without Review or Takeover.
+
+## Locked Review Decisions
+
+```txt
+approve
+deny
+narrow
+correct
+takeover
+needs_revision
+```
+
+Rules:
+
+- A Review MUST identify reviewer worker and reviewer actor.
+- A Review MUST target a Request, action, contribution, artifact, memory
+  proposal, skill proposal, evidence item, or final outcome.
+- A Review MAY resolve a Request.
+- A Review MAY create LearningRecord, MemoryProposal, or SkillProposal signals.
+
+## Locked Takeover Model
+
+Takeover is temporary direct human control.
+
+States:
+
+```txt
+requested
+locked
+human_active
+reconciliation_required
+resumed
+closed
+```
+
+Rules:
+
+- Takeover MUST create or increment a lock epoch.
+- Agent actions from an old lock epoch MUST be rejected.
+- Resume MUST require reconciliation.
+- Takeover MUST be recorded as a learning signal.
+
+## Locked Contribution Model
+
+Contribution answers who did what.
+
+Contribution types include:
+
+```txt
+intent
+instruction
+plan
+research
+execution
+artifact
+review
+correction
+decision
+evidence_capture
+memory_proposal
+skill_proposal
+submission
+```
+
+Contributor types are:
+
+```txt
+human
+agent
+service
+tool
+shared
+```
+
+Rules:
+
+- Contributions MUST distinguish human, agent, service, tool, and shared work.
+- Shared contribution MUST NOT erase individual contributing actors.
+- Contribution is not payment or accounting. It is the protocol attribution
+  record downstream systems MAY evaluate.
+
+## Locked Evidence Model
+
+EvidenceManifest is the portable proof package for a WorkSession.
+
+It MUST include references to:
+
+- WorkSession
+- event chain root
+- artifacts
+- evidence items
+- policy decisions
+- requests
+- reviews
+- contributions
+- limitations
+- export profile
+
+Rules:
+
+- Evidence MUST be captured during work.
+- Evidence MUST NOT be reconstructed only at the end.
+- Redacted exports MUST remain derived from the same event chain.
+- EvidenceManifest MUST be portable across compatible products and hosts.
+
+## Locked Learning Model
+
+LearningRecord captures what improved because of the WorkSession.
+
+Subject types are:
+
+```txt
+human
+agent
+pair
+```
+
+Rules:
+
+- Learning MUST NOT mean only agent memory.
+- Jarvis MUST record human learning, agent learning, and pair learning.
+- LearningRecord MAY point to MemoryProposal or SkillProposal.
+- Durable memory and active skill behavior MUST require governed review.
+
+## Locked Compatibility Target
+
+Existing agents and products remain first-class.
+
+Jarvis-compatible adapters MUST be able to wrap an existing agent without
+rewriting the agent runtime.
+
+A compatible adapter maps:
+
+```txt
+human identity or operator       -> HumanWorker + Actor
+agent process or agent product   -> AgentWorker + Actor
+agent step                       -> JarvisEvent
+tool/action authorization        -> PolicyDecision
+blocked action                   -> Request
+human approval/correction        -> Review
+human direct control             -> Takeover
+work performed                   -> Contribution
+trace/artifact/source/output     -> EvidenceManifest entry
+confirmed improvement            -> LearningRecord / MemoryProposal / SkillProposal
+```
+
+If an adapter cannot expose a native concept, it MUST either:
+
+- produce the closest valid Jarvis record with explicit limitations, or
+- mark the capability unsupported during capability negotiation.
+
+## Locked Host Boundary
+
+A host implements Jarvis. A host is not Jarvis.
+
+Hosts own:
+
+- UI
+- accounts and identity integration
+- model selection
+- tool execution
+- MCP hosting
+- sandbox choice
+- storage
+- queues
+- deployment
+- observability
+- billing
+- product-specific workflows
+
+Jarvis owns:
+
+- protocol vocabulary
+- object semantics
+- lifecycle states
+- event envelope
+- policy decision semantics
+- request/review/takeover semantics
+- contribution semantics
+- evidence export semantics
+- governed learning semantics
+- conformance expectations
+
+## Locked Conformance Expectations
+
+A v0-compatible host MUST prove:
+
+- WorkSession is the source of truth.
+- HumanWorker and AgentWorker both exist.
+- Every meaningful JarvisEvent has an Actor.
+- Policy gates autonomous AgentWorker action.
+- Policy-denied or review-required action creates Request.
+- Request cannot resolve without Review or Takeover.
+- Review decisions are explicit.
+- Takeover blocks stale autonomous continuation.
+- Contributions are attributable.
+- EvidenceManifest is captured during work and exportable.
+- Learning is governed.
+- MemoryProposal and SkillProposal do not silently become durable behavior.
+- Portable export contains no product-private infrastructure requirement.
+
+## Locked Portable Export
+
+A v0 portable export MUST contain:
+
+```txt
+protocol_version
+WorkSession
+Workers
+Actors
+JarvisEvents
+PolicyDecisions
+Requests
+Reviews
+Takeovers
+Contributions
+EvidenceManifest
+LearningRecords
+MemoryProposals
+SkillProposals
+limitations
+```
+
+The export MAY contain extension fields only when they are namespaced and do
+not change the meaning of the core protocol fields.
+
+## Open Before Schema Freeze
+
+These questions remain open for the schema phase:
+
+1. Version negotiation shape.
+2. Capability negotiation shape.
+3. Extension namespace format.
+4. Standard error codes.
+5. Required vs optional fields per object.
+6. JSON Schema package layout.
+7. Canonical example WorkSession export.
+8. Passing and failing conformance fixtures.
+
+These are schema questions, not thesis questions.
+
+## Entry Gate For Schemas
+
+Schema drafting can begin when this document is accepted.
+
+Schema drafting MUST use:
+
+- this document for locked meaning
+- `11-core-protocol-objects.md` for object definitions
+- `13-protocol-readiness-review.md` for readiness gaps
+
+Schema drafting MUST NOT reopen:
+
+- whether Jarvis is a protocol
+- whether Jarvis owns runtime
+- whether any host product is the protocol
+- whether human and agent both learn
+- whether WorkSession is the source of truth

--- a/README.md
+++ b/README.md
@@ -274,5 +274,7 @@ If v0 proves this loop, Jarvis is real.
   plan for protocol lock, schemas, Garden POC, and interoperability proof.
 - [13-protocol-readiness-review.md](./13-protocol-readiness-review.md) -
   protocol-readiness check against proven protocol patterns.
+- [14-protocol-lock.md](./14-protocol-lock.md) - locked v0 thesis,
+  vocabulary, lifecycle, boundaries, conformance expectations, and schema gate.
 - [ROADMAP.md](./ROADMAP.md) - release roadmap, milestones, decision gates,
   risks, and immediate next actions.

--- a/README.md
+++ b/README.md
@@ -192,9 +192,9 @@ SkillProposal
 6. Evidence is captured during work.
 7. Contributions are attributable.
 8. Human judgment remains central.
-9. Execution may be delegated; accountability remains attributable.
+9. Execution can be delegated; accountability remains attributable.
 10. HumanWorker and AgentWorker both learn.
-11. Every session should improve the next session.
+11. Every completed WorkSession improves the next WorkSession.
 
 ## Boundaries
 
@@ -271,7 +271,7 @@ If v0 proves this loop, Jarvis is real.
 - [11-core-protocol-objects.md](./11-core-protocol-objects.md) - canonical
   object definitions, invariants, statuses, and portable export surface.
 - [12-30-day-roadmap.md](./12-30-day-roadmap.md) - focused 30-day execution
-  plan for protocol lock, schemas, Garden POC, and interoperability proof.
+  plan for protocol lock, schemas, first host POC, and interoperability proof.
 - [13-protocol-readiness-review.md](./13-protocol-readiness-review.md) -
   protocol-readiness check against proven protocol patterns.
 - [14-protocol-lock.md](./14-protocol-lock.md) - locked v0 thesis,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,6 +9,8 @@ tests, examples, and documentation. It does not create an execution stack.
 For the immediate execution plan, see
 [12-30-day-roadmap.md](./12-30-day-roadmap.md).
 
+For the schema entry gate, see [14-protocol-lock.md](./14-protocol-lock.md).
+
 ## Roadmap Contract
 
 Jarvis owns:


### PR DESCRIPTION
## Summary
- add `14-protocol-lock.md` as the v0 schema entry gate
- lock the Jarvis thesis, non-goals, vocabulary, lifecycle, boundaries, compatibility target, conformance expectations, and portable export shape
- link the protocol lock from README and ROADMAP

## Why
Before schemas and implementation start, Jarvis needs one document that makes the protocol meaning stable and prevents drift into a runtime, agent framework, product UI, or host-specific workflow.

## Validation
- markdown links ok
- stale product/runtime wording scan clean
- worktree clean after push

## Next after merge
- draft version negotiation
- draft capability negotiation
- define extension namespace rules
- start JSON schemas and conformance fixtures