### PR TITLE
Lock Week 1 core object fields

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,6 +223,7 @@ Before changing protocol direction, read:
 - [docs/protocol/14-protocol-lock.md](./docs/protocol/14-protocol-lock.md)
 - [docs/protocol/15-openapi-communication-binding.md](./docs/protocol/15-openapi-communication-binding.md)
 - [docs/protocol/11-core-protocol-objects.md](./docs/protocol/11-core-protocol-objects.md)
+- [docs/protocol/12-request-protocol.md](./docs/protocol/12-request-protocol.md)
 - [docs/planning/12-30-day-roadmap.md](./docs/planning/12-30-day-roadmap.md)
 
 ## Change Discipline

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ stable.
 - [09-host-integration.md](./protocol/09-host-integration.md)
 - [10-protocol-mvp.md](./protocol/10-protocol-mvp.md)
 - [11-core-protocol-objects.md](./protocol/11-core-protocol-objects.md)
+- [12-request-protocol.md](./protocol/12-request-protocol.md)
 - [14-protocol-lock.md](./protocol/14-protocol-lock.md)
 - [15-openapi-communication-binding.md](./protocol/15-openapi-communication-binding.md)
 

--- a/docs/planning/ROADMAP.md
+++ b/docs/planning/ROADMAP.md
@@ -221,7 +221,8 @@ Output:
 Done when:
 
 - policy-denied action creates Request
-- Request cannot resolve without Review
+- Request cannot reach human-resolved state without Review or Takeover
+- Request blocks only its declared scope
 - Review approves, denies, narrows, corrects, takes over, or requests revision
 - takeover rejects stale autonomous continuation
 
@@ -282,7 +283,7 @@ Done when a host proves:
 - WorkSession is the source of truth
 - Policy gates autonomous action
 - blocked action creates Request
-- Review resolves Request
+- Review or Takeover resolves Request
 - Takeover prevents stale continuation
 - Contributions are attributable
 - EvidenceManifest is portable

--- a/docs/planning/week-1/README.md
+++ b/docs/planning/week-1/README.md
@@ -153,6 +153,8 @@ Done when:
 Purpose: define required fields and reason-to-exist for every core object and
 the OutcomeReport extension.
 
+Spec: [chunk-1-core-object-field-lock.md](./chunk-1-core-object-field-lock.md)
+
 Core objects:
 
 ```txt

--- a/docs/planning/week-1/README.md
+++ b/docs/planning/week-1/README.md
@@ -226,6 +226,9 @@ Outputs:
 
 - PolicyDecision semantics
 - Request lifecycle
+- Request blocking scope
+- Request and non-blocking communication boundary
+- anti-livelock Request rules
 - Review lifecycle
 - Takeover lifecycle
 - escalation rules
@@ -236,7 +239,9 @@ Outputs:
 Done when:
 
 - AgentWorker actions outside policy create Requests
+- Requests block only their declared scope
 - HumanWorker judgment records Reviews or Takeovers
+- approval is scoped and bounded
 - Takeover races are rejected
 - AgentWorker resumes only after allowed protocol state
 

--- a/docs/planning/week-1/chunk-1-core-object-field-lock.md
+++ b/docs/planning/week-1/chunk-1-core-object-field-lock.md
@@ -1,0 +1,135 @@
+# Chunk 1: Core Object And Extension Field Lock
+
+Chunk 1 locks the fields that Week 2 OpenAPI components encode.
+
+This chunk does not create the OpenAPI document. It defines the protocol field
+contract that the OpenAPI document must preserve.
+
+## Scope
+
+Core objects:
+
+```txt
+Worker
+Actor
+HumanWorker
+AgentWorker
+WorkSession
+JarvisEvent
+Policy
+PolicyDecision
+Request
+Review
+Takeover
+Contribution
+EvidenceManifest
+LearningRecord
+MemoryProposal
+SkillProposal
+```
+
+Extension object:
+
+```txt
+OutcomeReport
+```
+
+## Outputs
+
+- required fields for every core object
+- optional fields for every core object
+- forbidden field classes for every core object
+- protocol reason for every required field group
+- stable id and reference rules
+- OutcomeReport extension field lock
+- OpenAPI component mapping notes
+
+## Non-Goals
+
+Chunk 1 does not:
+
+- write the OpenAPI document
+- define HTTP paths
+- build a runtime
+- build a product proof
+- start Garden POC work
+- implement adapters
+- create conformance fixtures
+- add product-private fields
+
+## Field Rules
+
+Every field must fall into one category:
+
+```txt
+required
+optional
+extension
+forbidden
+```
+
+Required fields define portable protocol meaning.
+
+Optional fields add protocol-visible context without changing required
+semantics.
+
+Extension fields must be namespaced and must not change the meaning of core
+fields.
+
+Forbidden fields belong to hosts, products, identity systems, runtimes,
+databases, cloud platforms, billing systems, or private execution stacks.
+
+## OpenAPI Component Mapping Notes
+
+Week 2 maps this field lock into OpenAPI 3.1 components as follows:
+
+- required field blocks become OpenAPI `required` arrays
+- optional field blocks become OpenAPI properties outside `required`
+- forbidden field blocks become conformance rejection cases
+- `extensions` uses namespaced keys only
+- nested reference shapes such as `contributor_refs` become named components
+- opaque refs stay strings or typed ref objects without host-private structure
+- portable exports exclude forbidden fields
+
+## Review Requirements
+
+Chunk 1 requires:
+
+- Zero-Trust Security Reviewer
+- Protocol Thesis Reviewer
+- Chief Engineer Reviewer
+- Conformance And Interop Reviewer
+- Human Workflow Reviewer
+
+All five lanes are required because this chunk defines the contract surface
+that Week 2 OpenAPI work encodes.
+
+## Zero-Trust Checks
+
+Reviewers must verify:
+
+- every state-changing object remains attributable to an Actor
+- every WorkSession-scoped object references `work_session_id`
+- every autonomous AgentWorker action is traceable to PolicyDecision
+- WorkSession records expose revision and latest event hash values needed for
+  Week 2 replay, stale-write, and previous-hash checks
+- optional fields do not create a path for credentials, secrets, raw auth
+  tokens, database internals, deployment details, runtime internals, or
+  product-private state
+- event hash fields remain portable and verifiable
+- OutcomeReport records required `source_ref`, `reporter_ref`,
+  `accepted_by_actor_id`, required `learning_record_refs`, and cannot mutate
+  sealed WorkSession or EvidenceManifest records
+
+## Done Criteria
+
+Chunk 1 is complete when:
+
+- `11-core-protocol-objects.md` contains the field lock
+- `OutcomeReport` is locked as an extension, not a v0 core object
+- every core object has required, optional, and forbidden field classes
+- every required field group has a protocol reason
+- local checks pass
+- all five reviewer lanes complete
+- findings are integrated or rejected with concrete reasons
+- PR is opened

--- a/docs/planning/week-1/chunk-1-core-object-field-lock.md
+++ b/docs/planning/week-1/chunk-1-core-object-field-lock.md
@@ -42,6 +42,7 @@ OutcomeReport
 - protocol reason for every required field group
 - stable id and reference rules
 - OutcomeReport extension field lock
+- Request blocking scope, safe fallback, and expiry fields
 - OpenAPI component mapping notes
 
 ## Non-Goals

--- a/docs/protocol/00-principles.md
+++ b/docs/protocol/00-principles.md
@@ -145,8 +145,9 @@ Inside policy, the agent proceeds. Outside policy, it creates a Request.
 
 When the agent lacks permission, context, or judgment, it creates a Request.
 
-Requests are structured protocol objects, not vague interruptions. A human
-approves, denies, narrows, corrects, answers, or takes over.
+Requests are structured, scoped deferrals, not vague interruptions, chat, or
+notifications. A Request blocks only its declared scope. A human approves,
+denies, narrows, corrects, answers, or takes over.
 
 ## Reviews Teach The System
 

--- a/docs/protocol/03-autonomy-policy.md
+++ b/docs/protocol/03-autonomy-policy.md
@@ -138,27 +138,36 @@ permission
 context
   agent needs missing information
 
-decision
+judgment
   agent needs human judgment
+
+correction
+  agent needs human correction because direction, evidence, or requirement
+  interpretation conflicts
 
 review
   agent completed work that requires inspection
 
 takeover
   agent determines the human must continue directly
+
+escalation
+  agent detects risk, ambiguity, policy conflict, or high-impact action
 ```
 
 ## Request Payload
 
