### PR TITLE
Add participant OpenAPI schemas

### DIFF
--- a/docs/openapi/README.md
+++ b/docs/openapi/README.md
@@ -12,7 +12,7 @@ protocol, frontend protocol, or agent framework.
 
 - [jarvis-openapi.yaml](./jarvis-openapi.yaml) - v0.1 OpenAPI entry point.
 
-## Chunk 1 Lock
+## Chunk Locks
 
 Chunk 1 locks the OpenAPI document skeleton:
 
@@ -37,9 +37,19 @@ x-jarvis-protocol
 Chunk 1 defines the global HostAuth baseline. Later chunks define
 operation-specific Jarvis header requirements from the locked protocol docs.
 
-Chunk 1 does not define component field schemas, path operation bodies,
-operation-specific security requirements, examples, or conformance fixtures.
-Later chunks define those sections from the locked protocol docs.
+Chunk 2 defines shared schema primitives and the participant schemas:
+
+```txt
+Worker
+Actor
+HumanWorker
+AgentWorker
+```
+
+Chunk 2 does not define path operation bodies, operation-specific security
+requirements, WorkSession schema, control-plane schemas, evidence and learning
+schemas, examples, or conformance fixtures. Later chunks define those sections
+from the locked protocol docs.
 
 ## Boundary
 

--- a/docs/openapi/jarvis-openapi.yaml
+++ b/docs/openapi/jarvis-openapi.yaml
@@ -35,7 +35,315 @@ tags:
     description: Compatibility and conformance entry operations.
 paths: {}
 components:
