### PR TITLE
Close Week 1 positioning lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ When v0 proves this loop, Jarvis is real.
 - [docs/README.md](./docs/README.md) - docs index.
 - [docs/protocol/](./docs/protocol/) - protocol definition, architecture,
   object model, policy, memory, evidence, integration boundaries, package
-  contracts, MVP, and protocol lock.
+  contracts, MVP, protocol lock, OpenAPI binding, and positioning lock.
 - [docs/planning/](./docs/planning/) - roadmap, 30-day plan, and upload-ready
   planning sheets.
 - [docs/reviews/](./docs/reviews/) - protocol readiness and acceptance review

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,8 +20,10 @@ stable.
 - [10-protocol-mvp.md](./protocol/10-protocol-mvp.md)
 - [11-core-protocol-objects.md](./protocol/11-core-protocol-objects.md)
 - [12-request-protocol.md](./protocol/12-request-protocol.md)
+- [13-contribution-evidence-learning.md](./protocol/13-contribution-evidence-learning.md)
 - [14-protocol-lock.md](./protocol/14-protocol-lock.md)
 - [15-openapi-communication-binding.md](./protocol/15-openapi-communication-binding.md)
+- [16-positioning-adoption-lock.md](./protocol/16-positioning-adoption-lock.md)
 
 ## Planning
 

--- a/docs/planning/12-30-day-roadmap.md
+++ b/docs/planning/12-30-day-roadmap.md
@@ -36,9 +36,9 @@ Jarvis sits beside existing standards:
   not MCP.
 - A2A standardizes agent-to-agent communication and delegation. Jarvis records
   A2A delegation inside a WorkSession, but Jarvis is not A2A.
-- AG-UI standardizes agent-to-frontend interaction. Jarvis feeds AG-UI
-  interfaces with WorkSession state, Requests, Reviews, and EvidenceManifest
-  data, but Jarvis is not a frontend protocol.
+- AG-UI standardizes agent-to-frontend interaction. Hosts may expose Jarvis
+  WorkSession records to AG-UI clients, but Jarvis does not define frontend
+  events, rendering, UI state, or UI transport.
 - Agent SDKs, coding agents, local agents, and hosted agent products provide
   runtimes, tools, sessions, handoffs, tracing, or execution environments.
   Compatible adapters map their work into collaboration records instead of
@@ -48,7 +48,7 @@ Protocol grounding:
 
 - MCP: https://modelcontextprotocol.io/specification/
 - A2A: https://a2a-protocol.org/latest/
-- AGNTCY ACP: https://github.com/agntcy/acp-spec
+- AGNTCY ACP: https://spec.acp.agntcy.org/
 - AG-UI: https://docs.ag-ui.com/
 - OpenAPI 3.1.1: https://spec.openapis.org/oas/v3.1.1.html
 - RFC 8785 JSON Canonicalization Scheme:

--- a/docs/planning/week-1/README.md
+++ b/docs/planning/week-1/README.md
@@ -292,16 +292,20 @@ Outputs:
 Done when:
 
 - OpenAPI contract authors have exact inputs
-- every mutating operation requires `Jarvis-Protocol-Version`,
+- every WorkSession-scoped mutating operation requires `Jarvis-Protocol-Version`,
   `Jarvis-Actor-Id`, `Jarvis-Idempotency-Key`, `Jarvis-Request-Timestamp`,
   `Jarvis-Expected-WorkSession-Revision`, and
   `Jarvis-Previous-Event-Hash`
+- Worker registration, Actor registration, and OutcomeReport submission use
+  the non-WorkSession mutation header set
 - Worker and Actor reference registration does not become identity ownership
 - OpenAPI 3.1 remains the default host-facing binding
 
 ### Chunk 6: Positioning And Adoption Lock
 
 Purpose: lock why Jarvis exists beside existing agents and protocols.