-A request includes:
+A Request includes:
 
 ```txt
 reason
 proposed action
 risk class
+blocking scope
 requested scope
 expected result
 alternatives
+default if no response
 expiration
 work_session_id
 evidence/context
@@ -183,27 +192,30 @@ Canonical fields include:
 - irreversible effects
 - requested grant scope and expiry
 - narrower alternatives
+- default if no response
 
 The human response is one of:
 
 ```txt
 approve
 deny
-approve with narrower scope
-answer with context
-edit the plan
-take over
-resume/delegate back to agent
+narrow
+correct
+takeover
+needs_revision
 ```
 
 Approvals are one-use decisions bound to approver, request version, expiry,
-WorkSession, and canonical action hash. Request resolution uses compare-and-set
-from `pending` to `resolved`. Stale, replayed, or mismatched approvals are
-rejected.
+WorkSession, declared blocking scope, and canonical action hash. Request
+resolution uses compare-and-set from unresolved state to resolved state. Stale,
+replayed, or mismatched approvals are rejected.
 
 ## Inbox Semantics
 
-Inbox is the deferred control plane for autonomy.
+Hosts may surface Requests through an inbox.
+
+Jarvis owns Request state, Review resolution, Takeover transition, and the
+event record. Jarvis does not define an inbox product surface.
 
 An inbox item explains:
 

--- a/docs/protocol/04-work-sessions.md
+++ b/docs/protocol/04-work-sessions.md
@@ -63,6 +63,7 @@ tool_executed
 artifact_created
 request_created
 request_resolved
+request_closed
 human_takeover_started
 human_takeover_finished
 review_added

--- a/docs/protocol/06-integration-boundaries.md
+++ b/docs/protocol/06-integration-boundaries.md
@@ -104,21 +104,31 @@ OutcomeReport
   id
   work_session_id
   source_ref
+  reporter_ref
+  accepted_by_actor_id
+  outcome: accepted | rejected | needs_revision | disputed | partial
+  learning_record_refs
+  received_at
   external_system_ref
   reporter_actor_id
-  outcome: accepted | rejected | needs_revision | disputed | partial
   reason
   reviewer_feedback_refs
-  received_at
 ```
 
 Rules:
 
 - OutcomeReport arrives after a WorkSession is completed.
-- OutcomeReport does not mutate the sealed WorkSession or EvidenceManifest.
-- OutcomeReport creates or references a new LearningRecord.
-- OutcomeReport must remain attributable to a reporter Actor or external
-  reporter reference.
+- It does not mutate the sealed WorkSession or EvidenceManifest.
+- The report creates or references a new LearningRecord.
+- `source_ref` is required and identifies the completed WorkSession export,
+  external task record, evaluation record, or other portable work reference
+  whose outcome is being reported.
+- `reporter_ref` identifies the external or protocol reporter that supplied the
+  outcome.
+- `accepted_by_actor_id` records the protocol Actor with review authority that
+  accepted the report into Jarvis records.
+- `reporter_actor_id` is present only when the reporter is already represented
+  as a protocol Actor.
 - OutcomeReport is an extension. It does not change the v0 core object list.
 
 ## Host Contract

--- a/docs/protocol/07-protocol-decisions.md
+++ b/docs/protocol/07-protocol-decisions.md
@@ -12,7 +12,7 @@ This document records decisions that are fixed for the Jarvis protocol.
 - Every serious collaboration creates or resumes a WorkSession.
 - Policy governs autonomous agent action.
 - Action outside policy creates Request.
-- Human review resolves Request.
+- Human Review or Takeover resolves Request.
 - Human takeover is a protocol state, not a UI convention.
 - Contributions are attributable to human, agent, service, tool, or shared
   work.

--- a/docs/protocol/08-package-contracts.md
+++ b/docs/protocol/08-package-contracts.md
@@ -106,7 +106,7 @@ Release tests:
 - event envelopes validate required ids and timestamps.
 - event hashes exclude `event_hash` and signature fields.
 - WorkSession status transitions reject invalid transitions.
-- Request resolution requires Review.
+- Human resolution of Request requires Review or Takeover.
 - Takeover creates a lock epoch.
 
 ## `@jarvis/policy`
@@ -268,7 +268,7 @@ Conformance tests check:
 
 - WorkSession lifecycle
 - policy-denied action to Request
-- Request to Review resolution
+- Request to Review or Takeover resolution
 - takeover and reconciliation
 - contribution attribution
 - evidence capture

--- a/docs/protocol/10-protocol-mvp.md
+++ b/docs/protocol/10-protocol-mvp.md
@@ -124,13 +124,18 @@ The MVP conformance suite checks:
 - a WorkSession cannot start without HumanWorker, AgentWorker, objective, and
   Policy.
 - policy-denied action creates Request.
-- Request resolution requires Review.
+- Request blocks only its declared scope unless scope is whole WorkSession.
+- Human resolution of Request requires Review or Takeover.
 - approval narrows scope when the human restricts the request.
+- narrowed approval rejects execution outside the approved scope.
+- expired Request applies its safe fallback.
 - takeover creates a lock epoch.
 - stale autonomous events after takeover are rejected.
