### PR TITLE
Lock WorkSession lifecycle

### DIFF
--- a/docs/planning/week-1/README.md
+++ b/docs/planning/week-1/README.md
@@ -202,6 +202,8 @@ Done when:
 
 Purpose: lock WorkSession states and transitions.
 
+Spec: [chunk-2-worksession-lifecycle-lock.md](./chunk-2-worksession-lifecycle-lock.md)
+
 Outputs:
 
 - WorkSession state list

--- a/docs/planning/week-1/chunk-2-worksession-lifecycle-lock.md
+++ b/docs/planning/week-1/chunk-2-worksession-lifecycle-lock.md
@@ -63,7 +63,7 @@ mutable states.
 
 ## Required Transition Rules
 
-Compatible implementations must enforce the transition table in
+Compatible implementations MUST enforce the transition table in
 [04-work-sessions.md](../../protocol/04-work-sessions.md).
 
 Every state change requires:
@@ -96,6 +96,7 @@ Compatible implementations reject:
 ```txt
 missing_actor
 missing_policy
+missing_policy_decision
 missing_objective
 unknown_state
 invalid_transition

--- a/docs/planning/week-1/chunk-2-worksession-lifecycle-lock.md
+++ b/docs/planning/week-1/chunk-2-worksession-lifecycle-lock.md
@@ -1,0 +1,161 @@
+# Chunk 2: WorkSession Lifecycle Lock
+
+Chunk 2 locks the WorkSession state machine that Week 2 OpenAPI operations
+encode.
+
+This chunk does not create the OpenAPI document. It defines the protocol
+lifecycle rules, state transitions, revision requirements, hash-chain
+requirements, and export eligibility that OpenAPI must preserve.
+
+## Scope
+
+Chunk 2 locks:
+
+```txt
+WorkSession states
+allowed transitions
+rejected transitions
+state-change event requirements
+waiting_on_human blocker accounting
+revision rules
+event hash-chain rules
+stale-write rejection
+completion, failure, cancellation, and closure rules
+export eligibility
+```
+
+## Non-Goals
+
+Chunk 2 does not:
+
+- define runtime execution
+- define host storage
+- define product workflow
+- define Garden POC behavior
+- define queue behavior
+- define model calls
+- define billing, deployment, or monitoring
+- change Request, Review, Takeover, Contribution, Evidence, or Learning
+  semantics except where WorkSession lifecycle references them
+
+## WorkSession States
+
+Chunk 2 locks these WorkSession states:
+
+```txt
+created
+active
+waiting_on_human
+takeover
+reconciling
+completed
+failed
+cancelled
+closed
+```
+
+`created`, `active`, `waiting_on_human`, `takeover`, and `reconciling` are
+mutable states.
+
+`completed`, `failed`, and `cancelled` are terminal outcome states.
+
+`closed` is the sealed archival state. It never transitions to another state.
+
+## Required Transition Rules
+
+Compatible implementations must enforce the transition table in
+[04-work-sessions.md](../../protocol/04-work-sessions.md).
+
+Every state change requires:
+
+```txt
+Jarvis-Protocol-Version
+Jarvis-Actor-Id
+Jarvis-Idempotency-Key
+Jarvis-Request-Timestamp
+Jarvis-Expected-WorkSession-Revision
+Jarvis-Previous-Event-Hash
+```
+
+Every accepted state change records a JarvisEvent, increments `revision`, and
+sets `last_event_hash` to the new event hash.
+
+WorkSession creation starts from expected revision `0` and
+`Jarvis-Previous-Event-Hash` equal to the protocol genesis hash. The start event
+sets `JarvisEvent.previous_hash` to the same genesis hash.
+
+Every transition out of `waiting_on_human` records
+`blocked_scope_resolution_refs`. The refs prove that each blocked scope was
+resolved, closed, transferred into Takeover, or recorded as an evidence
+limitation.
+
+## Rejection Rules
+
+Compatible implementations reject:
+
+```txt
+missing_actor
+missing_policy
+missing_objective
+unknown_state
+invalid_transition
+stale_work_session_revision
+invalid_previous_event_hash
+missing_idempotency_key
+duplicate_idempotency_key_mismatch
+missing_jarvis_event
+missing_blocked_scope_resolution_refs
+missing_reconciliation_refs
+mutation_after_closed
+invalid_export_state
+unauthorized_actor
+```
+
+## Export Rules
+
+Final portable export is valid only from:
+
+```txt
+completed
+failed
+cancelled
+closed
+```
+
+Export from `active`, `waiting_on_human`, `takeover`, or `reconciling` is an
+interim host snapshot, not a final Jarvis EvidenceManifest export.
+
+Export never includes product-private fields, credentials, secrets, raw runtime
+state, host-only database ids, deployment details, billing data, private scores,
+or product UI state.
+
+## Reviewer Focus
+
+Reviewers must verify:
+
+- WorkSession states are named once and used consistently
+- transition rules do not create hidden runtime ownership
+- stale writes are rejected by revision and previous event hash
+- every transition out of `waiting_on_human` accounts for blocked scopes
+- `closed` is sealed
+- terminal outcome states do not grant new authority
+- export is only valid from permitted states
+- the lifecycle supports human-agent collaboration without becoming product UI
+
+## Done Criteria
+
+Chunk 2 is complete when:
+
+- [04-work-sessions.md](../../protocol/04-work-sessions.md) contains the locked
+  state machine
+- [11-core-protocol-objects.md](../../protocol/11-core-protocol-objects.md)
+  lists the same WorkSession states
+- [14-protocol-lock.md](../../protocol/14-protocol-lock.md) states the same
+  lifecycle rules
+- conformance and MVP docs mention invalid transition, stale revision, previous
+  hash, and export eligibility checks
+- local checks pass
+- Zero-Trust Security Reviewer plus at least three other reviewer lanes pass
+- valid findings are integrated
+- rejected findings are recorded with concrete reasons
+- PR is opened

--- a/docs/protocol/04-work-sessions.md
+++ b/docs/protocol/04-work-sessions.md
@@ -33,7 +33,11 @@ explains how the record behaves during collaboration.
 WorkSession
   id
   protocol_version
+  created_by_actor_id
+  revision
+  last_event_hash
   objective
+  source_ref
   human_worker_id
   agent_worker_id
   policy_id
@@ -43,17 +47,201 @@ WorkSession
   contribution_ledger_ref
   evidence_manifest_ref
   learning_record_refs
+  created_at
+  updated_at
 ```
 
 A WorkSession contains many protocol events. Jarvis records protocol facts, not
 host execution objects.
 
