### PR TITLE
Add Week 2 OpenAPI skeleton

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,8 +32,16 @@ Planning docs and sheets track execution.
 - [ROADMAP.md](./planning/ROADMAP.md)
 - [12-30-day-roadmap.md](./planning/12-30-day-roadmap.md)
 - [week-1/README.md](./planning/week-1/README.md)
+- [week-2/README.md](./planning/week-2/README.md)
 - [sheets/jarvis_roadmap.csv](./planning/sheets/jarvis_roadmap.csv)
 - [sheets/jarvis_roadmap.xlsx](./planning/sheets/jarvis_roadmap.xlsx)
+
+## OpenAPI
+
+The OpenAPI directory contains the v0.1 machine-readable communication binding.
+
+- [openapi/README.md](./openapi/README.md)
+- [openapi/jarvis-openapi.yaml](./openapi/jarvis-openapi.yaml)
 
 ## Architecture Brief
 

--- a/docs/openapi/README.md
+++ b/docs/openapi/README.md
@@ -1,0 +1,48 @@
+# Jarvis OpenAPI Contract
+
+This directory contains the machine-readable OpenAPI 3.1 communication binding
+for Jarvis v0.1.
+
+Jarvis is the human-agent collaboration and learning-loop protocol. OpenAPI
+defines how compatible hosts exchange Jarvis protocol records. OpenAPI does not
+make Jarvis a runtime, product, auth system, database, cloud stack, tool
+protocol, frontend protocol, or agent framework.
+
+## Files
+
+- [jarvis-openapi.yaml](./jarvis-openapi.yaml) - v0.1 OpenAPI entry point.
+
+## Chunk 1 Lock
+
+Chunk 1 locks the OpenAPI document skeleton:
+
+```txt
+openapi
+jsonSchemaDialect
+info
+servers
+security
+tags
+paths
+components.schemas
+components.parameters
+components.headers
+components.requestBodies
+components.responses
+components.securitySchemes
+components.examples
+x-jarvis-protocol
+```
+
+Chunk 1 defines the global HostAuth baseline. Later chunks define
+operation-specific Jarvis header requirements from the locked protocol docs.
+
+Chunk 1 does not define component field schemas, path operation bodies,
+operation-specific security requirements, examples, or conformance fixtures.
+Later chunks define those sections from the locked protocol docs.
+
+## Boundary
+
+Compatible hosts publish their own server URLs, identity providers, credential
+handling, storage, execution, deployment, billing, and UI. Jarvis defines
+protocol records and conformance requirements only.

