### PR TITLE
Lock OpenAPI security entry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,7 +155,7 @@ schema-file packages are not the primary contract.
 
 Jarvis starts from zero trust.
 
-Every mutating operation requires:
+Every WorkSession-scoped mutating operation requires:
 
 ```txt
 Jarvis-Protocol-Version
@@ -166,8 +166,23 @@ Jarvis-Expected-WorkSession-Revision
 Jarvis-Previous-Event-Hash
 ```
 
-Every accepted state change records the Actor, verifies authority, checks the
-current WorkSession revision, and links to the previous event hash.
+Every non-WorkSession protocol mutation requires:
+
+```txt
+Jarvis-Protocol-Version
+Jarvis-Actor-Id
+Jarvis-Idempotency-Key
+Jarvis-Request-Timestamp
+```
+
+Worker registration, Actor registration, and OutcomeReport submission are
+non-WorkSession protocol mutations. They verify Actor authority, idempotency,
+protocol version, and timestamp. They do not require fake WorkSession revision
+or previous event hash values.
+
+Every accepted WorkSession-scoped state change records the Actor, verifies
+authority, checks the current WorkSession revision, and links to the previous
+event hash.
 
 Every AgentWorker action that affects a WorkSession records a PolicyDecision
 before the action is accepted as protocol state.

--- a/docs/planning/week-1/README.md
+++ b/docs/planning/week-1/README.md
@@ -277,6 +277,8 @@ Done when:
 
 Purpose: lock the OpenAPI inputs required before Week 2 drafting.
 
+Spec: [chunk-5-openapi-security-entry-lock.md](./chunk-5-openapi-security-entry-lock.md)
+
 Outputs:
 
 - required headers