+## Lifecycle States
+
+WorkSession states are:
+
+```txt
+created
+active
+waiting_on_human
+takeover
+reconciling
+completed
+failed
+cancelled
+closed
+```
+
+State meanings:
+
+```txt
+created
+  WorkSession exists with HumanWorker, AgentWorker, objective, Policy, initial
+  revision, and initial event hash.
+
+active
+  HumanWorker and AgentWorker can continue work inside Policy.
+
+waiting_on_human
+  One or more declared scopes are blocked on HumanWorker Review, context,
+  judgment, or Takeover.
+
+takeover
+  HumanWorker has direct control over a declared scope and stale AgentWorker
+  continuation is rejected.
+
+reconciling
+  HumanWorker takeover output is being reconciled into the WorkSession before
+  AgentWorker continuation.
+
+completed
+  The WorkSession reached its intended outcome.
+
+failed
+  The WorkSession cannot reach its intended outcome.
+
+cancelled
+  An authorized Actor stopped the WorkSession before intended completion.
+
+closed
+  The WorkSession is sealed for archival/export state. No further mutation is
+  accepted except idempotent replay of the same accepted request.
+```
+
+`created`, `active`, `waiting_on_human`, `takeover`, and `reconciling` are
+mutable states. `completed`, `failed`, and `cancelled` are terminal outcome
+states. `closed` is the sealed archival state.
+
+## Transition Table
+
+Compatible implementations MUST enforce this state machine:
+
+```txt
+created -> active
+created -> cancelled
+
+active -> waiting_on_human
+active -> takeover
+active -> completed
+active -> failed
+active -> cancelled
+
+waiting_on_human -> active
+waiting_on_human -> takeover
+waiting_on_human -> completed
+waiting_on_human -> failed
+waiting_on_human -> cancelled
+
+takeover -> reconciling
+takeover -> failed
+takeover -> cancelled
+
+reconciling -> active
+reconciling -> waiting_on_human
+reconciling -> completed
+reconciling -> failed
+reconciling -> cancelled
+
+completed -> closed
+failed -> closed
+cancelled -> closed
+```
+
+`closed` has no outgoing transition.
+
+Rejected transitions include:
+
+```txt
+created -> completed
+created -> failed
+created -> closed
+active -> closed
+waiting_on_human -> closed
+takeover -> active
+takeover -> completed
+takeover -> closed
+reconciling -> takeover
+completed -> active
+completed -> failed
+completed -> cancelled
+failed -> active
+failed -> completed
+failed -> cancelled
+cancelled -> active
+cancelled -> completed
+cancelled -> failed
+closed -> created
+closed -> active
+closed -> waiting_on_human
+closed -> takeover
+closed -> reconciling
+closed -> completed
+closed -> failed
+closed -> cancelled
+```
+
+Any transition not listed as allowed is rejected.
+
+## Transition Events
+
+Every allowed WorkSession state transition uses one canonical event type:
+
+```txt
+genesis -> created                 work_session_started
+
+created -> active                 work_session_activated
+created -> cancelled              work_session_cancelled
+
+active -> waiting_on_human         work_session_waiting_on_human
+active -> takeover                 work_session_takeover
+active -> completed                work_session_completed
+active -> failed                   work_session_failed
+active -> cancelled                work_session_cancelled
+
+waiting_on_human -> active         work_session_activated
+waiting_on_human -> takeover       work_session_takeover
+waiting_on_human -> completed      work_session_completed
+waiting_on_human -> failed         work_session_failed
+waiting_on_human -> cancelled      work_session_cancelled
+
+takeover -> reconciling            work_session_reconciling
+takeover -> failed                 work_session_failed
+takeover -> cancelled              work_session_cancelled
+
+reconciling -> active              work_session_activated
+reconciling -> waiting_on_human    work_session_waiting_on_human
+reconciling -> completed           work_session_completed
+reconciling -> failed              work_session_failed
+reconciling -> cancelled           work_session_cancelled
+
+completed -> closed                work_session_closed
+failed -> closed                   work_session_closed
+cancelled -> closed                work_session_closed
+```
+
+Takeover object events remain separate:
+
+```txt
+human_takeover_started
+human_takeover_finished
+```
+
+`work_session_takeover` records the WorkSession state transition.
+`human_takeover_started` records the Takeover object and declared
+human-controlled scope. Both records reference the same takeover id.
+
 ## Events
 
