### PR TITLE
Add Week 1 execution gate

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ Planning docs and sheets track execution.
 
 - [ROADMAP.md](./planning/ROADMAP.md)
 - [12-30-day-roadmap.md](./planning/12-30-day-roadmap.md)
+- [week-1/README.md](./planning/week-1/README.md)
 - [sheets/jarvis_roadmap.csv](./planning/sheets/jarvis_roadmap.csv)
 - [sheets/jarvis_roadmap.xlsx](./planning/sheets/jarvis_roadmap.xlsx)
 

--- a/docs/planning/week-1/README.md
+++ b/docs/planning/week-1/README.md
@@ -1,0 +1,341 @@
+# Week 1 Execution Spec
+
+Week 1 locks the Jarvis protocol before OpenAPI contract drafting starts.
+
+This week does not build Garden POC, runtime features, adapters, product UI, or
+demo flows. This week locks the protocol meaning, lifecycle, zero-trust
+security boundary, and positioning needed for Week 2 OpenAPI work.
+
+## Week 1 Goal
+
+Freeze the core protocol vocabulary, communication strategy, and security
+boundary.
+
+Week 1 is complete when:
+
+- every protocol object has a clear reason to exist
+- every core lifecycle transition is named
+- PolicyDecision semantics are locked
+- Request, Review, and Takeover lifecycle rules are locked
+- EvidenceManifest, Contribution, LearningRecord, MemoryProposal,
+  SkillProposal, and OutcomeReport semantics are locked
+- OpenAPI 3.1 remains the machine-readable communication contract
+- zero-trust headers, security schemes, and forbidden export fields are locked
+- Jarvis is explained without relying on Garden, Workstream, Harnessy, any
+  runtime, or any product proof
+- no document describes Jarvis as a runtime, product, agent framework, or
+  personal agent
+
+## Chunk Gate
+
+Every Week 1 chunk follows this gate.
+
+```txt
+1. Create or update the chunk spec.
+2. Implement the document changes for that chunk.
+3. Run deterministic local checks.
+4. Spawn at least four reviewer agents.
+5. Give every reviewer the repo docs, changed files, and chunk spec.
+6. Wait for all reviewer reports.
+7. Integrate valid findings.
+8. Record rejected findings with concrete reasons.
+9. Run final checks.
+10. Open a PR for the chunk.
+```
+
+A chunk is not complete without the Zero-Trust Security Reviewer plus at least
+three other completed reviewer reports.
+
+The reviewer pool is:
+
+```txt
+Protocol Thesis Reviewer
+  Checks that Jarvis stays the human-agent collaboration and learning-loop
+  protocol.
+
+Zero-Trust Security Reviewer
+  Checks replay protection through `Jarvis-Idempotency-Key` and
+  `Jarvis-Request-Timestamp`, actor authority through `Jarvis-Actor-Id`,
+  WorkSession revision safety through `Jarvis-Expected-WorkSession-Revision`,
+  event hash linkage through `Jarvis-Previous-Event-Hash`, export boundaries,
+  and forbidden host-private fields.
+
+Chief Engineer Reviewer
+  Checks architecture, naming, object boundaries, maintainability, and
+  implementation readiness.
+
+Conformance And Interop Reviewer
+  Checks that existing agents, hosts, and external products map into Jarvis
+  without runtime rewrites or product-specific assumptions.
+
+Human Workflow Reviewer
+  Checks that Requests, Reviews, Takeovers, Contributions, Evidence,
+  LearningRecords, MemoryProposals, and SkillProposals preserve human
+  judgment, agent autonomy, pair learning, and understandable work handoff.
+```
+
+Every chunk must include the Zero-Trust Security Reviewer plus at least three
+other reviewer lanes. Five lanes are required for high-risk chunks.
+
+## Required Reviewer Context
+
+Every reviewer receives:
+
+- [AGENTS.md](../../../AGENTS.md)
+- [README.md](../../../README.md)
+- [docs/protocol/04-work-sessions.md](../../protocol/04-work-sessions.md)
+- [docs/protocol/11-core-protocol-objects.md](../../protocol/11-core-protocol-objects.md)
+- [docs/protocol/14-protocol-lock.md](../../protocol/14-protocol-lock.md)
+- [docs/protocol/15-openapi-communication-binding.md](../../protocol/15-openapi-communication-binding.md)
+- [docs/reviews/13-protocol-readiness-review.md](../../reviews/13-protocol-readiness-review.md)
+- [docs/planning/12-30-day-roadmap.md](../12-30-day-roadmap.md)
+- the current chunk spec
+- the changed files
+
+## Local Checks
+
+Every chunk that changes protocol semantics, OpenAPI strategy, lifecycle rules,
+portable export, or conformance rules also runs a zero-trust invariant scan for
+the required headers, actor authority, revision safety, previous event hash,
+PolicyDecision requirement, and forbidden export fields.
+
+Every chunk runs:
+
+```txt
+git diff --check
+python3 scripts/check_markdown_links.py
+python3 scripts/check_week1_wording.py
+```
+
+If those scripts do not exist in the branch, the chunk adds them before the PR.
+
+Week 1 chunks do not touch demo assets. Demo checks belong to a later
+product-proof or simulation update, not this protocol-lock gate.
+
+Chunks that touch roadmap sheets also run:
+
+```txt
+CSV sanity check
+XLSX sanity check
+```
+
+## Stale Wording Scan
+
+The scan rejects wording that violates the boundaries in `AGENTS.md`, turns
+Jarvis into a host-owned implementation concern, makes product proof active
+before the conformance gate, or makes locked protocol decisions sound optional.
+
+## Week 1 Chunks
+
+### Chunk 0: Execution Gate
+
+Purpose: lock the Week 1 working method.
+
+Outputs:
+
+- Week 1 chunk spec directory
+- reviewer lanes
+- required reviewer context
+- local checks
+- stale wording scan
+- completion rules
+
+Done when:
+
+- the chunk gate exists in docs
+- Zero-Trust Security Reviewer plus at least three other reviewers validate the
+  gate
+- findings are integrated or rejected with reasons
+- PR is opened
+
+### Chunk 1: Core Object And Extension Field Lock
+
+Purpose: define required fields and reason-to-exist for every core object and
+the OutcomeReport extension.
+
+Core objects:
+
+```txt
+Worker
+Actor
+HumanWorker
+AgentWorker
+WorkSession
+JarvisEvent
+Policy
+PolicyDecision
+Request
+Review
+Takeover
+Contribution
+EvidenceManifest
+LearningRecord
+MemoryProposal
+SkillProposal
+```
+
+Extension object:
+
+```txt
+OutcomeReport
+```
+
+Outputs:
+
+- required fields
+- optional fields
+- forbidden fields
+- stable ids and references
+- ownership boundary for every field
+- host-private field exclusion rules
+
+Done when:
+
+- every object has a reason to exist
+- every required field has a protocol reason
+- no object owns host implementation details
+- every object maps into OpenAPI `components.schemas`
+
+### Chunk 2: WorkSession Lifecycle Lock
+
+Purpose: lock WorkSession states and transitions.
+
+Outputs:
+
+- WorkSession state list
+- allowed transitions
+- rejected transitions
+- revision rules
+- event hash-chain rules
+- close, fail, cancel, and export rules
+
+Done when:
+
+- a host knows exactly when WorkSession state changes
+- stale writes are rejected
+- event order is verifiable
+- export is only valid from a permitted lifecycle state
+
+### Chunk 3: Policy, Request, Review, And Takeover Lock
+
+Purpose: lock the human judgment and control plane.
+
+Outputs:
+
+- PolicyDecision semantics
+- Request lifecycle
+- Review lifecycle
+- Takeover lifecycle
+- escalation rules
+- review-required action rules
+- denied action rules
+- takeover lock epoch rules
+
+Done when:
+
+- AgentWorker actions outside policy create Requests
+- HumanWorker judgment records Reviews or Takeovers
+- Takeover races are rejected
+- AgentWorker resumes only after allowed protocol state
+
+### Chunk 4: Contribution, Evidence, And Learning Lock
+
+Purpose: lock attribution, proof, and shared learning.
+
+Outputs:
+
+- Contribution ledger minimum shape
+- EvidenceManifest minimum export shape
+- evidence capture timing rules
+- LearningRecord semantics
+- MemoryProposal review rules
+- SkillProposal review rules
+- OutcomeReport semantics
+
+Done when:
+
+- human, agent, pair, and service contributions are distinguishable
+- evidence is captured during work
+- learning is governed
+- memory and skill updates do not silently mutate durable state
+- OutcomeReport does not turn Jarvis into an evaluation system
+
+### Chunk 5: OpenAPI Security Entry Lock
+
+Purpose: lock the OpenAPI inputs required before Week 2 drafting.
+
+Outputs:
+
+- required headers
+- security scheme requirements
+- protocol error model
+- version negotiation rules
+- capability negotiation rules
+- extension namespace rules
+- forbidden export fields
+
+Done when:
+
+- OpenAPI contract authors have exact inputs
+- every mutating operation requires `Jarvis-Protocol-Version`,
+  `Jarvis-Actor-Id`, `Jarvis-Idempotency-Key`, `Jarvis-Request-Timestamp`,
+  `Jarvis-Expected-WorkSession-Revision`, and
+  `Jarvis-Previous-Event-Hash`
+- Worker and Actor reference registration does not become identity ownership
+- OpenAPI 3.1 remains the default host-facing binding
+
+### Chunk 6: Positioning And Adoption Lock
+
+Purpose: lock why Jarvis exists beside existing agents and protocols.
+
+Outputs:
+
+- positioning against MCP
+- positioning against A2A
+- positioning against ACP
+- positioning against AG-UI
+- positioning against agent SDKs
+- positioning against coding agents and personal agents
+- one-paragraph Jarvis explanation
+
+Done when:
+
+- Jarvis is clearly not another agent
+- Jarvis is clearly not another runtime
+- existing agents remain first-class
+- adoption argument centers on policy, review, attribution, evidence, and
+  shared learning
+
+## Chunk Review Record
+
+Each chunk PR must include:
+
+```txt
+Reviewer lanes completed:
+- Protocol Thesis Reviewer
+- Zero-Trust Security Reviewer
+- Chief Engineer Reviewer
+- Conformance And Interop Reviewer
+- Human Workflow Reviewer
+
+Zero-trust decision:
+- replay protection:
+- actor authority:
+- WorkSession revision safety:
+- event hash linkage:
+- PolicyDecision requirement:
+- export boundary:
+- forbidden host-private fields:
+
+Findings integrated:
+- ...
+
+Findings rejected:
+- finding
+- reason
+
+Checks:
+- ...
+```
+
+No chunk is complete without this review record.