-  schemas: {}
+  schemas:
+    JarvisId:
+      type: string
+      minLength: 1
+      maxLength: 160
+      pattern: "^[A-Za-z0-9][A-Za-z0-9._:-]*$"
+      description: Portable Jarvis protocol identifier. Host-private database ids stay outside protocol records.
+    OpaqueRef:
+      type: string
+      minLength: 1
+      maxLength: 512
+      description: Opaque protocol or external reference. Receivers do not need host-private infrastructure knowledge to preserve it.
+    Timestamp:
+      type: string
+      format: date-time
+      description: RFC 3339 timestamp.
+    NamespacedExtensions:
+      type: object
+      description: Namespaced extension fields. Extensions MUST NOT override core fields or contain forbidden host-private data.
+      propertyNames:
+        type: string
+        pattern: "^(?!.*(password|credential|token|secret|private_key|session_cookie|database|billing|runtime|container|deployment|model_api_key|raw_prompt|product_account|ui_state))[a-z0-9][a-z0-9-]*(\\.[a-z0-9_-]+)+$"
+      additionalProperties:
+        $ref: "#/components/schemas/PortableValue"
+    PortableValue:
+      description: Portable JSON value. Protocol records MUST NOT use this field to carry credentials, host-private ids, raw runtime state, billing data, or product UI state.
+      anyOf:
+        - type: string
+        - type: number
+        - type: integer
+        - type: boolean
+        - type: "null"
+        - type: array
+          items:
+            $ref: "#/components/schemas/PortableValue"
+        - type: object
+          propertyNames:
+            type: string
+            pattern: "^(?!.*(password|credential|token|secret|private_key|session_cookie|database|billing|runtime|container|deployment|model_api_key|raw_prompt|product_account|ui_state))[a-z0-9][a-z0-9._:-]*$"
+          additionalProperties:
+            $ref: "#/components/schemas/PortableValue"
+    WorkerType:
+      type: string
+      enum:
+        - human
+        - agent
+        - service
+        - tool
+    ActorType:
+      type: string
+      enum:
+        - human
+        - agent
+        - service
+        - tool
+    ContributionRole:
+      type: string
+      enum:
+        - human
+        - agent
+        - shared
+        - service
+        - tool
+    AutonomyLevel:
+      type: string
+      enum:
+        - observe_only
+        - propose_only
+        - execute_with_review
+        - bounded_execute
+        - full_execute_in_scope
+    AuthorityScope:
+      type: object
+      additionalProperties: false
+      required:
+        - grants
+      properties:
+        grants:
+          type: array
+          items:
+            type: string
+            minLength: 1
+          uniqueItems: true
+    AccountabilityScope:
+      type: object
+      additionalProperties: false
+      required:
+        - accountable_for
+      properties:
+        accountable_for:
+          type: array
+          items:
+            type: string
+            minLength: 1
+          uniqueItems: true
+    CapabilityRef:
+      type: object
+      additionalProperties: false
+      required:
+        - ref
+      properties:
+        ref:
+          $ref: "#/components/schemas/OpaqueRef"
+        capability_type:
+          type: string
+          minLength: 1
+        required:
+          type: boolean
+          default: false
+    EventAuthority:
+      type: object
+      additionalProperties: false
+      required:
+        - can_append_events
+      properties:
+        can_append_events:
+          type: boolean
+        allowed_event_types:
+          type: array
+          items:
+            type: string
+            minLength: 1
+          uniqueItems: true
+    ContributionScope:
+      type: object
+      additionalProperties: false
+      required:
+        - contribution_roles
+      properties:
+        contribution_roles:
+          type: array
+          items:
+            $ref: "#/components/schemas/ContributionRole"
+          minItems: 1
+          uniqueItems: true
+    Worker:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - type
+        - role
+        - authority_scope
+        - accountability_scope
+      properties:
+        id:
+          $ref: "#/components/schemas/JarvisId"
+        type:
+          $ref: "#/components/schemas/WorkerType"
+        role:
+          type: string
+          minLength: 1
+        authority_scope:
+          $ref: "#/components/schemas/AuthorityScope"
+        accountability_scope:
+          $ref: "#/components/schemas/AccountabilityScope"
+        display_name:
+          type: string
+          minLength: 1
+        capabilities:
+          type: array
+          items:
+            $ref: "#/components/schemas/CapabilityRef"
+          uniqueItems: true
+        extensions:
+          $ref: "#/components/schemas/NamespacedExtensions"
+      x-jarvis-forbidden-fields:
+        - password
+        - credential
+        - raw_auth_token
+        - billing_account
+        - provider_secret
+        - database_primary_key
+        - deployment_resource_id
+    Actor:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - worker_id
+        - type
+        - event_authority
+        - contribution_scope
+        - created_at
+      properties:
+        id:
+          $ref: "#/components/schemas/JarvisId"
+        worker_id:
+          $ref: "#/components/schemas/JarvisId"
+        type:
+          $ref: "#/components/schemas/ActorType"
+        event_authority:
+          $ref: "#/components/schemas/EventAuthority"
+        contribution_scope:
+          $ref: "#/components/schemas/ContributionScope"
+        created_at:
+          $ref: "#/components/schemas/Timestamp"
+        extensions:
+          $ref: "#/components/schemas/NamespacedExtensions"
+        valid_from:
+          $ref: "#/components/schemas/Timestamp"
+        valid_until:
+          $ref: "#/components/schemas/Timestamp"
+      x-jarvis-forbidden-fields:
+        - credential
+        - raw_auth_token
+        - session_cookie
+        - private_key
+        - database_primary_key
+    HumanWorker:
+      type: object
+      additionalProperties: false
+      required:
+        - worker_id
+        - actor_id
+        - role
+        - policy_authority
+        - review_authority
+      properties:
+        worker_id:
+          $ref: "#/components/schemas/JarvisId"
+        actor_id:
+          $ref: "#/components/schemas/JarvisId"
+        role:
+          type: string
+          minLength: 1
+        policy_authority:
+          $ref: "#/components/schemas/AuthorityScope"
+        review_authority:
+          $ref: "#/components/schemas/AuthorityScope"
+        profile_ref:
+          $ref: "#/components/schemas/OpaqueRef"
+        domain_context_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/OpaqueRef"
+          uniqueItems: true
+        preferences:
+          type: object
+          description: Portable human preference hints. Preferences MUST NOT contain private profile data, account state, credentials, billing data, or product UI state.
+          propertyNames:
+            type: string
+            pattern: "^(?!.*(password|credential|token|secret|private_key|session_cookie|database|billing|runtime|container|deployment|model_api_key|raw_prompt|product_account|ui_state))[a-z0-9][a-z0-9._:-]*$"
+          additionalProperties:
+            $ref: "#/components/schemas/PortableValue"
+        boundaries:
+          type: array
+          items:
+            type: string
+            minLength: 1
+        known_patterns:
+          type: array
+          items:
+            type: string
+            minLength: 1
+      x-jarvis-forbidden-fields:
+        - password
+        - credential
+        - raw_auth_token
+        - private_profile_data
+        - billing_account
+        - product_account_record
+    AgentWorker:
+      type: object
+      additionalProperties: false
+      required:
+        - worker_id
+        - actor_id
+        - agent_ref
+        - role
+        - capability_refs
+        - autonomy_level
+        - operating_constraints
+      properties:
+        worker_id:
+          $ref: "#/components/schemas/JarvisId"
+        actor_id:
+          $ref: "#/components/schemas/JarvisId"
+        agent_ref:
+          $ref: "#/components/schemas/OpaqueRef"
+        role:
+          type: string
+          minLength: 1
+        capability_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/CapabilityRef"
+          minItems: 1
+        autonomy_level:
+          $ref: "#/components/schemas/AutonomyLevel"
+        operating_constraints:
+          type: array
+          items:
+            type: string
+            minLength: 1
+          minItems: 1
+        tool_access_profile:
+          $ref: "#/components/schemas/OpaqueRef"
+        memory_access_profile:
+          $ref: "#/components/schemas/OpaqueRef"
+        extensions:
+          $ref: "#/components/schemas/NamespacedExtensions"
+      x-jarvis-forbidden-fields:
+        - model_api_key
+        - provider_secret
+        - raw_prompt_store
+        - runtime_process_id
+        - container_id
+        - database_primary_key
   parameters: {}
   headers: {}
   requestBodies: {}