-Important transitions are evented:
+Important transitions and work records are evented:
 
 ```txt
 work_session_started
+work_session_activated
+work_session_waiting_on_human
+work_session_takeover
+work_session_reconciling
+work_session_completed
+work_session_failed
+work_session_cancelled
+work_session_closed
 message_added
 plan_proposed
 tool_requested
@@ -71,13 +259,158 @@ memory_proposed
 memory_confirmed
 skill_proposed
 skill_updated
-work_session_completed
 ```
 
 The event log supports observability, debugging, evidence, and learning.
 
 The event log is append-only. Host checkpoints accelerate resume, but
 events are the source of truth.
+
+Every WorkSession state change records a JarvisEvent. The event payload records:
+
+```txt
+from_status
+to_status
+reason
+previous_revision
+next_revision
+```
+
+The JarvisEvent envelope records `actor_id`, `previous_hash`, and `event_hash`.
+State-change payloads do not duplicate those envelope fields.
+
+State-change events include `blocked_scope_resolution_refs` whenever the
+transition leaves `waiting_on_human`. State-change events include
+`reconciliation_refs` only when the transition leaves `reconciling`.
+
+`work_session_started` creates the initial `created` state. WorkSession creation
+uses expected revision `0` and `Jarvis-Previous-Event-Hash` equal to the
+protocol genesis hash. The start event sets `JarvisEvent.previous_hash` to the
+same genesis hash. The accepted start event sets `revision` to `1` and
+`last_event_hash` to the first event hash.
+
+Every transition from `waiting_on_human` requires every blocked scope to be
+accounted for by Review, Takeover, Request closure, or EvidenceManifest
+limitation refs. A WorkSession cannot leave `waiting_on_human` by ignoring
+unresolved blockers.
+
+The state-change event records this proof in `blocked_scope_resolution_refs`:
+
+```txt
+review_refs
+takeover_refs
+request_closure_refs
+evidence_limitation_refs
+```
+
+Completion from `waiting_on_human` is rejected while unresolved blockers remain
+for `whole_work_session`, `final_submission`, required review, or required
+evidence.
+
+`waiting_on_human -> active` requires every blocked scope to be resolved or
+closed. `waiting_on_human -> takeover` requires unresolved blocked scopes to be
+transferred into the referenced Takeover scope. `waiting_on_human -> failed` and
+`waiting_on_human -> cancelled` require unresolved blocked scopes to be recorded
+as evidence limitations or request closures.
+
+Every transition out of `reconciling` requires `reconciliation_refs`:
+
+```txt
+takeover_id
+human_contribution_refs
+affected_artifact_refs
+evidence_refs
+agent_event_refs
+context_manifest_refs
+learning_record_refs
+memory_proposal_refs
+skill_proposal_refs
+```
+
+This applies to:
+
+```txt
+reconciling -> active
+reconciling -> waiting_on_human
+reconciling -> completed
+reconciling -> failed
+reconciling -> cancelled
+```
+
+Learning, memory, and skill refs are required when reconciliation creates
+governed learning. They are omitted only when the reconciliation event records
+that no durable learning change was proposed.
+
+## Revision And Hash Chain
+
+Every mutating operation against a WorkSession requires:
+
+```txt
+Jarvis-Expected-WorkSession-Revision
+Jarvis-Previous-Event-Hash
+Jarvis-Idempotency-Key
+Jarvis-Actor-Id
+Jarvis-Request-Timestamp
+Jarvis-Protocol-Version
+```
+
+The protocol accepts a new mutation only when:
+
+```txt
+Jarvis-Expected-WorkSession-Revision == WorkSession.revision
+Jarvis-Previous-Event-Hash == WorkSession.last_event_hash
+Actor has authority for the requested transition or event
+Idempotency key is unused
+```
+
+If `Jarvis-Idempotency-Key` was already accepted with the same Actor, protocol
+version, operation, and canonical payload, the compatible implementation returns
+the original accepted result. It MUST NOT append another JarvisEvent, increment
+`revision`, or update `last_event_hash`. This replay check happens before stale
+revision and previous hash rejection.
+
+If the same idempotency key appears with a different Actor, protocol version,
+operation, or canonical payload, the mutation is rejected as
+`duplicate_idempotency_key_mismatch`.
+
+For `POST /work-sessions`, the protocol treats the creation request as expected
+revision `0` with previous event hash equal to the protocol genesis hash. The
+operation still requires actor authority, idempotency, timestamp, and protocol
+version. The idempotency key is scoped to the creating Actor, protocol version,
+operation, and canonical create payload.
+
+Accepted mutation behavior:
+
+```txt
+1. append JarvisEvent
+2. increment WorkSession.revision by 1
+3. set WorkSession.last_event_hash to JarvisEvent.event_hash
+4. update WorkSession.updated_at
+5. update WorkSession.status when the event is a state transition
+```
+
+Rejected mutation reasons:
+
+```txt
+missing_actor
+missing_policy
+missing_objective
+unknown_state
+invalid_transition
+stale_work_session_revision
+invalid_previous_event_hash
+missing_idempotency_key
+duplicate_idempotency_key_mismatch
+missing_jarvis_event
+missing_blocked_scope_resolution_refs
+missing_reconciliation_refs
+mutation_after_closed
+invalid_export_state
+unauthorized_actor
+```
+
+Hosts may store checkpoints, projections, or indexes. Those records never
+replace the append-only JarvisEvent log.
 
 Derived metrics such as revision rounds, elapsed time, blocked-action count,
 and response latency are computed from events and timestamps. Derived