--- a/scripts/check_markdown_links.py
+++ b/scripts/check_markdown_links.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Validate local Markdown links in the Jarvis repository."""
+
+from pathlib import Path
+import re
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+EXTERNAL_PREFIXES = ("http://", "https://", "#", "mailto:")
+
+
+def markdown_files() -> list[Path]:
+    files = list(ROOT.glob("*.md"))
+    files.extend(ROOT.joinpath("docs").rglob("*.md"))
+    return sorted(files)
+
+
+def main() -> int:
+    failures: list[tuple[Path, str]] = []
+
+    for path in markdown_files():
+        text = path.read_text(encoding="utf-8")
+        for match in LINK_RE.finditer(text):
+            target = match.group(1)
+            if target.startswith(EXTERNAL_PREFIXES):
+                continue
+
+            clean = target.split("#", 1)[0]
+            if not clean:
+                continue
+
+            resolved = (path.parent / clean).resolve()
+            if not resolved.exists():
+                failures.append((path.relative_to(ROOT), target))
+
+    if failures:
+        for path, target in failures:
+            print(f"{path}: broken local link: {target}")
+        return 1
+
+    print("markdown links ok")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_week1_wording.py
+++ b/scripts/check_week1_wording.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Reject wording that drifts away from the Jarvis protocol boundary."""
+
+from pathlib import Path
+import re
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FILES = [*ROOT.glob("*.md"), *ROOT.joinpath("docs").rglob("*.md")]
+
+PATTERNS = [
+    r"personal agent harness",
+    r"Garden POC active work",
+    r"schema-first contract",
+    r"demo-first plan",
+    r"host owns Jarvis",
+    r"Jarvis owns auth",
+    r"Jarvis owns runtime",
+    r"Jarvis owns database",
+    r"Jarvis owns cloud",
+    r"Jarvis owns product UI",
+    r"\bmaybe\b",
+    r"\bprobably\b",
+    r"\bcould\b",
+    r"\bshould\b",
+    r"\bsuggest\b",
+    r"\badvice\b",
+    r"\bcandidate\b",
+    r"if accepted",
+    r"if this is approved",
+]
+
+
+def main() -> int:
+    compiled = [re.compile(pattern) for pattern in PATTERNS]
+    failures: list[tuple[Path, int, str]] = []
+
+    for path in sorted(FILES):
+        text = path.read_text(encoding="utf-8")
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            for pattern in compiled:
+                if pattern.search(line):
+                    failures.append((path.relative_to(ROOT), line_number, line))
+                    break
+
+    if failures:
+        for path, line_number, line in failures:
+            print(f"{path}:{line_number}: rejected wording: {line}")
+        return 1
+
+    print("week1 wording ok")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds the Week 1 execution gate for Jarvis protocol-lock work.