@@ -79,16 +387,23 @@ x-jarvis-protocol:
     - task marketplace
     - product workflow
   chunk_lock:
-    id: week-2-chunk-1-openapi-skeleton
+    id: week-2-chunk-2-participant-schemas
     locks:
       - OpenAPI 3.1.1 entry point
       - v0.1 protocol metadata
       - required top-level buckets
       - tag taxonomy
       - host-owned server boundary
+      - shared schema primitives
+      - Worker schema
+      - Actor schema
+      - HumanWorker schema
+      - AgentWorker schema
     excludes:
-      - component field schemas
       - path operation bodies
       - operation-specific security requirements
+      - WorkSession schema
+      - control-plane schemas
+      - evidence and learning schemas
       - examples
       - conformance fixtures

--- a/docs/openapi/jarvis-openapi.yaml
+++ b/docs/openapi/jarvis-openapi.yaml
@@ -56,7 +56,7 @@ components:
       description: Namespaced extension fields. Extensions MUST NOT override core fields or contain forbidden host-private data.
       propertyNames:
         type: string
-        pattern: "^(?!.*(password|credential|token|secret|private_key|session_cookie|database|billing|runtime|container|deployment|model_api_key|raw_prompt|product_account|ui_state))[a-z0-9][a-z0-9-]*(\\.[a-z0-9_-]+)+$"
+        pattern: "^(?!.*(password|credential|token|secret|private_key|session_cookie|cookie|api_key|access_key|auth_header|oauth|database|billing|runtime|container|deployment|model_api_key|raw_prompt|product_account|ui_state))[a-z0-9][a-z0-9-]*(\\.[a-z0-9_-]+)+$"
       additionalProperties:
         $ref: "#/components/schemas/PortableValue"
     PortableValue:
@@ -73,7 +73,7 @@ components:
         - type: object
           propertyNames:
             type: string