@@ -253,6 +586,71 @@ runs a learning pass:
 
 The pass produces LearningRecord, MemoryProposal, and SkillProposal records.
 Policy decides what becomes durable.
+
+## Completion, Failure, Cancellation, And Closure
+
+`completed` means the WorkSession reached its intended outcome.
+
+`failed` means the WorkSession cannot reach its intended outcome. Failure records
+the reason, evidence limitations, and remaining unresolved Requests when they
+exist.
+
+`cancelled` means an authorized Actor stopped the WorkSession before intended
+completion. Cancellation records the Actor, reason, and policy basis. It does
+not grant authority to execute blocked work.
+
+After `completed`, `failed`, or `cancelled`, compatible implementations accept
+only:
+
+```txt
+final EvidenceManifest link or export record
+governed LearningRecord, MemoryProposal, or SkillProposal records allowed by
+  Policy
+transition to closed
+idempotent replay of the same accepted request
+```
+
+They reject new work events, new AgentWorker actions, new Requests, and
+unrelated Contributions.
+
+`closed` seals the WorkSession. After `closed`, compatible implementations MUST
+reject every mutating operation except idempotent replay of the same accepted
+request.
+
+## Export Eligibility
+
+Final portable EvidenceManifest export is valid only from:
+
+```txt
+completed
+failed
+cancelled
+closed
+```
+
+Exports from mutable states are interim host snapshots, not final Jarvis
+EvidenceManifest exports.
+
+If final export generation appends or links an EvidenceManifest record, that
+mutation happens before transition to `closed`. A `closed` WorkSession only
+permits read-only reproduction of an already sealed export.
+
+Every final export records:
+
+```txt
+work_session_id
+status
+revision
+event_chain_root
+last_event_hash
+exported_at
+generated_by_actor_id
+limitations
+```
+
+Final export MUST exclude product-private fields, credentials, secrets, raw
+runtime state, host-only database ids, deployment details, billing data, private
+scores, and product UI state.
 
 ## WorkSession Resumption
 