+
+Spec: [chunk-6-positioning-adoption-lock.md](./chunk-6-positioning-adoption-lock.md)
 
 Outputs:
 
@@ -318,8 +322,9 @@ Done when:
 - Jarvis is clearly not another agent
 - Jarvis is clearly not another runtime
 - existing agents remain first-class
-- adoption argument centers on policy, review, attribution, evidence, and
-  shared learning
+- adoption argument centers on policy, Requests, Reviews, Takeovers,
+  Contributions, Evidence, LearningRecords, MemoryProposals, and
+  SkillProposals
 
 ## Chunk Review Record
 

--- a/docs/planning/week-1/chunk-6-positioning-adoption-lock.md
+++ b/docs/planning/week-1/chunk-6-positioning-adoption-lock.md
@@ -1,0 +1,152 @@
+# Chunk 6: Positioning And Adoption Lock
+
+Chunk 6 closes Week 1 by locking why Jarvis exists beside existing agents,
+agent frameworks, agent protocols, and product hosts.
+
+This chunk does not create adapters, OpenAPI YAML, conformance fixtures,
+runtime code, product UI, or Garden POC behavior. It locks the adoption
+argument that Week 2 OpenAPI drafting must preserve.
+
+## Scope
+
+Chunk 6 locks:
+
+```txt
+one-paragraph Jarvis explanation
+positioning against MCP
+positioning against A2A
+positioning against AGNTCY ACP
+positioning against AG-UI
+positioning against agent SDKs
+positioning against coding agents
+positioning against personal agents
+existing-agent adoption rule
+non-replacement rule
+Week 1 closeout state
+```
+
+## Non-Goals
+
+Chunk 6 does not:
+
+- create an adapter
+- create OpenAPI YAML
+- create conformance fixtures
+- define runtime execution
+- define product UI
+- define Garden POC behavior
+- define task marketplace behavior
+- define auth provider behavior
+- replace MCP, A2A, ACP, AG-UI, agent SDKs, coding agents, or personal agents
+
+## Locked Position
+
+Jarvis is the human-agent collaboration and learning-loop protocol.
+
+Jarvis defines how HumanWorkers and AgentWorkers collaborate inside
+WorkSessions under policy, ask for help through Requests, capture human
+judgment through Reviews and Takeovers, record attributable Contributions,
+export portable EvidenceManifest records, and carry governed LearningRecords,
+MemoryProposals, and SkillProposals into future work.
+
+Jarvis does not run the agent. Jarvis records the collaboration.
+
+## One-Paragraph Explanation
+
+Jarvis is the protocol for governed human-agent collaboration and shared
+learning. It defines how a HumanWorker and an AgentWorker coordinate inside a
+WorkSession under shared goals and human-defined Policy, create Requests when
+the AgentWorker is blocked, record Reviews and Takeovers from human judgment,
+preserve attributable Contributions, export portable EvidenceManifest records,
+and carry governed LearningRecords, MemoryProposals, and SkillProposals into
+future WorkSessions.
+
+## Adjacent Protocol Positioning
+
+MCP standardizes how agent applications connect to tools, prompts, resources,
+and context servers. Jarvis records MCP use inside WorkSessions when MCP is
+used. Jarvis does not define MCP transports, MCP tools, MCP resources, or MCP
+server behavior.
+
+A2A standardizes communication and interoperability between independent agent
+systems. Jarvis records agent delegation or agent-to-agent coordination as
+WorkSession events, Contributions, and Evidence when A2A is used. Jarvis does
+not define A2A discovery, tasks, messages, artifacts, or protocol bindings.
+
+AGNTCY ACP defines a remote-agent interface with an OpenAPI contract. Jarvis
+uses the OpenAPI lesson for its own host-facing communication binding. Jarvis
+does not define remote-agent run execution, thread execution, output retrieval,
+or ACP agent interfaces.
+
+AG-UI standardizes how agents connect to user-facing applications through
+event-based frontend interaction. Hosts may expose Jarvis WorkSession state,
+Requests, Reviews, Takeovers, Contributions, and Evidence to AG-UI clients.
+Jarvis does not define frontend events, frontend rendering, user interface
+state, or UI transport.
+
+## Agent Product Positioning
+
+Agent SDKs provide execution primitives, model calls, tool calls, tracing,
+handoffs, and runtime behavior. Jarvis records the human-agent collaboration
+around that execution. Jarvis does not replace an SDK.
+
+Coding agents perform software work through terminals, editors, repositories,
+tools, sandboxes, and review loops. Jarvis records the WorkSession, Policy,
+Requests, Reviews, Takeovers, Contributions, Evidence, and Learning around that
+work. Jarvis does not replace the coding agent.
+
+Personal agents provide a product or assistant experience for a person. Jarvis
+defines the collaboration protocol that a personal agent may implement. Jarvis
+is not the personal agent product.
+
+## Adoption Rule
+
+Existing agents remain first-class.
+
+A compatible host or adapter maps existing agent work into Jarvis records
+without rewriting the agent runtime. The adapter records who acted, what Policy
+allowed, what was blocked, what the human reviewed, what evidence was captured,
+what contribution was made, and what learning was accepted.
+
+Adoption fails if the implementation requires a developer to abandon their
+agent, runtime, product UI, model provider, sandbox, database, or cloud.
+
+Adoption succeeds when different agents and products produce the same
+WorkSession, Request, Review, Takeover, Contribution, EvidenceManifest,
+LearningRecord, MemoryProposal, and SkillProposal semantics.
+
+## Why Jarvis Exists
+
+Existing systems answer different questions:
+
+```txt
+MCP answers: how does an agent use tools and resources?
+A2A answers: how do agents communicate and delegate?
+ACP answers: how does a remote agent expose a standard interface?
+AG-UI answers: how does an agent interact with a frontend?
+Agent SDKs answer: how does an agent execute?
+Coding agents answer: how does an agent work inside a codebase?
+Personal agents answer: how does a person experience an assistant?
+Jarvis answers: how do a human and an agent collaborate, produce evidence,
+record contribution, and learn together across WorkSessions?
+```
+
+That is the adoption point.
+
+## Done Criteria
+
+Chunk 6 is complete when:
+
+- [16-positioning-adoption-lock.md](../../protocol/16-positioning-adoption-lock.md)
+  locks the positioning argument
+- [14-protocol-lock.md](../../protocol/14-protocol-lock.md) no longer carries
+  stale Week 1 lock status
+- [week-1/README.md](./README.md) uses the final Week 1 header and positioning
+  wording
+- README and docs index point to the positioning lock
+- local checks pass
+- at least four reviewer lanes pass, including the Protocol Thesis Reviewer and
+  Conformance And Interop Reviewer
+- valid findings are integrated
+- rejected findings are recorded with concrete reasons
+- PR is opened