This PR locks how Week 1 chunks are executed before OpenAPI contract drafting starts:

- defines the chunk gate
- requires the Zero-Trust Security Reviewer plus at least three other reviewers
- defines the reviewer pool and reviewer context
- keeps Week 1 away from Garden POC, runtime work, adapters, product UI, and demo flows
- adds deterministic local checks for Markdown links and Week 1 wording drift
- adds the Week 1 planning doc to the docs index

## Chunk Review Record

Reviewer lanes completed:
- Protocol Thesis Reviewer: PASS
- Zero-Trust Security Reviewer: PASS
- Chief Engineer Reviewer: findings integrated
- Conformance And Interop Reviewer: findings integrated
- Human Workflow Reviewer: findings integrated

Zero-trust decision:
- replay protection: PASS, enforced through `Jarvis-Idempotency-Key` and `Jarvis-Request-Timestamp`
- actor authority: PASS, enforced through `Jarvis-Actor-Id`
- WorkSession revision safety: PASS, enforced through `Jarvis-Expected-WorkSession-Revision`
- event hash linkage: PASS, enforced through `Jarvis-Previous-Event-Hash`
- PolicyDecision requirement: PASS, included in reviewer gate and invariant scan
- export boundary: PASS, included in reviewer gate and invariant scan
- forbidden host-private fields: PASS, included in reviewer gate and invariant scan

Findings integrated:
- removed demo checks from Week 1
- replaced vague host/downstream wording with direct boundary language
- made Zero-Trust Security Reviewer mandatory
- required exact zero-trust invariant coverage
- added executable local check commands
- added `04-work-sessions.md` and `13-protocol-readiness-review.md` to reviewer context
- strengthened Human Workflow Reviewer around pair learning and handoff
- clarified reviewer pool versus required reviewer set
- treated `OutcomeReport` as an extension object, not a core object

Findings rejected:
- none

## Checks

- `git diff --check`
- `python3 scripts/check_markdown_links.py`
- `python3 scripts/check_week1_wording.py`