--- a/docs/protocol/04-work-sessions.md
+++ b/docs/protocol/04-work-sessions.md
@@ -360,6 +360,7 @@ The protocol accepts a new mutation only when:
 Jarvis-Expected-WorkSession-Revision == WorkSession.revision
 Jarvis-Previous-Event-Hash == WorkSession.last_event_hash
 Actor has authority for the requested transition or event
+AgentWorker mutation has a PolicyDecision recorded and linked before acceptance
 Idempotency key is unused
 ```
 
@@ -387,6 +388,7 @@ Accepted mutation behavior:
 3. set WorkSession.last_event_hash to JarvisEvent.event_hash
 4. update WorkSession.updated_at
 5. update WorkSession.status when the event is a state transition
+6. link PolicyDecision when the accepted mutation is from AgentWorker
 ```
 
 Rejected mutation reasons:
@@ -394,6 +396,7 @@ Rejected mutation reasons:
 ```txt
 missing_actor
 missing_policy
+missing_policy_decision
 missing_objective
 unknown_state
 invalid_transition

--- a/docs/protocol/08-package-contracts.md
+++ b/docs/protocol/08-package-contracts.md
@@ -106,6 +106,10 @@ Release tests:
 - event envelopes validate required ids and timestamps.
 - event hashes exclude `event_hash` and signature fields.
 - WorkSession status transitions reject invalid transitions.
+- stale WorkSession revision rejects mutation.
+- stale previous event hash rejects mutation.
+- final EvidenceManifest export requires completed, failed, cancelled, or closed
+  WorkSession state.
 - Human resolution of a Request requires Review or Takeover.
 - Takeover creates a lock epoch.
 

--- a/docs/protocol/08-package-contracts.md
+++ b/docs/protocol/08-package-contracts.md
@@ -105,6 +105,12 @@ Release tests:
 - canonical event serialization is stable.
 - event envelopes validate required ids and timestamps.
 - event hashes exclude `event_hash` and signature fields.
+- mutating requests reject missing `Jarvis-Protocol-Version`.
+- mutating requests reject missing `Jarvis-Actor-Id`.
+- mutating requests reject missing `Jarvis-Idempotency-Key`.
+- mutating requests reject missing `Jarvis-Request-Timestamp`.
+- mutating requests reject missing `Jarvis-Expected-WorkSession-Revision`.
+- mutating requests reject missing `Jarvis-Previous-Event-Hash`.
 - WorkSession status transitions reject invalid transitions.
 - stale WorkSession revision rejects mutation.
 - stale previous event hash rejects mutation.

--- a/docs/protocol/10-protocol-mvp.md
+++ b/docs/protocol/10-protocol-mvp.md
@@ -130,9 +130,10 @@ The MVP conformance suite checks:
 - every transition out of `waiting_on_human` records blocker accounting.
 - WorkSession lifecycle rejection ids include `unknown_state`,
   `missing_idempotency_key`, `duplicate_idempotency_key_mismatch`,
-  `missing_jarvis_event`, `missing_blocked_scope_resolution_refs`,
-  `missing_reconciliation_refs`, `mutation_after_closed`,
-  `invalid_export_state`, and `unauthorized_actor`.
+  `missing_jarvis_event`, `missing_policy_decision`,
+  `missing_blocked_scope_resolution_refs`, `missing_reconciliation_refs`,
+  `mutation_after_closed`, `invalid_export_state`, and
+  `unauthorized_actor`.
 - final EvidenceManifest export is valid only from completed, failed,
   cancelled, or closed WorkSession state.
 - policy-denied action creates Request.

--- a/docs/protocol/10-protocol-mvp.md
+++ b/docs/protocol/10-protocol-mvp.md
@@ -111,6 +111,7 @@ takeover
 reconciling
 completed
 failed
+cancelled
 closed
 ```
 
@@ -123,6 +124,17 @@ The MVP conformance suite checks:
 
 - a WorkSession cannot start without HumanWorker, AgentWorker, objective, and
   Policy.
+- invalid WorkSession transitions are rejected.
+- stale WorkSession revision is rejected.
+- stale previous event hash is rejected.
+- every transition out of `waiting_on_human` records blocker accounting.
+- WorkSession lifecycle rejection ids include `unknown_state`,
+  `missing_idempotency_key`, `duplicate_idempotency_key_mismatch`,
+  `missing_jarvis_event`, `missing_blocked_scope_resolution_refs`,
+  `missing_reconciliation_refs`, `mutation_after_closed`,
+  `invalid_export_state`, and `unauthorized_actor`.
+- final EvidenceManifest export is valid only from completed, failed,
+  cancelled, or closed WorkSession state.
 - policy-denied action creates Request.
 - Request blocks only its declared scope unless scope is whole WorkSession.
 - Human resolution of a Request requires Review or Takeover.

