### PR TITLE
Mark Week 1 complete and Week 2 active

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,24 +192,28 @@ state, host-only database ids, and deployment details.
 
 ## Current Execution Focus
 
-The current focus is Week 1 protocol lock.
+Week 1 protocol lock is complete.
+
+The current focus is Week 2 OpenAPI contract and conformance entry.
 
 Work on:
 
-- core object meanings
-- required fields
-- lifecycle states
-- PolicyDecision semantics
-- Request, Review, and Takeover lifecycle
-- EvidenceManifest minimum export shape
-- LearningRecord, MemoryProposal, and SkillProposal review states
-- OutcomeReport semantics
-- protocol positioning against MCP, A2A, ACP, AG-UI, and agent SDKs
-- zero-trust OpenAPI headers, security schemes, and forbidden export fields
+- OpenAPI 3.1 document skeleton
+- `components.schemas` for core protocol objects
+- path layout for core protocol operations
+- event envelope component
+- portable export component
+- security schemes and required protocol headers
+- protocol error model
+- golden-path conformance checklist
+- failure-mode conformance checklist
+- first OpenAPI examples for WorkSession, Request, Review, and export
 
 Do not start Garden POC work in this phase.
 Do not build runtime features in this repo.
 Do not add product-specific assumptions to protocol records.
+Do not reopen Week 1 locked protocol decisions unless a concrete contradiction
+blocks OpenAPI drafting.
 
 ## Wording Rules
 

--- a/docs/planning/12-30-day-roadmap.md
+++ b/docs/planning/12-30-day-roadmap.md
@@ -75,6 +75,8 @@ conformance entry rules are stable.
 
 ## Week 1: Protocol Lock And Research Grounding
 
+Status: complete.
+
 Goal: freeze the core protocol vocabulary, communication strategy, and security
 boundary.
 
@@ -101,11 +103,13 @@ Done when:
   agent application
 - every core object has a reason to exist
 - OpenAPI 3.1 is the machine-readable communication contract
-- Garden POC is not part of this week's active work
+- Garden POC was not part of Week 1 active work
 - Jarvis is explained in one paragraph without mentioning any host product
   or downstream evaluation system
 
 ## Week 2: OpenAPI Contract And Conformance Entry
+
+Status: active.
 
 Goal: produce the first OpenAPI 3.1 contract shape and conformance entry rules.
 

--- a/docs/planning/ROADMAP.md
+++ b/docs/planning/ROADMAP.md
@@ -13,6 +13,16 @@ For the immediate execution plan, see
 For the OpenAPI entry gate, see
 [14-protocol-lock.md](../protocol/14-protocol-lock.md).
 
+## Current Status
+
+Week 1 protocol lock is complete.
+
+Current active work: Week 2 OpenAPI contract and conformance entry.
+
+Week 2 drafts the OpenAPI 3.1 component syntax, path syntax, security scheme
+encoding, protocol examples, and conformance entry rules from the locked Week 1
+protocol decisions.
+
 ## Roadmap Contract
 
 Jarvis owns:
@@ -144,6 +154,8 @@ MemoryProposal and SkillProposal remain governed
 
 ## Milestone 0: Protocol Lock
 
+Status: complete.
+
 Owner: Architecture
 
 Output:
@@ -161,6 +173,8 @@ Done when:
   ownership to Jarvis.
 
 ## Milestone 1: OpenAPI Contract
+
+Status: active.
 
 Owner: Protocol
 


### PR DESCRIPTION
## Summary
- update AGENTS.md current execution focus from Week 1 protocol lock to Week 2 OpenAPI contract and conformance entry
- mark Week 1 complete and Week 2 active in the 30-day roadmap
- add current status to ROADMAP.md and mark Milestone 0 complete / Milestone 1 active

## Validation
- git diff --check
- python3 scripts/check_markdown_links.py
- python3 scripts/check_week1_wording.py
- python3 -m py_compile scripts/check_markdown_links.py scripts/check_week1_wording.py
- focused stale Week 1 active wording scan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated planning roadmap to reflect Week 1 protocol lock completion and current Week 2 focus on OpenAPI 3.1 contract drafting and conformance work.
  * Clarified project scope constraints and phase boundaries in planning documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->