--- a/docs/protocol/06-integration-boundaries.md
+++ b/docs/protocol/06-integration-boundaries.md
@@ -78,19 +78,23 @@ inputs into a Jarvis-compatible WorkSession.
 
 ## Adjacent Protocol Boundary
 
-MCP, A2A, and AG-UI are external protocols.
+MCP, A2A, ACP, and AG-UI are external protocols.
 
 ```txt
-MCP     agent/app <-> tools, prompts, resources, and context servers
-A2A     agent     <-> agent communication and delegation
-AG-UI   frontend  <-> agent state, UI events, and user interaction
-Jarvis  human     <-> agent collaboration, policy, evidence, and learning
+MCP     agent/app     <-> tools, prompts, resources, and context servers
+A2A     agent         <-> agent communication and delegation
+ACP     remote agent  <-> standard remote-agent interface
+AG-UI   frontend      <-> agent state, UI events, and user interaction
+Jarvis  human+agent   <-> collaboration, policy, evidence, and learning
 ```
 
 Jarvis records policy, attribution, evidence, review, takeover, contribution,
 and learning around the use of external protocols. Jarvis does not define their
 transport, runtime, tool semantics, UI semantics, or agent-to-agent
 coordination semantics.
+
+The locked positioning rules are defined in
+[16-positioning-adoption-lock.md](./16-positioning-adoption-lock.md).
 
 ## Post-Session Outcome Boundary
 