--- a/docs/protocol/11-core-protocol-objects.md
+++ b/docs/protocol/11-core-protocol-objects.md
@@ -1053,9 +1053,18 @@ Rules:
 - The event log is the protocol source of truth.
 - Allowed WorkSession transitions are defined in
   [04-work-sessions.md](./04-work-sessions.md).
+- Every mutating WorkSession operation MUST include
+  `Jarvis-Protocol-Version`, `Jarvis-Actor-Id`, `Jarvis-Idempotency-Key`,
+  `Jarvis-Request-Timestamp`, `Jarvis-Expected-WorkSession-Revision`, and
+  `Jarvis-Previous-Event-Hash`.
+- The operation MUST record the Actor from `Jarvis-Actor-Id` and verify
+  authority before applying changes.
+- `Jarvis-Expected-WorkSession-Revision` MUST match `WorkSession.revision`.
+- `Jarvis-Previous-Event-Hash` MUST match `WorkSession.last_event_hash`.
 - Every accepted WorkSession mutation increments `revision` and updates
   `last_event_hash`.
-- Stale expected revision or previous event hash rejects the mutation.
+- Missing headers, stale expected revision, or mismatched previous event hash
+  reject the mutation.
 - Final EvidenceManifest export is valid only from `completed`, `failed`,
   `cancelled`, or `closed`.
 - `closed` is sealed and rejects further mutation except idempotent replay of

--- a/docs/protocol/11-core-protocol-objects.md
+++ b/docs/protocol/11-core-protocol-objects.md
@@ -1038,6 +1038,7 @@ takeover
 reconciling
 completed
 failed
+cancelled
 closed
 ```
 
@@ -1045,11 +1046,20 @@ Rules:
 
 - A WorkSession is not chat history.
 - A WorkSession records the collaboration, not the host execution stack.
-- `source_ref` points to the origin of the work, task, product flow, or
+- `source_ref` points to the origin of the work, task, host work reference, or
   external system reference. It is opaque to Jarvis and never gives the
   protocol ownership of that external system.
 - Events are append-only.
 - The event log is the protocol source of truth.
+- Allowed WorkSession transitions are defined in
+  [04-work-sessions.md](./04-work-sessions.md).
+- Every accepted WorkSession mutation increments `revision` and updates
+  `last_event_hash`.
+- Stale expected revision or previous event hash rejects the mutation.
+- Final EvidenceManifest export is valid only from `completed`, `failed`,
+  `cancelled`, or `closed`.
+- `closed` is sealed and rejects further mutation except idempotent replay of
+  the same accepted request.
 - Private host fields stay outside portable Jarvis exports.
 
 ## JarvisEvent

--- a/docs/protocol/14-protocol-lock.md
+++ b/docs/protocol/14-protocol-lock.md
@@ -195,8 +195,16 @@ Rules:
 - WorkSession keeps an append-only JarvisEvent log.
 - WorkSession state changes follow the transition table in
   [04-work-sessions.md](./04-work-sessions.md).
+- Every mutating request that affects a WorkSession MUST include
+  `Jarvis-Protocol-Version`, `Jarvis-Actor-Id`, `Jarvis-Idempotency-Key`,
+  `Jarvis-Request-Timestamp`, `Jarvis-Expected-WorkSession-Revision`, and
+  `Jarvis-Previous-Event-Hash`.
+- Accepted mutations record the Actor from `Jarvis-Actor-Id`, verify authority,
+  enforce `Jarvis-Expected-WorkSession-Revision`, and enforce
+  `Jarvis-Previous-Event-Hash`.
 - Every accepted mutation increments `revision` and updates `last_event_hash`.
-- Stale expected revision or previous event hash rejects the mutation.
+- Missing headers, stale expected revision, or mismatched previous event hash
+  reject the mutation.
 - WorkSession owns Requests, Reviews, Takeovers, Contributions,
   EvidenceManifest, and LearningRecords.
 - Final EvidenceManifest export is valid only from `completed`, `failed`,

--- a/docs/protocol/14-protocol-lock.md
+++ b/docs/protocol/14-protocol-lock.md
@@ -185,6 +185,7 @@ takeover
 reconciling
 completed
 failed
+cancelled
 closed
 ```
 