-            pattern: "^(?!.*(password|credential|token|secret|private_key|session_cookie|database|billing|runtime|container|deployment|model_api_key|raw_prompt|product_account|ui_state))[a-z0-9][a-z0-9._:-]*$"
+            pattern: "^(?!.*(password|credential|token|secret|private_key|session_cookie|cookie|api_key|access_key|auth_header|oauth|database|billing|runtime|container|deployment|model_api_key|raw_prompt|product_account|ui_state))[a-z0-9][a-z0-9._:-]*$"
           additionalProperties:
             $ref: "#/components/schemas/PortableValue"
     WorkerType:
@@ -277,7 +277,7 @@ components:
           description: Portable human preference hints. Preferences MUST NOT contain private profile data, account state, credentials, billing data, or product UI state.
           propertyNames:
             type: string
-            pattern: "^(?!.*(password|credential|token|secret|private_key|session_cookie|database|billing|runtime|container|deployment|model_api_key|raw_prompt|product_account|ui_state))[a-z0-9][a-z0-9._:-]*$"
+            pattern: "^(?!.*(password|credential|token|secret|private_key|session_cookie|cookie|api_key|access_key|auth_header|oauth|database|billing|runtime|container|deployment|model_api_key|raw_prompt|product_account|ui_state))[a-z0-9][a-z0-9._:-]*$"
           additionalProperties:
             $ref: "#/components/schemas/PortableValue"
         boundaries:

--- a/docs/planning/week-2/README.md
+++ b/docs/planning/week-2/README.md
@@ -8,9 +8,10 @@ storage, model calls, adapters, or conformance fixtures beyond the active chunk.
 
 ## Chunks
 
-1. [chunk-1-openapi-skeleton.md](./chunk-1-openapi-skeleton.md)  
-   Lock the OpenAPI entry point, required buckets, tag taxonomy, and skeleton
-   validation.
+1. [chunk-1-openapi-skeleton.md](./chunk-1-openapi-skeleton.md)
+   Lock the OpenAPI entry point, required buckets, tag taxonomy, and skeleton validation.
+2. [chunk-2-participant-schemas.md](./chunk-2-participant-schemas.md)
+   Lock shared schema primitives, Worker, Actor, HumanWorker, and AgentWorker.
 
 ## Week 2 Done State
 

--- a/docs/planning/week-2/chunk-2-participant-schemas.md
+++ b/docs/planning/week-2/chunk-2-participant-schemas.md
@@ -1,0 +1,66 @@
+# Week 2 Chunk 2: Participant Schemas
+
+## Goal
+
+Encode the first OpenAPI `components.schemas` slice from the locked core object
+field list.
+
+## Scope
+
+This chunk locks:
+
+- shared schema primitives
+- `Worker`
+- `Actor`
+- `HumanWorker`
+- `AgentWorker`
+- forbidden-field metadata for those participant schemas
+- schema validation for the locked required fields
+
+This chunk does not define:
+
+- WorkSession schema
+- JarvisEvent schema
+- Policy or PolicyDecision schema
+- Request, Review, or Takeover schema
+- Contribution schema
+- EvidenceManifest schema
+- LearningRecord, MemoryProposal, or SkillProposal schema
+- OutcomeReport schema
+- path operation bodies
+- operation-specific security requirements
+- examples
+- conformance fixtures
+- runtime execution
+- Garden POC behavior
+
+## Files
+
+- [../../openapi/jarvis-openapi.yaml](../../openapi/jarvis-openapi.yaml)
+- [../../openapi/README.md](../../openapi/README.md)
+- [../../../scripts/check_openapi_skeleton.py](../../../scripts/check_openapi_skeleton.py)
+
+## Acceptance
+
+Chunk 2 is complete when:
+
+- the OpenAPI file parses as YAML
+- participant schemas exist under `components.schemas`
+- participant schemas encode the required fields from
+  [../../protocol/11-core-protocol-objects.md](../../protocol/11-core-protocol-objects.md)
+- participant schemas reject unspecified top-level fields with
+  `additionalProperties: false`
+- participant schemas list forbidden host-private fields in
+  `x-jarvis-forbidden-fields`
+- `Worker` and `Actor` keep human, agent, service, and tool participation
+  distinguishable
+- `HumanWorker` and `AgentWorker` reference their Worker and Actor records
+- no schema includes credentials, secrets, database ids, runtime ids, billing
+  fields, or product UI state as protocol properties
+- local validation passes
+
+## Boundary
+
+Participant schemas identify protocol workers and actors. They do not create
+accounts, authenticate callers, issue credentials, choose model providers, run
+agents, or define product UI.