--- a/docs/protocol/14-protocol-lock.md
+++ b/docs/protocol/14-protocol-lock.md
@@ -24,14 +24,18 @@ Locked now:
 - core states
 - conformance expectations
 - portable export shape
-
-Not locked yet:
-
-- exact OpenAPI component syntax
 - version negotiation
 - capability negotiation
-- extension format
-- error codes
+- extension namespace rules
+- protocol error ids
+- OpenAPI security entry requirements
+- positioning and adoption boundary
+
+Week 2 drafts:
+
+- exact OpenAPI component syntax
+- exact OpenAPI path syntax
+- OpenAPI examples
 - conformance fixtures
 
 ## Definition
@@ -75,6 +79,8 @@ Jarvis owns:
 - contribution semantics
 - evidence export semantics
 - governed learning semantics
+- OpenAPI communication binding requirements
+- positioning against adjacent protocols and agent products
 - conformance expectations
 
 Jarvis does not own:
@@ -516,13 +522,17 @@ protocol fields.
 
 OpenAPI contract work starts with:
 
-1. version negotiation
-2. capability negotiation
-3. extension namespace format
-4. standard error codes
-5. required and optional fields per object
-6. OpenAPI 3.1 component and path layout
-7. canonical WorkSession export example
-8. passing and failing conformance fixtures
+1. OpenAPI 3.1 component syntax.
+2. OpenAPI 3.1 path syntax.
+3. security scheme encoding from
+   [15-openapi-communication-binding.md](./15-openapi-communication-binding.md).
+4. required and optional fields per object.
+5. canonical WorkSession export example.
+6. passing and failing conformance fixtures.
+7. examples for WorkSession, Request, Review, Takeover, Contribution,
+   EvidenceManifest, LearningRecord, MemoryProposal, SkillProposal, and
+   OutcomeReport.
 
-The thesis is locked. The object model is locked. The lifecycle is locked.
+The thesis is locked. The object model is locked. The lifecycle is locked. The
+control plane is locked. Evidence and learning are locked. OpenAPI security
+entry is locked. Positioning is locked.

--- a/docs/protocol/15-openapi-communication-binding.md
+++ b/docs/protocol/15-openapi-communication-binding.md
@@ -59,9 +59,9 @@ that property for adoption.
 Primary references:
 
 - OpenAPI 3.1.1: https://spec.openapis.org/oas/v3.1.1.html
-- MCP transports: https://modelcontextprotocol.io/specification/2025-06-18/basic/transports
-- A2A specification: https://github.com/a2aproject/A2A/blob/main/docs/specification.md
-- AGNTCY ACP specification: https://github.com/agntcy/acp-spec
+- MCP transports: https://modelcontextprotocol.io/specification/2025-11-25/basic/transports
+- A2A specification: https://a2a-protocol.org/latest/specification/
+- AGNTCY ACP specification: https://spec.acp.agntcy.org/
 
 ## OpenAPI Contract Shape
 