@@ -192,8 +193,16 @@ Rules:
 
 - WorkSession starts with HumanWorker, AgentWorker, objective, and Policy.
 - WorkSession keeps an append-only JarvisEvent log.
+- WorkSession state changes follow the transition table in
+  [04-work-sessions.md](./04-work-sessions.md).
+- Every accepted mutation increments `revision` and updates `last_event_hash`.
+- Stale expected revision or previous event hash rejects the mutation.
 - WorkSession owns Requests, Reviews, Takeovers, Contributions,
   EvidenceManifest, and LearningRecords.
+- Final EvidenceManifest export is valid only from `completed`, `failed`,
+  `cancelled`, or `closed`.
+- `closed` rejects further mutation except idempotent replay of the same
+  accepted request.
 - WorkSession export stays free of product-private infrastructure fields.
 
 ## Request
@@ -396,6 +405,8 @@ A v0-compatible host proves:
 - WorkSession is the source of truth.
 - HumanWorker and AgentWorker both exist.
 - Every meaningful JarvisEvent has an Actor.
+- WorkSession invalid transitions are rejected.
+- WorkSession stale revision and previous hash mismatches are rejected.
 - Policy gates autonomous AgentWorker action.
 - Policy-denied or review-required action creates Request.
 - Human-resolved Request states are backed by Review or Takeover.

--- a/docs/protocol/15-openapi-communication-binding.md
+++ b/docs/protocol/15-openapi-communication-binding.md
@@ -148,9 +148,11 @@ current WorkSession revision, and links to the previous event hash. Every
 AgentWorker action that affects a WorkSession also records a PolicyDecision
 before the action is accepted as protocol state.
 
-`POST /work-sessions` uses expected revision `0` and the protocol genesis hash
-as `Jarvis-Previous-Event-Hash`. It still requires actor authority,
-idempotency, timestamp, and protocol version.
+Jarvis defines `POST /work-sessions` as the genesis WorkSession mutation.
+Compatible implementations MUST use expected revision `0` and the protocol
+genesis hash as `Jarvis-Previous-Event-Hash`. They MUST require actor
+authority, idempotency, timestamp, and protocol version before accepting the
+creation event.
 
 Every export excludes product-private fields, credentials, secrets, raw runtime
 state, database ids that only the host understands, deployment details, billing
@@ -184,6 +186,7 @@ stale_work_session_revision
 missing_idempotency_key
 missing_actor
 missing_policy
+missing_policy_decision
 missing_objective
 policy_denied
 request_unresolved

--- a/docs/protocol/15-openapi-communication-binding.md
+++ b/docs/protocol/15-openapi-communication-binding.md
@@ -148,8 +148,13 @@ current WorkSession revision, and links to the previous event hash. Every
 AgentWorker action that affects a WorkSession also records a PolicyDecision
 before the action is accepted as protocol state.
 
+`POST /work-sessions` uses expected revision `0` and the protocol genesis hash
+as `Jarvis-Previous-Event-Hash`. It still requires actor authority,
+idempotency, timestamp, and protocol version.
+
 Every export excludes product-private fields, credentials, secrets, raw runtime
-state, database ids that only the host understands, and deployment details.
+state, database ids that only the host understands, deployment details, billing
+data, private scores, and product UI state.
 
 ## Version And Capability Negotiation
 
@@ -174,14 +179,26 @@ Jarvis OpenAPI defines protocol errors for:
 
 ```txt
 invalid_transition
+unknown_state
+stale_work_session_revision
+missing_idempotency_key
 missing_actor
 missing_policy
+missing_objective
 policy_denied
 request_unresolved
 review_required
 stale_takeover_epoch
 invalid_event_hash
+invalid_previous_event_hash
+duplicate_idempotency_key_mismatch
+missing_jarvis_event
+missing_blocked_scope_resolution_refs
+missing_reconciliation_refs
+mutation_after_closed
+unauthorized_actor
 invalid_export
+invalid_export_state
 unsupported_capability
 forbidden_host_private_field
 ```

--- a/docs/reviews/acceptance-criteria.md
+++ b/docs/reviews/acceptance-criteria.md
@@ -86,12 +86,16 @@ Expected result:
 - invalid WorkSession transitions are rejected
 - stale WorkSession revision is rejected
 - stale previous event hash is rejected
+- every accepted WorkSession state change records Actor, verifies authority,
+  checks current WorkSession revision, and links to previous event hash
+- every AgentWorker action that affects a WorkSession records a PolicyDecision
+  before the action is accepted as protocol state
 - every transition out of `waiting_on_human` records blocker accounting
 - WorkSession lifecycle rejection ids include `unknown_state`,
   `missing_idempotency_key`, `duplicate_idempotency_key_mismatch`,