--- a/docs/openapi/jarvis-openapi.yaml
+++ b/docs/openapi/jarvis-openapi.yaml
@@ -1,0 +1,94 @@
+openapi: 3.1.1
+jsonSchemaDialect: https://json-schema.org/draft/2020-12/schema
+info:
+  title: Jarvis Human-Agent Collaboration Protocol
+  summary: Human-agent collaboration and learning-loop protocol.
+  description: |
+    Jarvis defines the protocol records and operations for governed
+    collaboration between HumanWorkers and AgentWorkers.
+
+    Jarvis does not define runtime execution, product UI, authentication
+    provider, storage, model calls, sandbox behavior, cloud deployment, billing,
+    task routing, or marketplace logic.
+  version: 0.1.0
+servers:
+  - url: https://jarvis.example.invalid
+    description: OpenAPI placeholder only. Jarvis does not operate this server; compatible hosts publish their own URLs.
+security:
+  - HostAuth: []
+tags:
+  - name: Workers
+    description: Worker and Actor protocol reference operations.
+  - name: WorkSessions
+    description: WorkSession lifecycle and event operations.
+  - name: ControlPlane
+    description: PolicyDecision, Request, Review, and Takeover operations.
+  - name: Attribution
+    description: Contribution operations.
+  - name: Learning
+    description: LearningRecord, MemoryProposal, and SkillProposal operations.
+  - name: Evidence
+    description: EvidenceManifest export operations.
+  - name: Feedback
+    description: OutcomeReport operations.
+  - name: Conformance
+    description: Compatibility and conformance entry operations.
+paths: {}
+components:
+  schemas: {}
+  parameters: {}
+  headers: {}
+  requestBodies: {}
+  responses: {}
+  securitySchemes:
+    HostAuth:
+      type: http
+      scheme: bearer
+      description: Host-owned caller authentication. Jarvis requires caller authentication for protocol operations and does not issue credentials.
+  examples: {}
+x-jarvis-protocol:
+  version: v0.1
+  layer: OpenAPI 3.1 communication binding
+  source_of_truth:
+    - docs/protocol/14-protocol-lock.md
+    - docs/protocol/15-openapi-communication-binding.md
+    - docs/protocol/11-core-protocol-objects.md
+    - docs/protocol/12-request-protocol.md
+    - docs/protocol/13-contribution-evidence-learning.md
+    - docs/reviews/acceptance-criteria.md
+  owns:
+    - protocol objects
+    - protocol operations
+    - protocol headers
+    - protocol error envelope
+    - portable export boundary
+    - conformance entry
+  outside_jarvis:
+    - runtime execution
+    - product UI
+    - authentication provider
+    - authorization backend
+    - database
+    - queues
+    - cloud provider
+    - sandbox implementation
+    - model provider
+    - tool execution
+    - billing
+    - deployment
+    - task marketplace
+    - product workflow
+  chunk_lock:
+    id: week-2-chunk-1-openapi-skeleton
+    locks:
+      - OpenAPI 3.1.1 entry point
+      - v0.1 protocol metadata
+      - required top-level buckets
+      - tag taxonomy
+      - host-owned server boundary
+    excludes:
+      - component field schemas
+      - path operation bodies
+      - operation-specific security requirements
+      - examples
+      - conformance fixtures

--- a/docs/planning/week-2/README.md
+++ b/docs/planning/week-2/README.md
@@ -1,0 +1,29 @@
+# Week 2: OpenAPI Contract And Conformance Entry
+
+Week 2 turns the locked protocol into the first OpenAPI 3.1 contract shape and
+conformance entry.
+
+This week does not build Garden POC, runtime features, product UI, auth,
+storage, model calls, adapters, or conformance fixtures beyond the active chunk.
+
+## Chunks
+
+1. [chunk-1-openapi-skeleton.md](./chunk-1-openapi-skeleton.md)  
+   Lock the OpenAPI entry point, required buckets, tag taxonomy, and skeleton
+   validation.
+
+## Week 2 Done State
+
+Week 2 is complete when the OpenAPI contract answers:
+
+```txt
+how a host creates a WorkSession
+how a host appends JarvisEvent records
+how AgentWorker actions record PolicyDecision
+how blocked action creates Request
+how HumanWorker response records Review or Takeover
+how Contribution and EvidenceManifest records are exported
+how OutcomeReport feeds post-session learning
+```
+
+The contract remains protocol-only. Hosts own implementation.