--- a/docs/planning/week-1/chunk-5-openapi-security-entry-lock.md
+++ b/docs/planning/week-1/chunk-5-openapi-security-entry-lock.md
@@ -14,7 +14,7 @@ Chunk 5 locks:
 
 ```txt
 required mutating headers
-recommended read headers
+read-operation header requirements
 security scheme requirements
 Actor authority requirements
 Worker and Actor registration boundary

--- a/docs/planning/week-1/chunk-5-openapi-security-entry-lock.md
+++ b/docs/planning/week-1/chunk-5-openapi-security-entry-lock.md
@@ -1,0 +1,270 @@
+# Chunk 5: OpenAPI Security Entry Lock
+
+Chunk 5 locks the OpenAPI security and negotiation inputs required before
+Week 2 OpenAPI drafting starts.
+
+This chunk does not create the OpenAPI YAML document. It defines the required
+headers, security scheme requirements, protocol error model, version
+negotiation rules, capability negotiation rules, extension namespace rules, and
+forbidden export fields that the Week 2 OpenAPI contract must encode.
+
+## Scope
+
+Chunk 5 locks:
+
+```txt
+required mutating headers
+recommended read headers
+security scheme requirements
+Actor authority requirements
+Worker and Actor registration boundary
+idempotency and replay requirements
+WorkSession revision checks
+previous event hash checks
+PolicyDecision requirement
+version negotiation
+capability negotiation
+extension namespace rules
+protocol error envelope
+protocol error ids
+forbidden export fields
+```
+
+## Non-Goals
+
+Chunk 5 does not:
+
+- create OpenAPI YAML
+- define auth provider implementation
+- define identity storage
+- define product account creation
+- define host database schema
+- define runtime execution
+- define Garden POC behavior
+- define client SDK code
+
+## Required Mutating Headers
+
+Every WorkSession-scoped mutating protocol operation MUST include:
+
+```txt
+Jarvis-Protocol-Version
+Jarvis-Actor-Id
+Jarvis-Idempotency-Key
+Jarvis-Request-Timestamp
+Jarvis-Expected-WorkSession-Revision
+Jarvis-Previous-Event-Hash
+```
+
+Compatible implementations MUST reject a WorkSession-scoped mutating request
+when any required header is missing, invalid, stale, mismatched, replayed with
+a different canonical payload, or outside timestamp tolerance.
+
+Non-WorkSession protocol mutations MUST include:
+
+```txt
+Jarvis-Protocol-Version
+Jarvis-Actor-Id
+Jarvis-Idempotency-Key
+Jarvis-Request-Timestamp
+```
+
+Worker registration, Actor registration, and OutcomeReport submission are
+non-WorkSession protocol mutations. They MUST verify Actor authority,
+idempotency, protocol version, and timestamp before state changes. They MUST
+NOT require fake WorkSession revision or previous event hash values.
+
+Jarvis timestamp tolerance is five minutes in the past and sixty seconds in the
+future. Hosts MAY be stricter. Hosts MUST NOT be looser. Requests outside
+tolerance reject as `stale_request_timestamp`.
+
+Operation header matrix:
+
+```txt
+WorkSession-scoped mutation
+  HostAuth
+  Jarvis-Protocol-Version
+  Jarvis-Actor-Id
+  Jarvis-Idempotency-Key
+  Jarvis-Request-Timestamp
+  Jarvis-Expected-WorkSession-Revision
+  Jarvis-Previous-Event-Hash
+
+Genesis WorkSession mutation
+  HostAuth
+  Jarvis-Protocol-Version
+  Jarvis-Actor-Id
+  Jarvis-Idempotency-Key
+  Jarvis-Request-Timestamp
+  Jarvis-Expected-WorkSession-Revision set to 0
+  Jarvis-Previous-Event-Hash set to protocol genesis hash
+
+Worker or Actor registration
+  HostAuth
+  Jarvis-Protocol-Version
+  Jarvis-Actor-Id
+  Jarvis-Idempotency-Key
+  Jarvis-Request-Timestamp
+
+OutcomeReport submission
+  HostAuth
+  Jarvis-Protocol-Version
+  Jarvis-Actor-Id
+  Jarvis-Idempotency-Key
+  Jarvis-Request-Timestamp
+
+WorkSession-scoped or export read
+  HostAuth
+  Jarvis-Protocol-Version
+  Jarvis-Actor-Id
+```
+
+## Security Schemes
+
+Jarvis OpenAPI MUST define security schemes without owning identity.
+
+The OpenAPI contract MUST support:
+
+```txt
+HostAuth
+  records that the host authenticated the caller without prescribing credential
+  format, auth provider, token type, session store, or account system
+
+ActorHeader
+  identifies the protocol Actor for attribution and authority checks
+
+ProtocolVersionHeader
+  selects the Jarvis protocol version
+
+IdempotencyHeader
+  protects mutation replay
+
+RequestTimestampHeader
+  rejects stale mutation requests
+
+RevisionHeader
+  protects WorkSession optimistic concurrency
+
+PreviousHashHeader
+  protects event-chain continuity
+```
+
+Authentication proves caller identity to the host. Authorization verifies that
+`Jarvis-Actor-Id` has authority for the protocol operation. Jarvis records the
+Actor. Jarvis does not own the host identity provider.
+
+## Negotiation Rules
+
+Version negotiation uses:
+
+```txt
+Jarvis-Protocol-Version
+```
+
+Capability negotiation uses:
+
+```txt
+Jarvis-Host-Capabilities
+Jarvis-Required-Capabilities
+```
+
+Extension negotiation uses:
+
+```txt
+Jarvis-Extensions
+```
+
+Unsupported required capability rejects as `unsupported_capability`.
+
+Unknown optional capability is ignored unless it changes a core field meaning.
+
+Extensions MUST be namespaced and MUST NOT override core fields.
+Invalid extension namespace rejects as `invalid_extension_namespace`. Extension
+core field override rejects as `extension_core_field_override`.
+
+## Read Operation Headers
+
+Read operations that return WorkSession-scoped records or portable exports MUST
+include caller authentication and:
+
+```txt
+Jarvis-Protocol-Version
+Jarvis-Actor-Id
+```
+
+Compatible implementations MUST verify that `Jarvis-Actor-Id` has authority to
+read the requested protocol record.
+
+Read operations MAY include:
+
+```txt
+Jarvis-Required-Capabilities
+Jarvis-Extensions
+```
+
+Read operations MUST NOT require mutation-only idempotency, expected revision,
+or previous event hash headers.
+
+## Protocol Error Envelope
+
+Every protocol error response MUST include:
+
+```txt
+error_id
+protocol_version
+object_type
+field
+reason
+remediation
+trace_id
+```
+
+When `Jarvis-Protocol-Version` is missing, `protocol_version` records the
+server-selected error contract version. When `Jarvis-Protocol-Version` is
+unsupported, `protocol_version` records the rejected version and remediation
+points to supported versions.
+
+The error response MUST NOT include credentials, secrets, raw runtime state,
+host-only database ids, deployment details, billing data, private scores, or
+product UI state, raw auth tokens, provider secrets, session cookies, or
+private keys.
+
+## Forbidden Export Fields
+
+Portable protocol export MUST exclude:
+
+```txt
+product-private fields
+credentials
+secrets
+raw runtime state
+host-only database ids
+deployment details
+billing data
+private scores
+product UI state
+raw auth tokens
+provider secrets
+session cookies
+private keys
+```
+
+## Done Criteria
+
+Chunk 5 is complete when:
+
+- [15-openapi-communication-binding.md](../../protocol/15-openapi-communication-binding.md)
+  locks headers, security schemes, negotiation, error envelope, and forbidden
+  export fields
+- [08-package-contracts.md](../../protocol/08-package-contracts.md) includes
+  release tests for required headers, security schemes, negotiation,
+  extension namespace rules, protocol errors, and forbidden export fields
+- [10-protocol-mvp.md](../../protocol/10-protocol-mvp.md) includes
+  conformance checks for OpenAPI security entry rules
+- [docs/reviews/acceptance-criteria.md](../../reviews/acceptance-criteria.md)
+  includes acceptance checks for the same rules
+- local checks pass
+- Zero-Trust Security Reviewer plus at least three other reviewer lanes pass
+- valid findings are integrated
+- rejected findings are recorded with concrete reasons
+- PR is opened

--- a/docs/protocol/07-protocol-decisions.md
+++ b/docs/protocol/07-protocol-decisions.md
@@ -49,8 +49,7 @@ This document records decisions that are fixed for the Jarvis protocol.
 - Security schemes define protocol entry requirements without owning host auth.
 - Capability and extension negotiation are protocol-owned.
 - Extension fields must be namespaced and cannot override core fields.
-- Protocol downgrade is rejected. Implementations must not silently downgrade a
-  request.
+- Compatible implementations MUST NOT silently downgrade a request.
 - Protocol errors use a structured error envelope.
 - WorkSession-scoped and export read operations require protocol version,
   caller authentication, and Actor authority. They do not require mutation-only

--- a/docs/protocol/07-protocol-decisions.md
+++ b/docs/protocol/07-protocol-decisions.md
@@ -33,6 +33,28 @@ This document records decisions that are fixed for the Jarvis protocol.
 - Review decisions are protocol-owned.
 - EvidenceManifest export shape is protocol-owned.
 - Conformance tests verify behavior, not infrastructure.
+- OpenAPI 3.1 is the primary host-facing communication binding.
+- Every WorkSession-scoped mutating operation requires
+  `Jarvis-Protocol-Version`,
+  `Jarvis-Actor-Id`, `Jarvis-Idempotency-Key`,
+  `Jarvis-Request-Timestamp`, `Jarvis-Expected-WorkSession-Revision`, and
+  `Jarvis-Previous-Event-Hash`.
+- Non-WorkSession protocol mutations require `Jarvis-Protocol-Version`,
+  `Jarvis-Actor-Id`, `Jarvis-Idempotency-Key`, and
+  `Jarvis-Request-Timestamp`.
+- Worker and Actor registration records protocol references. It does not create
+  accounts, authenticate callers, issue credentials, or own identity storage.
+- OutcomeReport submission does not mutate sealed WorkSession or
+  EvidenceManifest records.
+- Security schemes define protocol entry requirements without owning host auth.
+- Capability and extension negotiation are protocol-owned.
+- Extension fields must be namespaced and cannot override core fields.
+- Protocol downgrade is rejected. Implementations must not silently downgrade a
+  request.
+- Protocol errors use a structured error envelope.
+- WorkSession-scoped and export read operations require protocol version,
+  caller authentication, and Actor authority. They do not require mutation-only
+  idempotency, expected revision, or previous event hash headers.
 
 ## Explicit Non-Decisions
 

--- a/docs/protocol/08-package-contracts.md
+++ b/docs/protocol/08-package-contracts.md
@@ -105,12 +105,52 @@ Release tests:
 - canonical event serialization is stable.
 - event envelopes validate required ids and timestamps.
 - event hashes exclude `event_hash` and signature fields.
-- mutating requests reject missing `Jarvis-Protocol-Version`.
-- mutating requests reject missing `Jarvis-Actor-Id`.
-- mutating requests reject missing `Jarvis-Idempotency-Key`.
-- mutating requests reject missing `Jarvis-Request-Timestamp`.
-- mutating requests reject missing `Jarvis-Expected-WorkSession-Revision`.
-- mutating requests reject missing `Jarvis-Previous-Event-Hash`.
+- WorkSession-scoped mutating requests reject missing
+  `Jarvis-Protocol-Version` as `missing_protocol_version`.
+- WorkSession-scoped mutating requests reject missing `Jarvis-Actor-Id` as
+  `missing_actor`.
+- WorkSession-scoped mutating requests reject missing `Jarvis-Idempotency-Key`
+  as `missing_idempotency_key`.
+- mutating requests reject unsupported `Jarvis-Protocol-Version` as
+  `unsupported_protocol_version`.
+- WorkSession-scoped mutating requests reject missing
+  `Jarvis-Request-Timestamp` as
+  `missing_request_timestamp`.
+- mutating requests reject timestamps more than five minutes in the past or
+  sixty seconds in the future as `stale_request_timestamp`.
+- Hosts may use stricter timestamp tolerance and MUST NOT use looser tolerance.
+- WorkSession-scoped mutating requests reject missing
+  `Jarvis-Expected-WorkSession-Revision` as
+  `missing_expected_work_session_revision`.
+- WorkSession-scoped mutating requests reject missing
+  `Jarvis-Previous-Event-Hash` as
+  `missing_previous_event_hash`.
+- mutating requests reject replayed `Jarvis-Idempotency-Key` with different
+  canonical payload.
+- WorkSession-scoped mutating requests reject mismatched
+  `Jarvis-Expected-WorkSession-Revision`.
+- WorkSession-scoped mutating requests reject mismatched
+  `Jarvis-Previous-Event-Hash`.
+- non-WorkSession protocol mutations require `Jarvis-Protocol-Version`,
+  `Jarvis-Actor-Id`, `Jarvis-Idempotency-Key`, and
+  `Jarvis-Request-Timestamp`.
+- Worker registration, Actor registration, and OutcomeReport submission do not
+  require fake WorkSession revision or previous event hash values.
+- OpenAPI security schemes include HostAuth, ActorHeader,
+  ProtocolVersionHeader, IdempotencyHeader, RequestTimestampHeader,
+  RevisionHeader, and PreviousHashHeader.
+- WorkSession-scoped and export read operations require
+  `Jarvis-Protocol-Version`, caller authentication, and `Jarvis-Actor-Id`, and
+  do not require mutation-only idempotency, expected revision, or previous event
+  hash headers.
+- Worker and Actor registration never creates accounts, authenticates callers,
+  issues credentials, or owns identity storage.
+- unsupported required capabilities reject as `unsupported_capability`.
+- invalid extension namespace rejects as `invalid_extension_namespace`.
+- extension core field override rejects as `extension_core_field_override`.
+- protocol error envelope includes error_id, protocol_version, object_type,
+  field, reason, remediation, and trace_id.
+- protocol error responses exclude forbidden host-private fields.
 - WorkSession status transitions reject invalid transitions.
 - stale WorkSession revision rejects mutation.
 - stale previous event hash rejects mutation.

--- a/docs/protocol/10-protocol-mvp.md
+++ b/docs/protocol/10-protocol-mvp.md
@@ -184,6 +184,26 @@ The MVP conformance suite checks:
   `outcome_report_without_learning_record`.
 - exported protocol records do not require product-private infrastructure
   fields.
+- OpenAPI security entry checks require HostAuth, ActorHeader,
+  ProtocolVersionHeader, IdempotencyHeader, RequestTimestampHeader,
+  RevisionHeader, and PreviousHashHeader.
+- WorkSession-scoped and export read operations require
+  `Jarvis-Protocol-Version`, caller authentication, and `Jarvis-Actor-Id`, and
+  do not require mutation-only idempotency, expected revision, or previous event
+  hash headers.
+- Worker and Actor registration does not create accounts, authenticate callers,
+  issue credentials, or own identity storage.
+- unsupported required capabilities reject as `unsupported_capability`.
+- invalid extension namespace rejects as `invalid_extension_namespace`.
+- extension core field override rejects as `extension_core_field_override`.
+- protocol error envelope includes error_id, protocol_version, object_type,
+  field, reason, remediation, and trace_id.
+- OpenAPI security rejection ids include `missing_protocol_version`,
+  `unsupported_protocol_version`, `missing_actor`, `missing_idempotency_key`,
+  `missing_request_timestamp`, `stale_request_timestamp`,
+  `missing_expected_work_session_revision`, `missing_previous_event_hash`,
+  `invalid_extension_namespace`, and `extension_core_field_override`.
+- protocol error responses exclude forbidden host-private fields.
 
 ## Success Condition
 

--- a/docs/protocol/15-openapi-communication-binding.md
+++ b/docs/protocol/15-openapi-communication-binding.md
@@ -83,6 +83,10 @@ components.examples
 The `components.schemas` section defines the protocol objects. The `paths`
 section defines how hosts exchange those objects.
 
+OpenAPI authors MUST NOT add host implementation fields, auth-provider fields,
+database ids, runtime ids, billing fields, product UI state, or deployment
+details to core protocol schemas.
+
 ## Core Operations
 
 The first OpenAPI binding defines these operations:
@@ -108,6 +112,17 @@ POST /outcome-reports
 Worker and Actor operations register protocol references. They do not create
 accounts, authenticate users, issue credentials, or own identity storage.
 
+Worker and Actor registration rules:
+
+```txt
+Worker registration records protocol participant refs.
+Actor registration records protocol authority refs.
+Registration does not create host accounts.
+Registration does not authenticate callers.
+Registration does not issue credentials.
+Registration does not define identity storage.
+```
+
 The operations are protocol operations. They do not define how the host runs the
 agent, stores records, authenticates users, bills customers, renders UI, or
 deploys infrastructure.
@@ -132,7 +147,7 @@ portable export boundary
 forbidden host-private fields
 ```
 