+- duplicate pending Requests are deduplicated or superseded.
 - Contribution entries reference events or artifacts.
 - EvidenceManifest references policy decisions, requests, reviews,
   contributions, artifacts, and limitations.
+- Request resolution can create governed learning proposals.
 - MemoryProposal and SkillProposal require provenance and review state.
 - LearningRecord describes human learning, agent learning, or pair learning.
 - exported protocol records do not require product-private infrastructure

--- a/docs/protocol/11-core-protocol-objects.md
+++ b/docs/protocol/11-core-protocol-objects.md
@@ -54,6 +54,742 @@ workers inside a durable WorkSession.
 12. Durable memory and skill changes MUST remain proposals until governed review
     accepts them.
 
+## Core Field Lock
+
+The v0 field lock defines the portable protocol fields that Week 2 OpenAPI
+components must encode.
+
+Field classes:
+
+```txt
+required
+optional
+extension
+forbidden
+```
+
+Required fields carry protocol meaning and must appear in compatible records.
+Optional fields add protocol-visible context without changing required
+semantics. Extension fields must be namespaced. Forbidden fields belong to
+hosts, products, identity systems, runtimes, databases, cloud platforms, billing
+systems, or private execution stacks.
+
+### Field Class Rules
+
+- Required fields MUST be portable across hosts.
+- Required fields MUST NOT depend on product-private infrastructure.
+- Optional fields MUST NOT change the meaning of required fields.
+- Extension fields MUST be namespaced.
+- Extension fields MUST NOT override core field names.
+- Portable exports MUST exclude forbidden fields.
+- Host-private ids MUST stay outside portable protocol fields. Portable records
+  use `source_ref`, `external_system_ref`, evidence refs, or artifact refs as
+  opaque references without exposing database ids, runtime ids, deployment ids,
+  credentials, billing internals, or product-private state.
+
+### Stable Reference Rules
+
+- `id` identifies the protocol record.
+- `worker_id` references a Worker.
+- `actor_id` references an Actor.
+- `work_session_id` references a WorkSession.
+- `policy_id` references a Policy.
+- `request_id` references a Request.
+- `review_refs`, `event_refs`, `evidence_refs`, `artifact_refs`, and
+  `source_event_refs` contain protocol references or opaque external refs.
+- `contributor_refs` contains one or more ContributorRef objects:
+  `{worker_id, actor_id, contribution_role}`.
+- `reporter_ref` identifies an external reporter or protocol reporter without
+  requiring Jarvis to own the external system.
+- `accepted_by_actor_id` references the Actor that accepted an extension report
+  into Jarvis records.
+- Opaque external refs MUST NOT require Jarvis to understand the external
+  system.
+- `extensions` is the only generic extension container.
+- Every key in `extensions` MUST be namespaced.
+- `extensions` MUST NOT contain credentials, secrets, database ids,
+  runtime state, deployment details, billing data, private scores, or product
+  UI state.
+
+### Worker Field Lock
+
+Required fields:
+
+```txt
+id
+type
+role
+authority_scope
+accountability_scope
+```
+
+Required field reason: Worker records identify who or what participates in
+protocol-visible work, what role the participant plays, what authority it has,
+and where accountability attaches.
+
+Optional fields:
+
+```txt
+display_name
+capabilities
+extensions
+```
+
+Forbidden fields:
+
+```txt
+password
+credential
+raw_auth_token
+billing_account
+provider_secret
+database_primary_key
+deployment_resource_id
+```
+
+### Actor Field Lock
+
+Required fields:
+
+```txt
+id
+worker_id
+type
+event_authority
+contribution_scope
+created_at
+```
+
+Required field reason: Actor records bind protocol events and contributions to
+an authorized acting identity without collapsing human, agent, service, and
+tool actions.
+
+Optional fields:
+
+```txt
+extensions
+valid_from
+valid_until
+```
+
+Forbidden fields:
+
+```txt
+credential
+raw_auth_token
+session_cookie
+private_key
+database_primary_key
+```
+
+### HumanWorker Field Lock
+
+Required fields:
+
+```txt
+worker_id
+actor_id
+role
+policy_authority
+review_authority
+```
+
+Required field reason: HumanWorker records identify the accountable human,
+their acting identity, and the authority used for policy, review, correction,
+and takeover decisions.
+
+Optional fields:
+
+```txt
+profile_ref
+domain_context_refs
+preferences
+boundaries
+known_patterns
+```
+
+Forbidden fields:
+
+```txt
+password
+credential
+raw_auth_token
+private_profile_data
+billing_account
+product_account_record
+```
+
+### AgentWorker Field Lock
+
+Required fields:
+
+```txt
+worker_id
+actor_id
+agent_ref
+role
+capability_refs
+autonomy_level
+operating_constraints
+```
+
+Required field reason: AgentWorker records identify the agent participant, its
+acting identity, available protocol-visible capabilities, autonomy level, and
+constraints that bound autonomous work.
+
+Optional fields:
+
+```txt
+tool_access_profile
+memory_access_profile
+extensions
+```
+
+Forbidden fields:
+
+```txt
+model_api_key
+provider_secret
+raw_prompt_store
+runtime_process_id
+container_id
+database_primary_key
+```
+
+### WorkSession Field Lock
+
+Required fields:
+
+```txt
+id
+protocol_version
+created_by_actor_id
+objective
+human_worker_id
+agent_worker_id
+policy_id
+status
+revision
+last_event_hash
+event_log_ref
+created_at
+updated_at
+```
+
+Required field reason: WorkSession records bind the human-agent pair, objective,
+policy, lifecycle state, protocol version, creating Actor, current revision,
+latest event hash, and event log that forms the source of truth.
+
+Optional fields:
+
+```txt
+source_ref
+context_manifest_ref
+contribution_ledger_ref
+evidence_manifest_ref
+learning_record_refs
+```
+
+Forbidden fields:
+
+```txt
+database_primary_key
+queue_message_id
+runtime_session_id
+cloud_resource_id
+ui_state
+credential
+raw_auth_token
+```
+
+### JarvisEvent Field Lock
+
+Required fields:
+
+```txt
+id
+sequence
+type
+work_session_id
+actor_id
+timestamp
+payload
+previous_hash
+event_hash
+canonicalization
+```
+
+Required field reason: JarvisEvent records make WorkSession state attributable,
+ordered, append-only, and export-verifiable.
+
+Payload rule: `payload` contains only protocol-defined event fields, portable
+refs, or opaque external refs. It MUST NOT contain credentials, secrets,
+database ids, runtime state, deployment details, billing data, private scores,
+or product UI state.
+
+Optional fields:
+
+```txt
+trace_context
+actor_signature
+signing_key_ref
+```
+
+Forbidden fields:
+
+```txt
+raw_auth_token
+credential
+private_key
+database_primary_key
+runtime_trace_secret
+provider_secret
+```
+
+### Policy Field Lock
+
+Required fields:
+
+```txt
+id
+owner_worker_id
+created_by_actor_id
+autonomy_level
+allowed_actions
+denied_actions
+review_required_actions
+risk_classes
+escalation_rules
+created_at
+```
+
+Required field reason: Policy records define the human-owned and attributable
+boundary that allows, denies, narrows, or escalates AgentWorker action.
+
+Optional fields:
+
+```txt
+tool_grants
+memory_grants
+external_send_rules
+extensions
+```
+
+Forbidden fields:
+
+```txt
+credential
+raw_auth_token
+provider_secret
+billing_rule
+cloud_policy_id
+database_primary_key
+```
+
+### PolicyDecision Field Lock
+
+Required fields:
+
+```txt
+id
+work_session_id
+actor_id
+policy_id
+requested_action
+normalized_action_hash
+risk_class
+result
+reason
+created_at
+```
+
+Required field reason: PolicyDecision records why an AgentWorker action was
+allowed, denied, narrowed, or sent for human review.
+
+Optional fields:
+
+```txt
+data_sensitivity
+selected_grant_refs
+denied_grant_refs
+request_id
+evidence_refs
+```
+
+Forbidden fields:
+
+```txt
+hidden_policy_trace
+credential
+provider_secret
+database_primary_key
+runtime_decision_object
+```
+
+### Request Field Lock
+
+Required fields:
+
+```txt
+id
+work_session_id
+requester_actor_id
+requester_worker_id
+policy_decision_id
+type
+reason
+requested_action
+risk_class
+status
+created_at
+```
+
+Required field reason: Request records the point where AgentWorker work cannot
+continue safely without human permission, context, judgment, review, or
+takeover, and ties that blocked action to the PolicyDecision that triggered
+the Request.
+
+Optional fields:
+
+```txt
+missing_permission_or_context
+options
+expires_at
+```
+
+Forbidden fields:
+
+```txt
+private_inbox_id
+notification_provider_id
+credential
+raw_auth_token
+database_primary_key
+```
+
+### Review Field Lock
+
+Required fields:
+
+```txt
+id
+work_session_id
+reviewer_actor_id
+reviewer_worker_id
+target_ref
+decision
+created_at
+```
+
+Required field reason: Review records human judgment over a protocol target and
+resolves or changes the course of work.
+
+Optional fields:
+
+```txt
+comments
+required_changes
+```
+
+Forbidden fields:
+
+```txt
+private_comment_thread_id
+credential
+raw_auth_token
+database_primary_key
+product_ui_state
+```
+
+### Takeover Field Lock
+
+Required fields:
+
+```txt
+id
+work_session_id
+requested_by_actor_id
+controlling_actor_id
+reason
+lock_epoch
+state
+created_at
+```
+
+Required field reason: Takeover records direct human control, the lock epoch
+that blocks stale autonomous continuation, and the state needed for safe
+resumption.
+
+Optional fields:
+
+```txt
+resumed_by_actor_id
+reconciliation_notes
+resolved_at
+```
+
+Forbidden fields:
+
+```txt
+runtime_lock_id
+database_primary_key
+credential
+raw_auth_token
+ui_session_id
+```
+
+### Contribution Field Lock
+
+Required fields:
+
+```txt
+id
+work_session_id
+contributor_refs
+contributor_type
+contribution_type
+event_refs
+created_at
+```
+
+Required field reason: Contribution records who did what and keeps human,
+agent, service, tool, and shared work distinguishable. `contributor_refs`
+contains one or more `{worker_id, actor_id, contribution_role}` references so
+shared contribution preserves individual attribution.
+
+Optional fields:
+
+```txt
+artifact_refs
+review_refs
+evidence_refs
+confidence
+limitations
+```
+
+Forbidden fields:
+
+```txt
+payment_account
+compensation_rule
+private_score
+credential
+database_primary_key
+```
+
+### EvidenceManifest Field Lock
+
+Required fields:
+
+```txt
+id
+work_session_id
+generated_by_actor_id
+objective
+event_chain_root
+evidence_item_refs
+policy_decision_refs
+request_refs
+review_refs
+contribution_refs
+export_profile
+generated_at
+```
+
+Required field reason: EvidenceManifest records attributable portable proof of
+what was requested, reviewed, observed, produced, decided, attributed, and
+exported during the WorkSession.
+
+Optional fields:
+
+```txt
+artifact_refs
+limitation_refs
+redaction_refs
+```
+
+Forbidden fields:
+
+```txt
+credential
+raw_auth_token
+provider_secret
+database_primary_key
+cloud_storage_secret
+unredacted_secret_value
+```
+
+### LearningRecord Field Lock
+
+Required fields:
+
+```txt
+id
+work_session_id
+created_by_actor_id
+subject_type
+subject_ref
+lesson_type
+source_event_refs
+review_state
+scope
+created_at
+```
+
+Required field reason: LearningRecord records who created the learning record,
+what the human, agent, or pair learned, and ties that learning to source events
+and governed scope.
+
+Optional fields:
+
+```txt
+proposed_change
+memory_proposal_refs
+skill_proposal_refs
+```
+
+Forbidden fields:
+
+```txt
+silent_memory_write
+unreviewed_skill_activation
+credential
+raw_auth_token
+database_primary_key
+```
+
+### MemoryProposal Field Lock
+
+Required fields:
+
+```txt
+id
+work_session_id
+proposed_by_actor_id
+proposed_for: human | agent | pair | project | task
+memory_scope
+memory_type
+content
+provenance
+confidence
+review_required
+status
+created_at
+```
+
+Required field reason: MemoryProposal records a governed memory change for the
+human, agent, pair, project, or task with provenance, scope, confidence, and
+review state before durable memory changes.
+
+Optional fields:
+
+```txt
+source_event_refs
+review_refs
+expires_at
+```
+
+Forbidden fields:
+
+```txt
+silent_memory_write
+credential
+raw_auth_token
+private_embedding_store_id
+database_primary_key
+```
+
+### SkillProposal Field Lock
+
+Required fields:
+
+```txt
+id
+work_session_id
+proposed_by_actor_id
+proposed_for: human | agent | pair | project | task
+skill_scope
+skill_name
+trigger_conditions
+procedure
+review_checks
+failure_cases
+provenance
+status
+created_at
+```
+
+Required field reason: SkillProposal records a reusable way of working, the
+human, agent, pair, project, or task scope it improves, and the review checks
+required before the skill becomes active.
+
+Optional fields:
+
+```txt
+required_tools
+source_event_refs
+review_refs
+```
+
+Forbidden fields:
+
+```txt
+automatic_tool_grant
+unreviewed_skill_activation
+credential
+raw_auth_token
+database_primary_key
+```
+
+### OutcomeReport Extension Field Lock
+
+`OutcomeReport` is an extension object. It does not change the v0 core object
+list.
+
+Required fields:
+
+```txt
+id
+work_session_id
+source_ref
+reporter_ref
+accepted_by_actor_id
+outcome
+learning_record_refs
+received_at
+```
+
+Required field reason: OutcomeReport records attributable post-session feedback
+and links it to governed LearningRecords without mutating the sealed
+WorkSession or EvidenceManifest. `source_ref` identifies the completed
+WorkSession export, external task record, evaluation record, or other portable
+work reference whose outcome is being reported. `reporter_ref` identifies the
+external or protocol reporter.
+`accepted_by_actor_id` identifies the protocol Actor with review authority that
+accepted the report into Jarvis records.
+
+Optional fields:
+
+```txt
+external_system_ref
+reporter_actor_id
+reason
+reviewer_feedback_refs
+```
+
+Forbidden fields:
+
+```txt
+task_marketplace_score_rule
+payment_status
+settlement_account
+credential
+raw_auth_token
+database_primary_key
+sealed_work_session_mutation
+sealed_evidence_mutation
+```
+
 ## Worker
 
 `Worker` is the base participant contract.