--- a/docs/planning/week-2/chunk-1-openapi-skeleton.md
+++ b/docs/planning/week-2/chunk-1-openapi-skeleton.md
@@ -1,0 +1,55 @@
+# Week 2 Chunk 1: OpenAPI Skeleton
+
+## Goal
+
+Create the v0.1 OpenAPI 3.1 entry point without reopening protocol semantics.
+
+## Scope
+
+This chunk locks:
+
+- OpenAPI 3.1.1 document entry
+- v0.1 protocol metadata
+- top-level OpenAPI buckets
+- tag taxonomy
+- global HostAuth baseline
+- source document references
+- host-owned server boundary
+- skeleton validation script
+
+This chunk does not define:
+
+- component field schemas
+- path operation request bodies
+- path operation response bodies
+- operation-specific security requirements
+- examples
+- conformance fixtures
+- adapter behavior
+- Garden POC behavior
+- runtime execution
+
+## Files
+
+- [../../openapi/jarvis-openapi.yaml](../../openapi/jarvis-openapi.yaml)
+- [../../openapi/README.md](../../openapi/README.md)
+- [../../../scripts/check_openapi_skeleton.py](../../../scripts/check_openapi_skeleton.py)
+
+## Acceptance
+
+Chunk 1 is complete when:
+
+- the OpenAPI file parses as YAML
+- `openapi` is `3.1.1`
+- `info.version` is `0.1.0`
+- `x-jarvis-protocol.version` is `v0.1`
+- required OpenAPI buckets exist
+- required tags exist
+- global security requires `HostAuth`
+- `HostAuth` is defined without making Jarvis an identity provider
+- the document states that hosts own server URLs and implementation details
+- local validation passes
+
+## Boundary
+
+Jarvis owns the OpenAPI communication binding. Hosts own implementation.