-Every mutating operation requires:
+Every WorkSession-scoped mutating operation requires:
 
 ```txt
 Jarvis-Protocol-Version
@@ -143,10 +158,123 @@ Jarvis-Expected-WorkSession-Revision
 Jarvis-Previous-Event-Hash
 ```
 
-Every accepted state change records the Actor, verifies authority, checks the
-current WorkSession revision, and links to the previous event hash. Every
-AgentWorker action that affects a WorkSession also records a PolicyDecision
-before the action is accepted as protocol state.
+Required WorkSession-scoped mutating header semantics:
+
+```txt
+Jarvis-Protocol-Version
+  selects the Jarvis protocol version used by the request
+
+Jarvis-Actor-Id
+  identifies the protocol Actor whose authority is checked and recorded
+
+Jarvis-Idempotency-Key
+  protects mutation replay for the same Actor, operation, protocol version, and
+  canonical payload
+
+Jarvis-Request-Timestamp
+  rejects stale or replayed requests outside protocol timestamp tolerance
+
+Jarvis-Expected-WorkSession-Revision
+  protects WorkSession optimistic concurrency
+
+Jarvis-Previous-Event-Hash
+  links the accepted mutation to the current WorkSession event chain
+```
+
+Missing or invalid mutating headers reject the request before protocol state
+changes.
+
+Non-WorkSession protocol mutations MUST include:
+
+```txt
+Jarvis-Protocol-Version
+Jarvis-Actor-Id
+Jarvis-Idempotency-Key
+Jarvis-Request-Timestamp
+```
+
+Worker registration, Actor registration, and OutcomeReport submission are
+non-WorkSession protocol mutations. They MUST verify Actor authority,
+idempotency, protocol version, and timestamp before state changes. They MUST
+NOT require fake WorkSession revision or previous event hash values.
+
+Jarvis timestamp tolerance is five minutes in the past and sixty seconds in the
+future. Hosts MAY be stricter. Hosts MUST NOT be looser. Requests outside
+tolerance reject as `stale_request_timestamp`.
+
+Operation header matrix:
+
+```txt
+WorkSession-scoped mutation
+  requires HostAuth
+  requires Jarvis-Protocol-Version
+  requires Jarvis-Actor-Id
+  requires Jarvis-Idempotency-Key
+  requires Jarvis-Request-Timestamp
+  requires Jarvis-Expected-WorkSession-Revision
+  requires Jarvis-Previous-Event-Hash
+
+Genesis WorkSession mutation
+  requires HostAuth
+  requires Jarvis-Protocol-Version
+  requires Jarvis-Actor-Id
+  requires Jarvis-Idempotency-Key
+  requires Jarvis-Request-Timestamp
+  requires Jarvis-Expected-WorkSession-Revision set to 0
+  requires Jarvis-Previous-Event-Hash set to protocol genesis hash
+
+Worker or Actor registration
+  requires HostAuth
+  requires Jarvis-Protocol-Version
+  requires Jarvis-Actor-Id
+  requires Jarvis-Idempotency-Key
+  requires Jarvis-Request-Timestamp
+  does not require Jarvis-Expected-WorkSession-Revision
+  does not require Jarvis-Previous-Event-Hash
+
+OutcomeReport submission
+  requires HostAuth
+  requires Jarvis-Protocol-Version
+  requires Jarvis-Actor-Id
+  requires Jarvis-Idempotency-Key
+  requires Jarvis-Request-Timestamp
+  does not require Jarvis-Expected-WorkSession-Revision
+  does not require Jarvis-Previous-Event-Hash
+
+WorkSession-scoped or export read
+  requires HostAuth
+  requires Jarvis-Protocol-Version
+  requires Jarvis-Actor-Id
+  does not require Jarvis-Idempotency-Key
+  does not require Jarvis-Expected-WorkSession-Revision
+  does not require Jarvis-Previous-Event-Hash
+```
+
+Read operations that return WorkSession-scoped records or portable exports MUST
+include caller authentication and:
+
+```txt
+Jarvis-Protocol-Version
+Jarvis-Actor-Id
+```
+
+Compatible implementations MUST verify that `Jarvis-Actor-Id` has authority to
+read the requested protocol record.
+
+Read operations MAY include:
+
+```txt
+Jarvis-Required-Capabilities
+Jarvis-Extensions
+```
+
+Read operations MUST NOT require mutation-only idempotency, expected revision,
+or previous event hash headers.
+
+Every accepted WorkSession-scoped state change records the Actor, verifies
+authority, checks the current WorkSession revision, and links to the previous
+event hash. Every AgentWorker action that affects a WorkSession also records a
+PolicyDecision before the action is accepted as protocol state.
 
 Jarvis defines `POST /work-sessions` as the genesis WorkSession mutation.
 Compatible implementations MUST use expected revision `0` and the protocol