@@ -67,7 +803,7 @@ Worker
   capabilities
   authority_scope
   accountability_scope
-  metadata
+  extensions
 ```
 
 Requirements:
@@ -91,6 +827,9 @@ Actor
   type: human | agent | service | tool
   event_authority
   contribution_scope
+  extensions
+  valid_from
+  valid_until
   created_at
 ```
 
@@ -159,6 +898,7 @@ AgentWorker
   memory_access_profile
   autonomy_level
   operating_constraints
+  extensions
 ```
 
 The AgentWorker supplies:
@@ -194,6 +934,9 @@ Rules:
 WorkSession
   id
   protocol_version
+  created_by_actor_id
+  revision
+  last_event_hash
   objective
   source_ref
   human_worker_id
@@ -270,12 +1013,13 @@ Rules:
 - `actor_signature` and `signing_key_ref` are optional. Signed export profiles
   use them to prove authorship; unsigned profiles still require Actor
   attribution.
-- AgentWorker action events SHOULD include payload reproducibility references:
+- AgentWorker action events SHOULD include only portable reproducibility refs:
   `model_ref`, `input_refs`, `prompt_ref`, `context_manifest_ref`, and related
   evidence hashes when the host provides them.
+- Payload refs MUST NOT expose host-private execution details, runtime state,
+  database ids, credentials, deployment ids, billing data, private scores, or
+  product UI state.
 - Event hashes make the protocol record inspectable and exportable.
-- Host-private execution details stay in payload references, not required
-  protocol fields.
 
 ## Policy
 
@@ -285,6 +1029,7 @@ Rules:
 Policy
   id
   owner_worker_id
+  created_by_actor_id
   autonomy_level
   allowed_actions
   denied_actions
@@ -294,6 +1039,7 @@ Policy
   external_send_rules
   risk_classes
   escalation_rules
+  extensions
   created_at
 ```
 