--- a/scripts/check_openapi_skeleton.py
+++ b/scripts/check_openapi_skeleton.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Validate the Jarvis v0.1 OpenAPI skeleton."""
+
+from pathlib import Path
+import sys
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+OPENAPI_PATH = ROOT / "docs" / "openapi" / "jarvis-openapi.yaml"
+
+REQUIRED_TOP_LEVEL = {
+    "openapi",
+    "jsonSchemaDialect",
+    "info",
+    "servers",
+    "security",
+    "tags",
+    "paths",
+    "components",
+    "x-jarvis-protocol",
+}
+
+REQUIRED_COMPONENTS = {
+    "schemas",
+    "parameters",
+    "headers",
+    "requestBodies",
+    "responses",
+    "securitySchemes",
+    "examples",
+}
+
+REQUIRED_PROTOCOL_METADATA = {
+    "version",
+    "layer",
+    "source_of_truth",
+    "owns",
+    "outside_jarvis",
+    "chunk_lock",
+}
+
+REQUIRED_TAGS = {
+    "Workers",
+    "WorkSessions",
+    "ControlPlane",
+    "Attribution",
+    "Learning",
+    "Evidence",
+    "Feedback",
+    "Conformance",
+}
+
+EXPECTED_TITLE = "Jarvis Human-Agent Collaboration Protocol"
+EXPECTED_PLACEHOLDER_SERVER = "https://jarvis.example.invalid"
+EXPECTED_CHUNK_ID = "week-2-chunk-1-openapi-skeleton"
+
+
+def fail(message: str) -> int:
+    print(f"openapi skeleton check failed: {message}")
+    return 1
+
+
+def main() -> int:
+    if not OPENAPI_PATH.exists():
+        return fail(f"missing {OPENAPI_PATH.relative_to(ROOT)}")
+
+    data = yaml.safe_load(OPENAPI_PATH.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        return fail("root document is not an object")
+
+    missing = REQUIRED_TOP_LEVEL - set(data)
+    if missing:
+        return fail(f"missing top-level keys: {', '.join(sorted(missing))}")
+
+    if data["openapi"] != "3.1.1":
+        return fail("openapi must be 3.1.1")
+
+    info = data["info"]
+    if not isinstance(info, dict):
+        return fail("info must be an object")
+    if info.get("version") != "0.1.0":
+        return fail("info.version must be 0.1.0")
+    if info.get("title") != EXPECTED_TITLE:
+        return fail(f"info.title must be {EXPECTED_TITLE!r}")
+
+    protocol = data["x-jarvis-protocol"]
+    if not isinstance(protocol, dict):
+        return fail("x-jarvis-protocol must be an object")
+    if protocol.get("version") != "v0.1":
+        return fail("x-jarvis-protocol.version must be v0.1")
+    missing_protocol = REQUIRED_PROTOCOL_METADATA - set(protocol)
+    if missing_protocol:
+        return fail(
+            "missing x-jarvis-protocol keys: "
+            + ", ".join(sorted(missing_protocol))
+        )
+
+    chunk_lock = protocol["chunk_lock"]
+    if not isinstance(chunk_lock, dict):
+        return fail("x-jarvis-protocol.chunk_lock must be an object")
+    if chunk_lock.get("id") != EXPECTED_CHUNK_ID:
+        return fail(f"x-jarvis-protocol.chunk_lock.id must be {EXPECTED_CHUNK_ID}")
+
+    components = data["components"]
+    if not isinstance(components, dict):
+        return fail("components must be an object")
+    missing_components = REQUIRED_COMPONENTS - set(components)
+    if missing_components:
+        return fail(
+            "missing component buckets: " + ", ".join(sorted(missing_components))
+        )
+    for bucket in REQUIRED_COMPONENTS:
+        if not isinstance(components[bucket], dict):
+            return fail(f"components.{bucket} must be an object")
+
+    security_schemes = components["securitySchemes"]
+    host_auth = security_schemes.get("HostAuth")
+    if not isinstance(host_auth, dict):
+        return fail("components.securitySchemes.HostAuth is required")
+    if host_auth.get("type") != "http" or host_auth.get("scheme") != "bearer":
+        return fail("HostAuth must be an HTTP bearer security scheme")
+
+    security = data.get("security")
+    if security == []:
+        return fail("root security must not be an empty no-auth array")
+    if security != [{"HostAuth": []}]:
+        return fail("root security must require HostAuth")
+
+    tags = data["tags"]
+    if not isinstance(tags, list):
+        return fail("tags must be a list")
+    tag_names = {tag.get("name") for tag in tags if isinstance(tag, dict)}
+    missing_tags = REQUIRED_TAGS - tag_names
+    if missing_tags:
+        return fail(f"missing tags: {', '.join(sorted(missing_tags))}")
+
+    if not isinstance(data["paths"], dict):
+        return fail("paths must be an object")
+
+    servers = data.get("servers")
+    if not servers:
+        return fail("servers must state the host-owned server boundary")
+    if not isinstance(servers, list) or not isinstance(servers[0], dict):
+        return fail("servers must be a list of server objects")
+    if servers[0].get("url") != EXPECTED_PLACEHOLDER_SERVER:
+        return fail("server URL must be the Jarvis placeholder URL")
+    description = servers[0].get("description", "")
+    if "Jarvis does not operate this server" not in description:
+        return fail("server description must state that Jarvis does not operate it")
+
+    print("openapi skeleton ok")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add the Jarvis v0.1 OpenAPI 3.1.1 skeleton at docs/openapi/jarvis-openapi.yaml
- add OpenAPI docs and Week 2 chunk 1 planning docs
- add a skeleton validator for top-level sections, HostAuth baseline, protocol metadata, tags, component buckets, and server boundary
- link the new OpenAPI and Week 2 docs from docs/README.md

## Scope
This chunk locks the OpenAPI entry point only. It does not define component field schemas, path operation bodies, operation-specific security requirements, examples, conformance fixtures, adapters, Garden POC behavior, or runtime execution.

## Review lanes
- protocol boundary: passed
- OpenAPI structure: passed
- zero-trust/conformance: passed
- wording/directness: passed

## Validation
- python3 scripts/check_openapi_skeleton.py
- python3 scripts/check_markdown_links.py
- python3 scripts/check_week1_wording.py
- git diff --check
- python3 -m py_compile scripts/check_markdown_links.py scripts/check_week1_wording.py scripts/check_openapi_skeleton.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added OpenAPI 3.1.1 protocol specification skeleton for the Jarvis Human-Agent Collaboration Protocol.
  * Added Week 2 planning documentation outlining protocol contract scope and key requirements.
  * Updated main documentation index with planning and OpenAPI section links.

* **Chores**
  * Added OpenAPI skeleton validation script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->