@@ -157,6 +285,59 @@ creation event.
 Every export excludes product-private fields, credentials, secrets, raw runtime
 state, database ids that only the host understands, deployment details, billing
 data, private scores, and product UI state.
+
+Forbidden export fields include:
+
+```txt
+product-private fields
+credentials
+secrets
+raw runtime state
+host-only database ids
+deployment details
+billing data
+private scores
+product UI state
+raw auth tokens
+provider secrets
+session cookies
+private keys
+```
+
+## Security Schemes
+
+Jarvis OpenAPI MUST define security schemes without owning identity.
+
+Required security entries:
+
+```txt
+HostAuth
+  records that the host authenticated the caller without prescribing credential
+  format, auth provider, token type, session store, or account system
+
+ActorHeader
+  binds the request to `Jarvis-Actor-Id`
+
+ProtocolVersionHeader
+  binds the request to `Jarvis-Protocol-Version`
+
+IdempotencyHeader
+  binds the request to `Jarvis-Idempotency-Key`
+
+RequestTimestampHeader
+  binds the request to `Jarvis-Request-Timestamp`
+
+RevisionHeader
+  binds the request to `Jarvis-Expected-WorkSession-Revision`
+
+PreviousHashHeader
+  binds the request to `Jarvis-Previous-Event-Hash`
+```
+
+Authentication proves caller identity to the host. Authorization verifies that
+`Jarvis-Actor-Id` has authority for the requested protocol operation. Jarvis
+records the Actor and authority check result. Jarvis does not own the host
+identity provider, auth backend, session store, or account system.
 
 ## Version And Capability Negotiation
 