@@ -353,6 +1099,7 @@ Request
   work_session_id
   requester_actor_id
   requester_worker_id
+  policy_decision_id
   type: permission | context | decision | review | takeover
   reason
   requested_action
@@ -408,8 +1155,8 @@ Rules:
 - Review is a protocol object, not only UI feedback.
 - Review resolves a Request.
 - Review creates learning signals.
-- Review narrows future authority.
-- Review triggers Takeover.
+- Review records authority changes when the decision changes scope.
+- Review creates Takeover only when the decision is `takeover`.
 
 ## Takeover
 
@@ -457,8 +1204,7 @@ Rules:
 Contribution
   id
   work_session_id
-  contributor_worker_id
-  contributor_actor_id
+  contributor_refs
   contributor_type: human | agent | service | tool | shared
   contribution_type
   event_refs
@@ -503,6 +1249,7 @@ Rules:
 EvidenceManifest
   id
   work_session_id
+  generated_by_actor_id
   objective
   event_chain_root
   artifact_refs
@@ -532,6 +1279,7 @@ Rules:
 LearningRecord
   id
   work_session_id
+  created_by_actor_id
   subject_type: human | agent | pair
   subject_ref
   lesson_type
@@ -560,7 +1308,7 @@ MemoryProposal
   id
   work_session_id
   proposed_by_actor_id
-  proposed_for: human | agent | shared | project | task
+  proposed_for: human | agent | pair | project | task
   memory_scope
   memory_type
   content
@@ -588,6 +1336,8 @@ SkillProposal
   id
   work_session_id
   proposed_by_actor_id
+  proposed_for: human | agent | pair | project | task
+  skill_scope
   skill_name
   trigger_conditions
   procedure

--- a/docs/protocol/11-core-protocol-objects.md
+++ b/docs/protocol/11-core-protocol-objects.md
@@ -432,29 +432,67 @@ Required fields:
 
 ```txt
 id
+protocol_version
 work_session_id
 requester_actor_id
 requester_worker_id
+target_human_worker_id
 policy_decision_id
 type
-reason
+blocking_scope
+reason_code
+reason_summary
 requested_action
+requested_outcome
 risk_class
+human_decision_needed
+options
+default_if_no_response
 status
 created_at
+expires_at
 ```
 
 Required field reason: Request records the point where AgentWorker work cannot
 continue safely without human permission, context, judgment, review, or
-takeover, and ties that blocked action to the PolicyDecision that triggered
-the Request.
+takeover. It ties the blocked scope to the PolicyDecision that triggered the
+Request and records the safe fallback when the HumanWorker does not respond.
 
 Optional fields:
 
 ```txt
 missing_permission_or_context
-options
-expires_at
+policy_refs
+data_sensitivity
+recommended_option
+safer_alternatives
+evidence_refs
+artifact_refs
+contribution_refs
+resolved_at
+resolved_by_review_id
+resolved_by_takeover_id
+closed_by_event_ref
+superseded_by_request_id
+duplicate_of_request_id
+```
+
+Conditionally required fields:
+
+```txt
+resolved_at
+  required when status is approved, denied, narrowed, answered, needs_revision,
+  takeover, expired, cancelled, or superseded
+
+resolved_by_review_id
+  required when status is approved, denied, narrowed, answered, or
+  needs_revision
+
+resolved_by_takeover_id
+  required when status is takeover
+
+closed_by_event_ref
+  required when status is expired, cancelled, or superseded
 ```
 
 Forbidden fields:
@@ -465,6 +503,14 @@ notification_provider_id
 credential
 raw_auth_token
 database_primary_key
+runtime_state
+provider_secret
+billing_field
+deployment_field
+product_ui_state
+hidden_policy_trace
+unbounded_approval
+implicit_authority_grant
 ```
 
 ### Review Field Lock
@@ -491,6 +537,33 @@ comments
 required_changes
 ```
 