--- a/docs/protocol/10-protocol-mvp.md
+++ b/docs/protocol/10-protocol-mvp.md
@@ -115,8 +115,7 @@ cancelled
 closed
 ```
 
-Jarvis defines valid transitions. Implementing products decide how they store,
-stream, or execute the session.
+Jarvis defines valid transitions. Hosts own storage, streaming, and execution.
 
 ## Conformance Tests
 
@@ -164,7 +163,8 @@ The v0.1 conformance suite checks:
   takeovers, contributions, artifacts, evidence items, and limitations.
 - EvidenceManifest final export rejects mutable WorkSession states.
 - EvidenceManifest excludes forbidden export fields.
-- Request resolution can create governed learning proposals.
+- Request resolution records governed learning proposals when the Review,
+  Takeover, or safe fallback changes future WorkSession behavior.
 - MemoryProposal and SkillProposal require provenance and review state.
 - MemoryProposal rejects model-derived or tool-derived self-confirmation.
 - SkillProposal rejects activation without review.

--- a/docs/protocol/10-protocol-mvp.md
+++ b/docs/protocol/10-protocol-mvp.md
@@ -39,7 +39,7 @@ Jarvis v0.1 excludes:
 - authentication
 - billing
 
-Those are implementation concerns for hosts.
+Hosts own implementation concerns.
 
 ## Golden Path
 

--- a/scripts/check_openapi_skeleton.py
+++ b/scripts/check_openapi_skeleton.py
@@ -204,7 +204,20 @@ REQUIRED_TAGS = {
 EXPECTED_TITLE = "Jarvis Human-Agent Collaboration Protocol"
 EXPECTED_PLACEHOLDER_SERVER = "https://jarvis.example.invalid"
 EXPECTED_CHUNK_ID = "week-2-chunk-2-participant-schemas"
-FORBIDDEN_KEY_PATTERN_MARKER = "password|credential|token|secret"
+PORTABLE_VALUE_REF = {"$ref": "#/components/schemas/PortableValue"}
+FORBIDDEN_PORTABLE_KEY_PATTERN = (
+    "^(?!.*(password|credential|token|secret|private_key|session_cookie|"
+    "cookie|api_key|access_key|auth_header|oauth|database|billing|runtime|"
+    "container|deployment|model_api_key|raw_prompt|product_account|ui_state))"
+)
+NAMESPACED_EXTENSION_PATTERN = (
+    FORBIDDEN_PORTABLE_KEY_PATTERN
+    + "[a-z0-9][a-z0-9-]*(\\.[a-z0-9_-]+)+$"
+)
+PORTABLE_PROPERTY_PATTERN = (
+    FORBIDDEN_PORTABLE_KEY_PATTERN
+    + "[a-z0-9][a-z0-9._:-]*$"
+)
 
 
 def fail(message: str) -> int:
@@ -291,13 +304,13 @@ def main() -> int:
             return fail(f"{schema_name} must set additionalProperties: false")
 
     extensions_schema = schemas["NamespacedExtensions"]
-    if extensions_schema.get("additionalProperties") is True:
-        return fail("NamespacedExtensions must not allow arbitrary properties")
+    if extensions_schema.get("additionalProperties") != PORTABLE_VALUE_REF:
+        return fail("NamespacedExtensions additionalProperties must use PortableValue")
     extension_pattern = (
         extensions_schema.get("propertyNames", {}).get("pattern", "")
     )
-    if FORBIDDEN_KEY_PATTERN_MARKER not in extension_pattern:
-        return fail("NamespacedExtensions must reject forbidden property names")
+    if extension_pattern != NAMESPACED_EXTENSION_PATTERN:
+        return fail("NamespacedExtensions must use the canonical property pattern")
 
     portable_value = schemas["PortableValue"]
     object_branch = None
@@ -308,10 +321,10 @@ def main() -> int:
     if object_branch is None:
         return fail("PortableValue must include a bounded object branch")
     portable_key_pattern = object_branch.get("propertyNames", {}).get("pattern", "")
-    if FORBIDDEN_KEY_PATTERN_MARKER not in portable_key_pattern:
-        return fail("PortableValue object keys must reject forbidden property names")
-    if "[a-z0-9]" not in portable_key_pattern:
-        return fail("PortableValue object keys must use lowercase portable names")
+    if portable_key_pattern != PORTABLE_PROPERTY_PATTERN:
+        return fail("PortableValue object keys must use the canonical property pattern")
+    if object_branch.get("additionalProperties") != PORTABLE_VALUE_REF:
+        return fail("PortableValue object additionalProperties must use PortableValue")
 
     for schema_name, required_fields in REQUIRED_SCHEMA_FIELDS.items():
         schema = schemas[schema_name]
@@ -351,11 +364,11 @@ def main() -> int:
             )
 
     preferences = schemas["HumanWorker"]["properties"]["preferences"]
-    if preferences.get("additionalProperties") is True:
-        return fail("HumanWorker.preferences must not allow arbitrary properties")
+    if preferences.get("additionalProperties") != PORTABLE_VALUE_REF:
+        return fail("HumanWorker.preferences additionalProperties must use PortableValue")
     preference_pattern = preferences.get("propertyNames", {}).get("pattern", "")
-    if FORBIDDEN_KEY_PATTERN_MARKER not in preference_pattern:
-        return fail("HumanWorker.preferences must reject forbidden property names")
+    if preference_pattern != PORTABLE_PROPERTY_PATTERN:
+        return fail("HumanWorker.preferences must use the canonical property pattern")
 
     security_schemes = components["securitySchemes"]
     host_auth = security_schemes.get("HostAuth")

--- a/scripts/check_openapi_skeleton.py
+++ b/scripts/check_openapi_skeleton.py
@@ -41,6 +41,155 @@ REQUIRED_PROTOCOL_METADATA = {
     "chunk_lock",
 }
 
+REQUIRED_SCHEMAS = {
+    "JarvisId",
+    "OpaqueRef",
+    "Timestamp",
+    "NamespacedExtensions",
+    "PortableValue",
+    "WorkerType",
+    "ActorType",
+    "ContributionRole",
+    "AutonomyLevel",
+    "AuthorityScope",
+    "AccountabilityScope",
+    "CapabilityRef",
+    "EventAuthority",
+    "ContributionScope",
+    "Worker",
+    "Actor",
+    "HumanWorker",
+    "AgentWorker",
+}
+
+REQUIRED_SCHEMA_FIELDS = {
+    "Worker": {
+        "id",
+        "type",
+        "role",
+        "authority_scope",
+        "accountability_scope",
+    },
+    "Actor": {
+        "id",
+        "worker_id",
+        "type",
+        "event_authority",
+        "contribution_scope",
+        "created_at",
+    },
+    "HumanWorker": {
+        "worker_id",
+        "actor_id",
+        "role",
+        "policy_authority",
+        "review_authority",
+    },
+    "AgentWorker": {
+        "worker_id",
+        "actor_id",
+        "agent_ref",
+        "role",
+        "capability_refs",
+        "autonomy_level",
+        "operating_constraints",
+    },
+}
+
+REQUIRED_ENUMS = {
+    "WorkerType": {
+        "human",
+        "agent",
+        "service",
+        "tool",
+    },
+    "ActorType": {
+        "human",
+        "agent",
+        "service",
+        "tool",
+    },
+    "ContributionRole": {
+        "human",
+        "agent",
+        "shared",
+        "service",
+        "tool",
+    },
+    "AutonomyLevel": {
+        "observe_only",
+        "propose_only",
+        "execute_with_review",
+        "bounded_execute",
+        "full_execute_in_scope",
+    },
+}
+
+REQUIRED_CLOSED_OBJECT_SCHEMAS = {
+    "AuthorityScope",
+    "AccountabilityScope",
+    "CapabilityRef",
+    "EventAuthority",
+    "ContributionScope",
+    "Worker",
+    "Actor",
+    "HumanWorker",
+    "AgentWorker",
+}
+
+REQUIRED_FORBIDDEN_METADATA = {
+    "Worker": {
+        "password",
+        "credential",
+        "raw_auth_token",
+        "billing_account",
+        "provider_secret",
+        "database_primary_key",
+        "deployment_resource_id",
+    },
+    "Actor": {
+        "credential",
+        "raw_auth_token",
+        "session_cookie",
+        "private_key",
+        "database_primary_key",
+    },
+    "HumanWorker": {
+        "password",
+        "credential",
+        "raw_auth_token",
+        "private_profile_data",
+        "billing_account",
+        "product_account_record",
+    },
+    "AgentWorker": {
+        "model_api_key",
+        "provider_secret",
+        "raw_prompt_store",
+        "runtime_process_id",
+        "container_id",
+        "database_primary_key",
+    },
+}
+
+FORBIDDEN_SCHEMA_PROPERTIES = {
+    "password",
+    "credential",
+    "raw_auth_token",
+    "billing_account",
+    "provider_secret",
+    "database_primary_key",
+    "deployment_resource_id",
+    "session_cookie",
+    "private_key",
+    "private_profile_data",
+    "product_account_record",
+    "model_api_key",
+    "raw_prompt_store",
+    "runtime_process_id",
+    "container_id",
+}
+
 REQUIRED_TAGS = {
     "Workers",
     "WorkSessions",
@@ -54,7 +203,8 @@ REQUIRED_TAGS = {
 
 EXPECTED_TITLE = "Jarvis Human-Agent Collaboration Protocol"
 EXPECTED_PLACEHOLDER_SERVER = "https://jarvis.example.invalid"
-EXPECTED_CHUNK_ID = "week-2-chunk-1-openapi-skeleton"
+EXPECTED_CHUNK_ID = "week-2-chunk-2-participant-schemas"
+FORBIDDEN_KEY_PATTERN_MARKER = "password|credential|token|secret"
 
 
 def fail(message: str) -> int:
@@ -114,6 +264,98 @@ def main() -> int:
     for bucket in REQUIRED_COMPONENTS:
         if not isinstance(components[bucket], dict):
             return fail(f"components.{bucket} must be an object")
+
+    schemas = components["schemas"]
+    missing_schemas = REQUIRED_SCHEMAS - set(schemas)
+    if missing_schemas:
+        return fail("missing schemas: " + ", ".join(sorted(missing_schemas)))
+
+    for schema_name, expected_values in REQUIRED_ENUMS.items():
+        schema = schemas[schema_name]
+        actual_values = set(schema.get("enum", []))
+        if actual_values != expected_values:
+            return fail(
+                f"{schema_name} enum mismatch. expected "
+                + ", ".join(sorted(expected_values))
+                + "; got "
+                + ", ".join(sorted(actual_values))
+            )
+
+    for schema_name in REQUIRED_CLOSED_OBJECT_SCHEMAS:
+        schema = schemas[schema_name]
+        if not isinstance(schema, dict):
+            return fail(f"components.schemas.{schema_name} must be an object")
+        if schema.get("type") != "object":
+            return fail(f"{schema_name} must be an object schema")
+        if schema.get("additionalProperties") is not False:
+            return fail(f"{schema_name} must set additionalProperties: false")
+
+    extensions_schema = schemas["NamespacedExtensions"]
+    if extensions_schema.get("additionalProperties") is True:
+        return fail("NamespacedExtensions must not allow arbitrary properties")
+    extension_pattern = (
+        extensions_schema.get("propertyNames", {}).get("pattern", "")
+    )
+    if FORBIDDEN_KEY_PATTERN_MARKER not in extension_pattern:
+        return fail("NamespacedExtensions must reject forbidden property names")
+
+    portable_value = schemas["PortableValue"]
+    object_branch = None
+    for branch in portable_value.get("anyOf", []):
+        if isinstance(branch, dict) and branch.get("type") == "object":
+            object_branch = branch
+            break
+    if object_branch is None:
+        return fail("PortableValue must include a bounded object branch")
+    portable_key_pattern = object_branch.get("propertyNames", {}).get("pattern", "")
+    if FORBIDDEN_KEY_PATTERN_MARKER not in portable_key_pattern:
+        return fail("PortableValue object keys must reject forbidden property names")
+    if "[a-z0-9]" not in portable_key_pattern:
+        return fail("PortableValue object keys must use lowercase portable names")
+
+    for schema_name, required_fields in REQUIRED_SCHEMA_FIELDS.items():
+        schema = schemas[schema_name]
+        declared_required = set(schema.get("required", []))
+        missing_fields = required_fields - declared_required
+        if missing_fields:
+            return fail(
+                f"{schema_name} missing required fields: "
+                + ", ".join(sorted(missing_fields))
+            )
+
+        properties = schema.get("properties")
+        if not isinstance(properties, dict):
+            return fail(f"{schema_name}.properties must be an object")
+        missing_properties = required_fields - set(properties)
+        if missing_properties:
+            return fail(
+                f"{schema_name} missing properties for required fields: "
+                + ", ".join(sorted(missing_properties))
+            )
+
+        forbidden_properties = FORBIDDEN_SCHEMA_PROPERTIES & set(properties)
+        if forbidden_properties:
+            return fail(
+                f"{schema_name} exposes forbidden properties: "
+                + ", ".join(sorted(forbidden_properties))
+            )
+
+        forbidden_metadata = set(schema.get("x-jarvis-forbidden-fields", []))
+        expected_metadata = REQUIRED_FORBIDDEN_METADATA[schema_name]
+        if forbidden_metadata != expected_metadata:
+            return fail(
+                f"{schema_name} x-jarvis-forbidden-fields mismatch. expected "
+                + ", ".join(sorted(expected_metadata))
+                + "; got "
+                + ", ".join(sorted(forbidden_metadata))
+            )
+
+    preferences = schemas["HumanWorker"]["properties"]["preferences"]
+    if preferences.get("additionalProperties") is True:
+        return fail("HumanWorker.preferences must not allow arbitrary properties")
+    preference_pattern = preferences.get("propertyNames", {}).get("pattern", "")
+    if FORBIDDEN_KEY_PATTERN_MARKER not in preference_pattern:
+        return fail("HumanWorker.preferences must reject forbidden property names")
 
     security_schemes = components["securitySchemes"]
     host_auth = security_schemes.get("HostAuth")


### PR DESCRIPTION
## Summary
- Add Week 2 chunk 2 participant schemas to the OpenAPI 3.1 contract: Worker, Actor, HumanWorker, AgentWorker, and shared primitives.
- Lock canonical enum values from the protocol docs, bounded portable extension/preference values, and forbidden-field metadata.
- Extend the OpenAPI validation script to enforce required participant fields, closed schemas, canonical enums, exact forbidden metadata, and bounded extension/preference keys.
- Replace soft host-boundary wording with direct protocol wording: Hosts own implementation concerns.

## Reviewer lanes
- Protocol-boundary / chief architect: pass.
- OpenAPI/schema reviewer: pass.
- Zero-trust/security/conformance reviewer: pass.
- Docs/wording/directness reviewer: pass.

## Validation
- python3 scripts/check_openapi_skeleton.py
- python3 scripts/check_markdown_links.py
- python3 scripts/check_week1_wording.py
- git diff --check
- python3 -m py_compile scripts/check_markdown_links.py scripts/check_week1_wording.py scripts/check_openapi_skeleton.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added OpenAPI component schemas for participant objects (Worker, Actor, HumanWorker, AgentWorker) and core primitives (identifiers, timestamps, capability/authority scopes).
  * Clarified chunked OpenAPI documentation and week-2 planning scope and acceptance criteria for participant schemas.
* **Chores**
  * Strengthened OpenAPI skeleton validation to enforce presence/shape of the new participant schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->