@@ -172,8 +353,37 @@ Jarvis-Required-Capabilities
 Jarvis-Extensions
 ```
 
-Unsupported capability produces a protocol error. Extension fields are
-namespaced and never change the meaning of core fields.
+Version negotiation rules:
+
+```txt
+Unsupported Jarvis-Protocol-Version rejects the request.
+Compatible minor version may proceed only when required capabilities match.
+Protocol downgrade is rejected as unsupported_protocol_version.
+A caller may request an older supported version only by explicitly setting
+Jarvis-Protocol-Version to that version. Implementations MUST NOT silently
+downgrade a request.
+```
+
+Capability negotiation rules:
+
+```txt
+Jarvis-Host-Capabilities declares supported optional capabilities.
+Jarvis-Required-Capabilities declares capabilities required by the caller.
+Unsupported required capability rejects as unsupported_capability.
+Unknown optional capability is ignored unless it changes a core field meaning.
+```
+
+Extension rules:
+
+```txt
+Jarvis-Extensions declares extension namespaces.
+Extension fields MUST be namespaced.
+Extension fields MUST NOT override core field names.
+Extension fields MUST NOT change the meaning of core fields.
+Extension fields MUST NOT contain forbidden export fields.
+Invalid extension namespace rejects as invalid_extension_namespace.
+Extension core field override rejects as extension_core_field_override.
+```
 
 ## Error Model
 
@@ -182,9 +392,17 @@ Jarvis OpenAPI defines protocol errors for:
 ```txt
 invalid_transition
 unknown_state