+Conditionally required fields:
+
+```txt
+approval_scope
+  required when decision is approve or narrow
+  forbidden when decision is deny, correct, takeover, or needs_revision
+```
+
+Nested component:
+
+```txt
+ApprovalScope
+  request_id
+  review_id
+  policy_decision_id
+  request_revision
+  request_event_hash
+  normalized_action_hash
+  approved_action
+  allowed_scope
+  denied_scope
+  expires_at
+  max_uses
+  applies_to_work_session_id
+  applies_to_actor_id
+```
+
 Forbidden fields:
 
 ```txt
@@ -499,6 +572,8 @@ credential
 raw_auth_token
 database_primary_key
 product_ui_state
+unbounded_approval
+implicit_authority_grant
 ```
 
 ### Takeover Field Lock
@@ -1091,30 +1166,44 @@ Rules:
 ## Request
 
 `Request` is the structured way an AgentWorker asks the HumanWorker for
-permission, context, judgment, review, or takeover.
+permission, context, judgment, review, correction, or takeover before safely
+continuing a declared scope of work.
 
 ```txt
 Request
   id
+  protocol_version
   work_session_id
   requester_actor_id
   requester_worker_id
+  target_human_worker_id
   policy_decision_id
-  type: permission | context | decision | review | takeover
-  reason
+  type: permission | context | judgment | review | correction | takeover |
+    escalation
+  blocking_scope: action | branch | artifact | tool_call | external_send |
+    final_submission | work_session
+  reason_code
+  reason_summary
   requested_action
+  requested_outcome
   missing_permission_or_context
   risk_class
+  human_decision_needed
   options
+  recommended_option
+  safer_alternatives
+  default_if_no_response
   status
   created_at
   expires_at
+  resolved_at
 ```
 
 Statuses:
 
 ```txt
 pending
+acknowledged
 approved
 denied
 narrowed
@@ -1123,14 +1212,26 @@ takeover
 needs_revision
 expired
 cancelled
+superseded
 ```
 
 Rules:
 
-- Request is not a vague notification.
-- Request means the agent cannot continue safely on that branch.
-- Request resolution requires Review or Takeover.
+- Request is not chat.
+- Request is not a notification.
+- Request is not authority.
+- Request blocks only its declared scope.
+- Request means the agent cannot continue safely on that declared scope.
+- Human resolution of Request requires Review or Takeover.
+- Resolved Request status records `resolved_by_review_id` or
+  `resolved_by_takeover_id`.
+- Closed Request status records `closed_by_event_ref`.
 - Approval is narrower than the requested action when the human restricts scope.
+- Every Request includes options, risk, and default behavior when the human does
+  not respond.
+- Duplicate pending Requests are deduplicated or superseded.
+- Expired Requests apply `default_if_no_response`; expiry never grants new
+  authority.
 
 ## Review
 
@@ -1147,15 +1248,21 @@ Review
   decision: approve | deny | narrow | correct | takeover | needs_revision
   comments
   required_changes