--- a/docs/protocol/16-positioning-adoption-lock.md
+++ b/docs/protocol/16-positioning-adoption-lock.md
@@ -1,0 +1,163 @@
+# Positioning And Adoption Lock
+
+Jarvis is the human-agent collaboration and learning-loop protocol.
+
+Jarvis does not compete with agent runtimes, tool protocols, UI protocols,
+agent-to-agent protocols, coding agents, personal agents, or product hosts.
+Jarvis defines the protocol record that makes human-agent work reviewable,
+attributable, portable, and able to improve across WorkSessions.
+
+## One-Paragraph Definition
+
+Jarvis is the protocol for governed human-agent collaboration and shared
+learning. It defines how a HumanWorker and an AgentWorker coordinate inside a
+WorkSession under shared goals and human-defined Policy, create Requests when
+the AgentWorker is blocked, record Reviews and Takeovers from human judgment,
+preserve attributable Contributions, export portable EvidenceManifest records,
+and carry governed LearningRecords, MemoryProposals, and SkillProposals into
+future WorkSessions.
+
+## The Category
+
+Jarvis is not an agent protocol in the narrow sense.
+
+Jarvis is the human-agent collaboration protocol.
+
+The primitive is:
+
+```txt
+HumanWorker + AgentWorker + WorkSession + Policy + Evidence + Learning
+```
+
+The primitive is not:
+
+```txt
+User -> Assistant -> Answer
+```
+
+Jarvis exists because useful work requires more than agent execution. Useful
+work needs human judgment, policy, review, takeover, attribution, evidence, and
+learning that survives the current task.
+
+## Adjacent Protocols
+
+MCP standardizes how LLM applications connect to tools, prompts, resources, and
+context servers. MCP uses JSON-RPC messages over transports such as Streamable
+HTTP, where clients send JSON-RPC messages to an MCP endpoint and servers may
+use SSE for streaming. Jarvis records tool and resource use as WorkSession
+events, PolicyDecisions, Contributions, and Evidence when MCP is used. Jarvis
+does not define MCP transports, MCP tools, MCP resources, MCP prompts, or MCP
+server behavior.
+
+A2A standardizes communication and interoperability between independent agent
+systems. A2A separates data model, abstract operations, and protocol bindings,
+including JSON-RPC, gRPC, and HTTP+JSON/REST. Jarvis records agent delegation
+or agent-to-agent coordination as WorkSession events, Contributions, and
+Evidence when A2A is used. Jarvis does not define A2A discovery, tasks,
+messages, artifacts, agent cards, or A2A protocol bindings.
+
+AGNTCY ACP defines a standard remote-agent interface and publishes an OpenAPI
+contract. Jarvis uses the same discipline of a discoverable host-facing
+contract. Jarvis does not define remote-agent execution, thread execution,
+interrupt delivery, output retrieval, or ACP agent interfaces.
+
+AG-UI standardizes how AI agents connect to user-facing applications through an
+open, lightweight, event-based protocol. AG-UI focuses on agent state, UI
+intents, user interactions, frontend tools, streaming, and interactive
+frontends. A Jarvis-compatible host or adapter may expose WorkSession state,
+Requests, Reviews, Takeovers, Contributions, Evidence, and Learning to AG-UI
+clients. Jarvis does not define frontend events, rendering, UI state, or
+user-interface transport.
+
+## Agent And Product Positioning
+
+Agent SDKs provide execution primitives, model calls, tool calls, tracing,
+handoffs, and runtime behavior. Jarvis records the human-agent collaboration
+around that execution. Jarvis does not replace an SDK.
+
+Coding agents perform software work through terminals, editors, repositories,
+tools, sandboxes, and review loops. Jarvis records the WorkSession, Policy,
+Requests, Reviews, Takeovers, Contributions, Evidence, and Learning around that
+work. Jarvis does not replace the coding agent.
+
+Personal agents provide a product or assistant experience for a person. Jarvis
+defines the collaboration protocol that a personal agent may implement. Jarvis
+is not the personal agent product.
+
+Product hosts provide UI, auth, storage, execution, connectors, notifications,
+cost tracking, support, and deployment. Jarvis defines the records that product
+hosts exchange. Jarvis does not become the product host.
+
+## Non-Replacement Rule
+
+Compatible implementations MUST NOT require developers to abandon their
+existing agent, runtime, SDK, product UI, model provider, sandbox, database, or
+cloud.
+
+Compatible implementations map existing work into Jarvis records:
+
+```txt
+human operator -> HumanWorker + Actor
+existing agent process or product -> AgentWorker + Actor
+agent action -> PolicyDecision + JarvisEvent
+blocked action -> Request
+human judgment -> Review or Takeover
+work performed -> Contribution
+trace/artifact/source/output -> EvidenceManifest evidence_item_refs
+confirmed improvement -> LearningRecord
+memory update proposal -> MemoryProposal
+reusable process proposal -> SkillProposal
+```
+
+The adapter may be thin. The protocol record must be complete.
+
+## Adoption Argument
+
+Jarvis adoption centers on:
+
+```txt
+policy
+requests
+reviews and takeovers
+contribution attribution
+evidence
+governed learning
+memory and skill proposals
+```
+
+Jarvis is worth adopting when a team needs to answer:
+
+```txt
+What work happened?
+Who acted?
+What did policy allow?
+Where did the agent ask for help?
+What did the human review or take over?
+What evidence proves the work?
+What contribution belongs to the human, agent, pair, or service?
+What learning carries into the next WorkSession?
+What memory or skill change was proposed, reviewed, accepted, rejected, or
+carried forward?
+```
+
+Those questions are not answered by a tool protocol, UI protocol, agent SDK,
+coding agent, personal agent, or runtime alone.
+
+## Compatibility Rule
+
+Existing agents remain first-class.
+
+Jarvis-compatible hosts and adapters MUST preserve the existing agent's
+execution model while recording Jarvis protocol semantics around it. If an
+agent already plans, calls tools, writes code, researches, drafts, or executes
+tasks, Jarvis does not change that execution. Jarvis records the collaboration
+loop that makes the work governed, reviewable, attributable, evidence-backed,
+and able to improve.
+
+## Source References
+
+- MCP specification: https://modelcontextprotocol.io/specification/
+- A2A specification: https://a2a-protocol.org/latest/specification/
+- AGNTCY ACP specification: https://spec.acp.agntcy.org/
+- AG-UI documentation: https://docs.ag-ui.com/
+- OpenAPI 3.1.1: https://spec.openapis.org/oas/v3.1.1.html