+missing_protocol_version
+unsupported_protocol_version
+missing_request_timestamp
+stale_request_timestamp
+missing_expected_work_session_revision
+missing_previous_event_hash
 stale_work_session_revision
 missing_idempotency_key
 missing_actor
+invalid_extension_namespace
+extension_core_field_override
 missing_policy
 missing_policy_decision
 missing_objective
@@ -229,8 +447,29 @@ unsupported_capability
 forbidden_host_private_field
 ```
 
-Errors are structured. The error body names the protocol object, field, reason,
-and remediation path.
+Errors are structured.
+
+Every protocol error response MUST include:
+
+```txt
+error_id
+protocol_version
+object_type
+field
+reason
+remediation
+trace_id
+```
+
+When `Jarvis-Protocol-Version` is missing, `protocol_version` records the
+server-selected error contract version. When `Jarvis-Protocol-Version` is
+unsupported, `protocol_version` records the rejected version and remediation
+points to supported versions.
+
+Error responses MUST NOT include credentials, secrets, raw runtime state,
+host-only database ids, deployment details, billing data, private scores,
+product UI state, raw auth tokens, provider secrets, session cookies, or
+private keys.
 
 ## This Week's Work
 

--- a/docs/reviews/acceptance-criteria.md
+++ b/docs/reviews/acceptance-criteria.md
@@ -142,6 +142,26 @@ Expected result:
   `outcome_report_without_learning_record`, and
   `forbidden_host_private_field`
 - exported records contain no product-private infrastructure requirement
+- OpenAPI security entry checks require HostAuth, ActorHeader,
+  ProtocolVersionHeader, IdempotencyHeader, RequestTimestampHeader,
+  RevisionHeader, and PreviousHashHeader
+- WorkSession-scoped and export read operations require
+  `Jarvis-Protocol-Version`, caller authentication, and `Jarvis-Actor-Id`, and
+  do not require mutation-only idempotency, expected revision, or previous event
+  hash headers
+- Worker and Actor registration does not create accounts, authenticate callers,
+  issue credentials, or own identity storage
+- unsupported required capabilities reject as `unsupported_capability`
+- invalid extension namespace rejects as `invalid_extension_namespace`
+- extension core field override rejects as `extension_core_field_override`
+- protocol error envelope includes error_id, protocol_version, object_type,
+  field, reason, remediation, and trace_id
+- OpenAPI security rejection ids include `missing_protocol_version`,
+  `unsupported_protocol_version`, `missing_actor`, `missing_idempotency_key`,
+  `missing_request_timestamp`, `stale_request_timestamp`,
+  `missing_expected_work_session_revision`, `missing_previous_event_hash`,
+  `invalid_extension_namespace`, and `extension_core_field_override`
+- protocol error responses exclude forbidden host-private fields
 
 ## Conformance Acceptance
 

--- a/docs/reviews/acceptance-criteria.md
+++ b/docs/reviews/acceptance-criteria.md
@@ -145,6 +145,9 @@ Expected result:
 - OpenAPI security entry checks require HostAuth, ActorHeader,
   ProtocolVersionHeader, IdempotencyHeader, RequestTimestampHeader,
   RevisionHeader, and PreviousHashHeader
+- Worker registration, Actor registration, and OutcomeReport submission do not
+  require `Jarvis-Expected-WorkSession-Revision` or
+  `Jarvis-Previous-Event-Hash`
 - WorkSession-scoped and export read operations require
   `Jarvis-Protocol-Version`, caller authentication, and `Jarvis-Actor-Id`, and
   do not require mutation-only idempotency, expected revision, or previous event


### PR DESCRIPTION
## Summary
- lock Week 1 Chunk 5 OpenAPI security-entry requirements
- define operation header classes for WorkSession mutations, genesis creation, Worker/Actor registration, OutcomeReport submission, and protected reads
- replace host-specific auth wording with HostAuth and tighten version, capability, extension, error, and forbidden-field rules
- align AGENTS, protocol decisions, package tests, MVP checks, and acceptance criteria

## Reviewer Lanes
- Protocol Thesis Reviewer: accepted HostAuth finding; removed bearer-token prescription
- Zero-Trust Security Reviewer: accepted timestamp tolerance and no-silent-downgrade findings; clarified mutation classes without fake WorkSession headers
- Chief Engineer Reviewer: accepted operation header matrix and complete error-id mapping findings
- OpenAPI/Conformance Reviewer: accepted extension rejection IDs and header class clarity findings
- Human Workflow Reviewer: accepted read-side caller authentication and Actor authority finding

## Validation
- git diff --check
- python3 scripts/check_markdown_links.py
- python3 scripts/check_week1_wording.py
- python3 -m py_compile scripts/check_markdown_links.py scripts/check_week1_wording.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refined zero-trust header rules by splitting WorkSession-scoped mutating operations from non-WorkSession protocol mutations.
  * Clarified which headers are required vs forbidden for mutations, reads, registrations, and outcome reports.
  * Added operation header matrices, protocol negotiation rules, forbidden export fields, and structured protocol error envelope with rejection IDs.
  * Expanded v0.1 acceptance and conformance criteria to reflect these security and error-handling requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->