+  approval_scope
   created_at
 ```
 
 Rules:
 
 - Review is a protocol object, not only UI feedback.
-- Review resolves a Request.
+- Review can resolve a Request.
+- Takeover can resolve a Request.
 - Review creates learning signals.
 - Review records authority changes when the decision changes scope.
+- Review with decision `approve` or `narrow` defines an ApprovalScope.
+- ApprovalScope binds the approved action to scope, expiry, WorkSession, and
+  Actor, and to the Request revision, Request event hash, PolicyDecision, and
+  normalized action hash.
 - Review creates Takeover only when the decision is `takeover`.
 
 ## Takeover

--- a/docs/protocol/12-request-protocol.md
+++ b/docs/protocol/12-request-protocol.md
@@ -1,0 +1,432 @@
+# Request Protocol
+
+Request is the control-plane object for intelligent deferral.
+
+A Request is a structured, scoped deferral created when an AgentWorker cannot
+safely, correctly, or responsibly continue a branch of work without HumanWorker
+permission, context, judgment, review, correction, or takeover.
+
+Request is not chat. Request is not a notification. Request is not authority.
+
+Request means one thing:
+
+```txt
+AgentWorker cannot continue the declared scope until HumanWorker resolves it or
+a terminal protocol transition closes it.
+```
+
+The canonical object shape is defined in
+[11-core-protocol-objects.md](./11-core-protocol-objects.md). This document
+defines how Request behaves.
+
+## Research Grounding
+
+Collaborative Gym shows why Request must be more precise than a message. It
+models human-agent collaboration as asynchronous, bidirectional interaction
+between human, agent, and task environment. Its results show that collaborative
+agents can outperform fully autonomous agents, while communication and
+situational-awareness failures remain major failure modes.
+
+Jarvis turns that lesson into protocol law:
+
+```txt
+communication informs
+Request defers blocked work
+Review resolves human judgment
+Takeover transfers direct control
+```
+
+Primary reference:
+
+- Collaborative Gym: https://arxiv.org/abs/2412.15701
+
+## Request, Notification, Review, And Takeover
+
+Jarvis keeps these concepts separate.
+
+```txt
+Notification
+  non-blocking information about progress, state, or completion
+
+Request
+  scoped blocker requiring HumanWorker resolution
+
+Review
+  HumanWorker judgment over a Request or another protocol target
+
+Takeover
+  HumanWorker direct control over a declared work scope
+```
+
+Notification is not a v0 core object. Hosts may surface progress messages,
+inbox items, or UI notifications, but those records do not block work unless a
+Request exists.
+
+Compatible implementations MUST NOT treat ordinary chat, progress updates, or
+status notifications as Requests.
+
+## Request Types
+
+Jarvis defines these Request types:
+
+```txt
+permission
+  AgentWorker needs authority outside current Policy.
+
+context
+  AgentWorker lacks information only the HumanWorker can provide.
+
+judgment
+  AgentWorker needs human taste, preference, priority, or decision.
+
+review
+  AgentWorker needs HumanWorker inspection of a plan, artifact, branch, or
+  final output.
+
+correction
+  AgentWorker detects conflict, uncertainty, or direction drift and needs
+  HumanWorker correction.
+
+takeover
+  AgentWorker recommends HumanWorker direct control over the declared scope.
+
+escalation
+  AgentWorker detects risk, policy conflict, ambiguity, or high-impact action.
+```
+
+## Blocking Scope
+
+Request blocks only its declared scope.
+
+```txt
+blocking_scope:
+  action
+  branch
+  artifact
+  tool_call
+  external_send
+  final_submission
+  work_session
+```
+
+Most Requests block one action, branch, artifact, tool call, external send, or
+final submission. `work_session` is reserved for cases where safe continuation
+of the whole WorkSession is impossible.
+
+AgentWorker may continue unrelated safe branches when Policy allows them.
+
+Compatible implementations MUST enforce the declared blocking scope. They MUST
+NOT freeze the whole WorkSession unless `blocking_scope` is `work_session` or a
+Takeover lock requires it.
+
+## Required Quality
+
+A valid Request answers six questions:
+
+```txt
+1. What is blocked?
+2. Why is it blocked?
+3. What does the AgentWorker want to do?
+4. What are the risks?
+5. What options does the HumanWorker have?
+6. What happens if the HumanWorker does not respond?
+```
+
+The protocol rejects vague Requests.
+
+Invalid:
+
+```txt
+Can I continue?
+```
+
+Valid:
+
+```txt
+I need network access to fetch package metadata from registry.npmjs.org.
+Current Policy denies external network access.
+Risk is medium because request metadata leaves the workspace.
+
+Options:
+1. Approve access to registry.npmjs.org for this WorkSession.
+2. Deny and continue with local package metadata only.
+3. Take over dependency inspection manually.
+
+Default if no response:
+Continue without network access and record an evidence limitation.
+```
+
+## Required Fields
+
+Every Request records:
+
+```txt
+id
+protocol_version
+work_session_id
+requester_actor_id
+requester_worker_id
+target_human_worker_id
+policy_decision_id
+type
+status
+blocking_scope
+reason_code
+reason_summary
+requested_action
+requested_outcome
+risk_class
+human_decision_needed
+options
+default_if_no_response
+created_at
+expires_at
+```
+
+`policy_decision_id` binds the Request to the PolicyDecision that blocked or
+flagged the action.
+
+`default_if_no_response` defines the safe fallback. The fallback never grants
+new authority. It may continue an unrelated safe branch, continue with limited
+evidence, cancel the blocked branch, or keep the blocked scope stopped.
+
+`expires_at` prevents stale unresolved Requests from becoming hidden workflow
+debt.
+
+## Optional Fields
+
+Request may also record:
+
+```txt
+policy_refs
+data_sensitivity
+missing_permission_or_context
+recommended_option
+safer_alternatives
+evidence_refs
+artifact_refs
+contribution_refs
+resolved_at
+resolved_by_review_id
+resolved_by_takeover_id
+closed_by_event_ref
+superseded_by_request_id
+duplicate_of_request_id
+```
+
+Optional fields add protocol-visible context. They do not change the meaning of
+required fields.
+
+## Lifecycle
+
+Request states are:
+
+```txt
+pending
+acknowledged
+approved
+denied
+narrowed
+answered
+needs_revision
+takeover
+expired
+cancelled
+superseded
+```
+
+State meanings:
+
+```txt
+pending
+  Request exists and blocks its declared scope.
+
+acknowledged
+  HumanWorker has seen the Request but has not resolved it.
+
+approved
+  HumanWorker grants the requested action exactly as requested.
+
+narrowed
+  HumanWorker grants a smaller scope.
+
+denied
+  HumanWorker rejects the requested action.
+
+answered
+  HumanWorker provides information or judgment without granting new authority.
+
+needs_revision
+  HumanWorker requires the AgentWorker to revise the plan, request, or output.
+
+takeover
+  HumanWorker takes control of the affected scope.
+
+expired
+  HumanWorker did not respond before expiry; safe fallback applies.
+
+cancelled
+  Authorized Actor cancels the Request through an append-only protocol event
+  because it is no longer relevant. Cancellation does not allow the blocked
+  action to proceed.
+
+superseded
+  A newer Request replaces this Request while preserving the blocked action
+  hash, policy decision, blocking scope, risk, and event references.
+```
+
+Human resolution of a Request requires Review or Takeover. Expiry,
+cancellation, and supersession are terminal protocol transitions. They close
+the Request, but they do not grant authority and they do not allow the blocked
+action to proceed.
+
+Resolved and closed Requests record the protocol reference that changed state:
+
+```txt
+resolved_by_review_id
+  required when status is approved, denied, narrowed, answered, or
+  needs_revision
+
+resolved_by_takeover_id
+  required when status is takeover
+
+closed_by_event_ref
+  required when status is expired, cancelled, or superseded
+```
+
+Allowed transitions:
+
+```txt
+pending -> acknowledged
+pending -> approved | denied | narrowed | answered | needs_revision | takeover
+pending -> expired | cancelled | superseded
+
+acknowledged -> approved | denied | narrowed | answered | needs_revision |
+  takeover
+acknowledged -> expired | cancelled | superseded
+```
+
+Terminal states do not transition back to `pending` or `acknowledged`.
+Terminal states do not change status again. A later Request may reference a
+terminal Request, but it never mutates the original Request.
+
+## Approval Scope
+
+Request does not create authority. Approval creates bounded authority.
+
+A Review with decision `approve` or `narrow` MUST define an ApprovalScope.
+
+```txt
+ApprovalScope
+  request_id
+  review_id
+  policy_decision_id
+  request_revision
+  request_event_hash
+  normalized_action_hash
+  approved_action
+  allowed_scope
+  denied_scope
+  expires_at
+  max_uses
+  applies_to_work_session_id
+  applies_to_actor_id
+```
+
+The AgentWorker resumes only inside the approved scope.
+
+Compatible implementations MUST reject execution outside the ApprovalScope.
+They MUST reject stale, replayed, mismatched, or expired approvals.
+
+## Event Chain
+
+Request is event-backed. The sequence below is behavioral, not a new event
+taxonomy. Compatible implementations encode it through canonical JarvisEvents
+defined for WorkSessions.
+
+```txt
+plan_proposed OR tool_requested
+PolicyDecision recorded as protocol state
+request_created
+review_added OR human_takeover_started OR request_closed
+request_resolved OR request_closed
+continued work inside approved scope
+LearningRecord, MemoryProposal, or SkillProposal
+```
+
+The event log remains append-only. Host database rows, inbox records, and UI
+notifications do not replace JarvisEvents.
+
+## Anti-Livelock Rules
+
+Jarvis rejects Request spam.
+
+Compatible implementations MUST enforce these rules:
+
+```txt
+1. Duplicate pending Requests are deduplicated or superseded without weakening
+   `policy_decision_id`, `blocking_scope`, risk, requested action hash, or
+   event references.
+2. Similar Requests are batched when safe.
+3. Low-risk uncertainty MUST NOT create a Request. Hosts may surface it as
+   non-blocking communication, but Jarvis does not require a Notification object
+   in v0.
+4. Every Request includes default_if_no_response.
+5. Every Request includes expires_at.
+6. AgentWorker may continue unrelated safe branches.
+7. Hosts enforce maximum pending Requests per WorkSession.
+8. Rejected Requests cannot be recreated unchanged immediately.
+9. Repeated failed Requests escalate to Review or Takeover.
+```
+
+## Learning Loop
+
+Every resolved or closed Request is teaching material.
+
+Request resolution or closure may create or reference:
+
+```txt
+LearningRecord
+MemoryProposal
+SkillProposal
+```
+
+Examples:
+
+```txt
+HumanWorker denies network access.
+  Future work prefers local evidence before external access.
+
+HumanWorker narrows approval.
+  Policy may gain a more precise grant pattern.
+
+HumanWorker corrects final submission.
+  SkillProposal may capture the corrected review process.
+
+HumanWorker takes over.
+  The pair records that this branch requires human control.
+```
+
+Learning remains governed. Request resolution or closure can propose learning,
+but it cannot silently confirm durable memory, skill, or policy changes.
+
+## Conformance Tests
+
+A Jarvis-compatible implementation MUST pass these Request tests:
+
+```txt
+1. Policy-denied action creates Request.
+2. AgentWorker cannot execute the blocked action before resolution.
+3. Human resolution requires Review or Takeover; expiry, cancellation, or
+   supersession only closes the Request.
+4. Approval can be narrowed.
+5. Narrowed approval prevents execution outside the approved scope.
+6. Expired Request applies default_if_no_response.
+7. Takeover creates lock epoch and blocks stale AgentWorker continuation.
+8. Duplicate Requests are deduplicated or superseded.
+9. Request resolution or closure chain appears in EvidenceManifest, including
+   Review, Takeover, or closure event refs as applicable.
+10. Request resolution can create governed learning proposals.
+11. Non-blocking host communication does not block WorkSession state.
+12. Request blocks only its declared scope unless scope is work_session.
+```

--- a/docs/protocol/14-protocol-lock.md
+++ b/docs/protocol/14-protocol-lock.md
@@ -18,6 +18,7 @@ Locked now:
 - thesis
 - boundary
 - vocabulary
+- core field classes
 - lifecycle
 - object relationships
 - core states
@@ -26,7 +27,7 @@ Locked now:
 
 Not locked yet:
 
-- exact OpenAPI field definitions
+- exact OpenAPI component syntax
 - version negotiation
 - capability negotiation
 - extension format

--- a/docs/protocol/14-protocol-lock.md
+++ b/docs/protocol/14-protocol-lock.md
@@ -198,13 +198,18 @@ Rules:
 
 ## Request
 
-Request is the structured way the AgentWorker asks for permission, context,
-judgment, review, or takeover.
+Request is structured, scoped deferral from AgentWorker to HumanWorker.
+
+Request is not chat. Request is not a notification. Request is not authority.
+Request blocks only its declared scope. Human resolution requires Review or
+Takeover. Expiry, cancellation, and supersession close a Request without
+granting authority.
 
 States:
 
 ```txt
 pending