--- a/docs/reviews/13-protocol-readiness-review.md
+++ b/docs/reviews/13-protocol-readiness-review.md
@@ -38,7 +38,7 @@ References:
 - OpenAPI Specification: https://spec.openapis.org/oas/latest.html
 - MCP: https://modelcontextprotocol.io/specification/
 - A2A: https://a2a-protocol.org/latest/
-- AGNTCY ACP: https://github.com/agntcy/acp-spec
+- AGNTCY ACP: https://spec.acp.agntcy.org/
 - AG-UI: https://docs.ag-ui.com/
 
 ## Protocol Disciplines
@@ -113,28 +113,35 @@ The docs now lock these points before OpenAPI contract work starts:
 - roadmap wording stays independent from downstream products.
 - core object spec uses protocol-style normative language.
 
-## OpenAPI Entry Gaps
+## Week 1 Closeout State
 
-OpenAPI work starts by closing these protocol gaps:
+Week 1 has locked the OpenAPI entry decisions needed before contract drafting:
 
-1. Version negotiation: define `protocol_version`, supported versions, and
-   compatibility behavior.
-2. Capability negotiation: define how a host declares supported Jarvis features.
-3. Extension model: define namespaced extension fields that preserve
-   portability.
-4. Error model: define protocol error codes for invalid transitions, missing
-   review, stale takeover epoch, invalid export, and unsupported capability.
-5. OpenAPI examples: create one complete WorkSession export.
-6. Conformance fixtures: create passing and failing examples.
-7. Security model: define required headers, authentication boundary,
-   idempotency, actor authorization, event hash validation, and forbidden
-   export fields.
+1. Version negotiation uses `Jarvis-Protocol-Version`.
+2. Capability negotiation uses `Jarvis-Host-Capabilities` and
+   `Jarvis-Required-Capabilities`.
+3. Extensions are namespaced and cannot override core fields.
+4. Protocol errors use structured error ids and a required error envelope.
+5. WorkSession-scoped mutations require protocol version, Actor id,
+   idempotency key, timestamp, expected WorkSession revision, and previous
+   event hash.
+6. Worker registration, Actor registration, and OutcomeReport submission use
+   the non-WorkSession mutation header set.
+7. WorkSession-scoped and export reads require protocol version, caller
+   authentication, and Actor authority.
+8. Portable exports and error responses exclude forbidden host-private fields.
+9. Positioning is locked: Jarvis integrates with MCP, A2A, ACP, AG-UI, agent
+   SDKs, coding agents, personal agents, and product hosts without replacing
+   them.
+
+Week 2 starts from these locked decisions and drafts OpenAPI component syntax,
+path syntax, examples, and conformance fixtures.
 
 ## Readiness State
 
