### PR TITLE
Tighten Request closure invariants

### DIFF
--- a/docs/protocol/08-package-contracts.md
+++ b/docs/protocol/08-package-contracts.md
@@ -106,7 +106,7 @@ Release tests:
 - event envelopes validate required ids and timestamps.
 - event hashes exclude `event_hash` and signature fields.
 - WorkSession status transitions reject invalid transitions.
-- Human resolution of Request requires Review or Takeover.
+- Human resolution of a Request requires Review or Takeover.
 - Takeover creates a lock epoch.
 
 ## `@jarvis/policy`

--- a/docs/protocol/10-protocol-mvp.md
+++ b/docs/protocol/10-protocol-mvp.md
@@ -125,7 +125,7 @@ The MVP conformance suite checks:
   Policy.
 - policy-denied action creates Request.
 - Request blocks only its declared scope unless scope is whole WorkSession.
-- Human resolution of Request requires Review or Takeover.
+- Human resolution of a Request requires Review or Takeover.
 - approval narrows scope when the human restricts the request.
 - narrowed approval rejects execution outside the approved scope.
 - expired Request applies its safe fallback.

--- a/docs/protocol/11-core-protocol-objects.md
+++ b/docs/protocol/11-core-protocol-objects.md
@@ -45,7 +45,8 @@ workers inside a durable WorkSession.
 3. Every meaningful protocol event MUST be attributable to an Actor.
 4. The AgentWorker MUST act autonomously only inside Policy.
 5. Action outside Policy MUST create a Request.
-6. A Request MUST be resolved only by Review or Takeover.
+6. Human resolution of a Request MUST use Review or Takeover. Expiry,
+   cancellation, and supersession close a Request without granting authority.
 7. A Review MUST record human judgment over a protocol target.
 8. Takeover MUST create a lock epoch and block stale autonomous continuation.
 9. Contribution MUST record who did what.
@@ -1222,7 +1223,7 @@ Rules:
 - Request is not authority.
 - Request blocks only its declared scope.
 - Request means the agent cannot continue safely on that declared scope.
-- Human resolution of Request requires Review or Takeover.
+- Human resolution of a Request requires Review or Takeover.
 - Resolved Request status records `resolved_by_review_id` or
   `resolved_by_takeover_id`.
 - Closed Request status records `closed_by_event_ref`.


### PR DESCRIPTION
## Summary
- align the core Request invariant with the Request protocol closure model
- clarify that human resolution uses Review or Takeover
- clarify that expiry, cancellation, and supersession close a Request without granting authority
- polish matching wording in package contract and MVP conformance docs

## Review
- CodeRabbit post-merge nitpick checked: SkillProposal.proposed_for is already locked to human | agent | pair | project | task in main
- Protocol Thesis reviewer: PASS
- Zero-Trust Security reviewer: PASS
- Chief Engineer reviewer: PASS
- Conformance/OpenAPI reviewer: PASS

## Validation
- git diff --check
- python3 scripts/check_markdown_links.py
- python3 scripts/check_week1_wording.py
- python3 -m py_compile scripts/check_markdown_links.py scripts/check_week1_wording.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified protocol requirements for human resolution of requests, specifying that Review or Takeover methods must be used.
  * Updated core protocol invariants to explain how requests are closed through expiry, cancellation, or supersession.
  * Improved wording consistency across protocol documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->