+acknowledged
 approved
 denied
 narrowed
@@ -213,15 +218,22 @@ takeover
 needs_revision
 expired
 cancelled
+superseded
 ```
 
 Rules:
 
 - Request belongs to one WorkSession.
 - Request identifies requester worker and requester actor.
-- Request states reason, requested action or missing context, risk class,
-  status, and creation time.
-- Request resolves through Review or Takeover.
+- Request identifies target HumanWorker.
+- Request states type, blocking scope, reason, requested action or missing
+  context, risk class, options, default behavior when the human does not
+  respond, status, creation time, and expiry.
+- Human-resolved Request states require Review or Takeover.
+- Closed Request states require an append-only JarvisEvent reference.
+- Request blocks only its declared scope unless scope is whole WorkSession.
+- Expiry applies the safe fallback and never grants new authority.
+- Duplicate pending Requests are deduplicated or superseded.
 
 ## Review
 
@@ -243,7 +255,8 @@ Rules:
 - Review identifies reviewer worker and reviewer actor.
 - Review targets a Request, action, contribution, artifact, memory proposal,
   skill proposal, evidence item, or final outcome.
-- Review resolves a Request.
+- Review can resolve a Request.
+- Takeover can resolve a Request.
 - Review creates learning signals.
 
 ## Takeover
@@ -385,7 +398,9 @@ A v0-compatible host proves:
 - Every meaningful JarvisEvent has an Actor.
 - Policy gates autonomous AgentWorker action.
 - Policy-denied or review-required action creates Request.
-- Request resolves through Review or Takeover.
+- Human-resolved Request states are backed by Review or Takeover.
+- Expired, cancelled, and superseded states are backed by closure events and
+  never grant authority.
 - Review decisions are explicit.
 - Takeover blocks stale autonomous continuation.
 - Contributions are attributable.

--- a/docs/reviews/acceptance-criteria.md
+++ b/docs/reviews/acceptance-criteria.md
@@ -83,8 +83,9 @@ Expected result:
 
 - all records validate against the OpenAPI 3.1 contract
 - WorkSession status transitions are valid
-- Request cannot resolve without Review
+- Request cannot reach human-resolved state without Review or Takeover
 - Review supports approve, deny, narrow, correct, takeover, and needs_revision
+- Request blocks only its declared scope unless scope is whole WorkSession
 - Takeover creates lock state
 - Contribution references events or artifacts
 - EvidenceManifest references the WorkSession event chain
@@ -97,7 +98,8 @@ A product is Jarvis-compatible when it proves:
 - WorkSession is the source of truth.
 - Policy gates autonomous action.
 - blocked action creates Request.
-- Review resolves Request.
+- Review or Takeover resolves Request.
+- Request and non-blocking host communication remain separate.
 - Takeover prevents stale continuation.
 - Contributions are attributable.
 - EvidenceManifest is portable.


### PR DESCRIPTION
## Summary
- locks required, optional, extension, and forbidden field classes for Jarvis v0 core protocol objects
- keeps OutcomeReport as an extension object, not part of the v0 core object list
- adds Chunk 1 execution spec and OpenAPI component mapping notes
- strengthens zero-trust field boundaries with constrained extensions, WorkSession revision, latest event hash, PolicyDecision traceability, shared Contribution attribution, EvidenceManifest proof fields, and governed learning links

## Reviewer gate
- Zero-Trust Security Reviewer: findings integrated, pass
- Protocol Thesis Reviewer: findings integrated, final pass
- Chief Engineer Reviewer: findings integrated
- Conformance And Interop Reviewer: findings integrated
- Human Workflow Reviewer: findings integrated

Rejected findings: none.

## Validation
- `git diff --check HEAD~1..HEAD`
- `python3 scripts/check_markdown_links.py`
- `python3 scripts/check_week1_wording.py`
- `python3 -m py_compile scripts/check_markdown_links.py scripts/check_week1_wording.py`

## Scope boundary
This PR does not create the OpenAPI document, runtime, adapter implementation, product proof, demo flow, Garden POC, Workstream logic, or Harnessy behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new Chunk 1 spec and linked it from the docs index to guide field-lock/OpenAPI work
  * Introduced a full Request Protocol spec describing scoped blocking, lifecycle, expiry, deduplication, and anti‑livelock rules
  * Expanded Request/Review/Takeover semantics: Review or Takeover can resolve Requests; scope-limited blocking and safe expiry behavior
  * Formalized Core Field Lock and export/portability constraints and clarified OutcomeReport attribution and actor provenance
  * Updated roadmap, acceptance criteria, and WorkSession event sequencing to reflect these changes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->