-The protocol thesis is stable. The boundaries are stable. The object set is
-stable enough to begin OpenAPI and examples.
+The protocol thesis is stable. The boundaries are stable. The object set,
+lifecycle, control plane, evidence model, learning model, OpenAPI security
+entry, and positioning boundary are stable enough to begin Week 2 OpenAPI
+drafting.
 
-Week 1 starts with the machine-readable OpenAPI contract, versioning,
-zero-trust security model, and conformance entry rules. Product proof waits
-behind that work.
+Product proof waits behind the OpenAPI contract and conformance entry rules.


### PR DESCRIPTION
## Summary
- add Chunk 6 positioning/adoption lock for MCP, A2A, ACP, AG-UI, agent SDKs, coding agents, personal agents, and product hosts
- add protocol positioning lock doc that keeps existing agents first-class and defines Jarvis as the human-agent collaboration and learning-loop protocol
- clean stale Week 1 status wording so Week 2 starts from locked version/capability/extension/error/security decisions
- update docs index, roadmap references, readiness review, and integration boundaries

## Reviewer Lanes
- Protocol Thesis Reviewer: completed; integrated AG-UI host/adaptor wording so Jarvis does not read as a frontend provider
- Zero-Trust Security Reviewer: completed; no findings
- Conformance And Interop Reviewer: completed; integrated HumanWorker/AgentWorker mapping and EvidenceManifest evidence_item_refs wording
- Human Workflow Reviewer: completed; integrated Requests, Takeovers, MemoryProposal, and SkillProposal into adoption wording
- Chief Engineer Reviewer: attempted twice; both timed out and were closed. Local consistency scans and deterministic checks passed.

## Findings Integrated
- replaced Jarvis-feeds-AG-UI wording with host/adaptor exposure wording
- expanded adoption success to include MemoryProposal and SkillProposal semantics
- expanded adoption center from generic review/evidence/learning to the full Request, Review, Takeover, Contribution, Evidence, LearningRecord, MemoryProposal, and SkillProposal loop
- added HumanWorker/Actor and AgentWorker/Actor mapping before adapter action mapping
- changed collected proof mapping to EvidenceManifest evidence_item_refs
- removed stale Week 1 not-locked/gap wording

## Checks
- git diff --check
- python3 scripts/check_markdown_links.py
- python3 scripts/check_week1_wording.py
- python3 -m py_compile scripts/check_markdown_links.py scripts/check_week1_wording.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded protocol documentation index with new entries on contribution evidence learning and positioning adoption lock.
  * Clarified Jarvis positioning relative to adjacent protocols (MCP, A2A, ACP, AG-UI).
  * Enhanced Week 1 planning documentation with explicit requirements for OpenAPI security headers and operation scoping.
  * Added comprehensive positioning and adoption lock documentation defining Jarvis scope and interoperability boundaries.
  * Updated external protocol specification references to canonical spec sites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->