-  `missing_jarvis_event`, `missing_blocked_scope_resolution_refs`,
-  `missing_reconciliation_refs`, `mutation_after_closed`,
-  `invalid_export_state`, and `unauthorized_actor`
+  `missing_jarvis_event`, `missing_policy_decision`,
+  `missing_blocked_scope_resolution_refs`, `missing_reconciliation_refs`,
+  `mutation_after_closed`, `invalid_export_state`, and `unauthorized_actor`
 - final EvidenceManifest export is valid only from completed, failed,
   cancelled, or closed WorkSession state
 - Request cannot reach human-resolved state without Review or Takeover

--- a/docs/reviews/acceptance-criteria.md
+++ b/docs/reviews/acceptance-criteria.md
@@ -83,6 +83,17 @@ Expected result:
 
 - all records validate against the OpenAPI 3.1 contract
 - WorkSession status transitions are valid
+- invalid WorkSession transitions are rejected
+- stale WorkSession revision is rejected
+- stale previous event hash is rejected
+- every transition out of `waiting_on_human` records blocker accounting
+- WorkSession lifecycle rejection ids include `unknown_state`,
+  `missing_idempotency_key`, `duplicate_idempotency_key_mismatch`,
+  `missing_jarvis_event`, `missing_blocked_scope_resolution_refs`,
+  `missing_reconciliation_refs`, `mutation_after_closed`,
+  `invalid_export_state`, and `unauthorized_actor`
+- final EvidenceManifest export is valid only from completed, failed,
+  cancelled, or closed WorkSession state
 - Request cannot reach human-resolved state without Review or Takeover
 - Review supports approve, deny, narrow, correct, takeover, and needs_revision
 - Request blocks only its declared scope unless scope is whole WorkSession


### PR DESCRIPTION
## Summary

Locks Week 1 Chunk 2: WorkSession lifecycle.

This PR defines the WorkSession state machine and the lifecycle rules that Week 2 OpenAPI operations must encode:

- locked WorkSession states: `created`, `active`, `waiting_on_human`, `takeover`, `reconciling`, `completed`, `failed`, `cancelled`, `closed`
- allowed and rejected transitions
- canonical transition events, including `genesis -> created` as `work_session_started`
- revision, previous-hash, idempotency, and replay rules
- `waiting_on_human` blocker accounting through `blocked_scope_resolution_refs`
- `reconciling` exit accounting through `reconciliation_refs`
- terminal outcome and `closed` mutation limits
- final EvidenceManifest export eligibility
- aligned lifecycle rejection IDs across protocol, OpenAPI binding, MVP, and acceptance docs

## Zero-Trust Notes

- Every mutating WorkSession operation requires Actor, protocol version, idempotency key, timestamp, expected revision, and previous event hash.
- Idempotent replay returns the original accepted result and does not append another event or increment revision.
- Same idempotency key with different Actor, version, operation, or canonical payload rejects as `duplicate_idempotency_key_mismatch`.
- `closed` rejects mutation except idempotent replay of the same accepted request.
- Final exports exclude product-private fields, credentials, secrets, raw runtime state, host-only database ids, deployment details, billing data, private scores, and product UI state.

## Reviewer Lanes

All five reviewer lanes passed after valid findings were integrated:

- Protocol Thesis Reviewer: PASS
- Zero-Trust Security Reviewer: PASS
- Chief Engineer Reviewer: PASS
- OpenAPI / Conformance Reviewer: PASS
- Human Workflow Reviewer: PASS

Integrated reviewer fixes:

- removed `actor_id`, `previous_hash`, and `event_hash` duplication from state-change payloads and kept those in the JarvisEvent envelope
- added `genesis -> created` / `work_session_started` to the transition-event table
- aligned lifecycle rejection IDs across docs
- required blocker accounting on every transition out of `waiting_on_human`
- added `missing_blocked_scope_resolution_refs` as the canonical rejection ID

## Checks

- `git diff --check`
- `python3 scripts/check_markdown_links.py`
- `python3 scripts/check_week1_wording.py`
- `python3 -m py_compile scripts/check_markdown_links.py scripts/check_week1_wording.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive WorkSession lifecycle lock spec with detailed state meanings, transitions, and reviewer/done criteria.
  * Introduced `cancelled` as a new WorkSession status and refined terminal-state semantics (completed/failed/cancelled/closed).
  * Formalized mutation validation (required protocol headers, revision/previous-hash checks, idempotency rules) and expanded event definitions.
  * Expanded error taxonomy and tightened final export eligibility and excluded-field rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->