### PR TITLE
Add WorkSession policy OpenAPI schemas

### DIFF
--- a/docs/openapi/README.md
+++ b/docs/openapi/README.md
@@ -51,6 +51,20 @@ requirements, WorkSession schema, control-plane schemas, evidence and learning
 schemas, examples, or conformance fixtures. Later chunks define those sections
 from the locked protocol docs.
 
+Chunk 3 defines the WorkSession, event, Policy, and PolicyDecision schema
+spine:
+
+```txt
+WorkSession
+JarvisEvent
+Policy
+PolicyDecision
+```
+
+Chunk 3 does not define Request, Review, Takeover, Contribution,
+EvidenceManifest, learning schemas, path operation bodies, examples, or
+conformance fixtures.
+
 ## Boundary
 
 Compatible hosts publish their own server URLs, identity providers, credential

--- a/docs/openapi/jarvis-openapi.yaml
+++ b/docs/openapi/jarvis-openapi.yaml
@@ -106,6 +106,39 @@ components:
         - execute_with_review
         - bounded_execute
         - full_execute_in_scope
+    WorkSessionStatus:
+      type: string
+      enum:
+        - created
+        - active
+        - waiting_on_human
+        - takeover
+        - reconciling
+        - completed
+        - failed
+        - cancelled
+        - closed
+    PolicyDecisionResult:
+      type: string
+      enum:
+        - allow
+        - deny
+        - narrow
+        - review_required
+    RiskClass:
+      type: string
+      enum:
+        - low
+        - medium
+        - high
+        - critical
+    DataSensitivity:
+      type: string
+      enum:
+        - public
+        - private
+        - confidential
+        - restricted
     AuthorityScope:
       type: object
       additionalProperties: false
@@ -169,6 +202,180 @@ components:
           items:
             $ref: "#/components/schemas/ContributionRole"
           minItems: 1
+          uniqueItems: true
+    CanonicalizationProfile:
+      type: object
+      additionalProperties: false
+      required:
+        - serialization
+        - hash_method
+      properties:
+        serialization:
+          type: string
+          minLength: 1
+        hash_method:
+          type: string
+          minLength: 1
+        profile_ref:
+          $ref: "#/components/schemas/OpaqueRef"
+    ProtocolTraceContext:
+      type: object
+      additionalProperties: false
+      properties:
+        trace_id:
+          $ref: "#/components/schemas/OpaqueRef"
+        parent_event_id:
+          $ref: "#/components/schemas/JarvisId"
+        correlation_ref:
+          $ref: "#/components/schemas/OpaqueRef"
+    JarvisEventPayload:
+      type: object
+      additionalProperties: false
+      required:
+        - object_type
+        - action
+      properties:
+        object_type:
+          type: string
+          enum:
+            - worker
+            - actor
+            - human_worker
+            - agent_worker
+            - work_session
+            - jarvis_event
+            - policy
+            - policy_decision
+            - request
+            - review
+            - takeover
+            - contribution
+            - evidence_manifest
+            - learning_record
+            - memory_proposal
+            - skill_proposal
+            - outcome_report
+            - protocol_error
+            - conformance_result
+        object_id:
+          $ref: "#/components/schemas/JarvisId"
+        action:
+          type: string
+          minLength: 1
+        field_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/OpaqueRef"
+          uniqueItems: true
+        evidence_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/OpaqueRef"
+          uniqueItems: true
+        summary:
+          type: string
+          minLength: 1
+    PolicyConstraint:
+      type: object
+      additionalProperties: false
+      required:
+        - kind
+      properties:
+        kind:
+          type: string
+          minLength: 1
+        scope_ref:
+          $ref: "#/components/schemas/OpaqueRef"
+        value_ref:
+          $ref: "#/components/schemas/OpaqueRef"
+        max_count:
+          type: integer
+          minimum: 0
+        unit:
+          type: string
+          minLength: 1
+        reason:
+          type: string
+          minLength: 1
+    EscalationRule:
+      type: object
+      additionalProperties: false
+      required:
+        - trigger
+        - required_action
+      properties:
+        trigger:
+          type: string
+          minLength: 1
+        risk_class:
+          $ref: "#/components/schemas/RiskClass"
+        required_action:
+          type: string
+          enum:
+            - create_request
+            - require_review
+            - start_takeover
+            - deny_action
+        reviewer_ref:
+          $ref: "#/components/schemas/OpaqueRef"
+        reason:
+          type: string
+          minLength: 1
+    PolicyActionRule:
+      type: object
+      additionalProperties: false
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          minLength: 1
+        scope_ref:
+          $ref: "#/components/schemas/OpaqueRef"
+        grant_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/OpaqueRef"
+          uniqueItems: true
+        constraints:
+          type: array
+          items:
+            $ref: "#/components/schemas/PolicyConstraint"
+    PolicyRequestLimits:
+      type: object
+      additionalProperties: false
+      properties:
+        max_pending_requests:
+          type: integer
+          minimum: 0
+        max_repeated_denials:
+          type: integer
+          minimum: 0
+        default_expiry_seconds:
+          type: integer
+          minimum: 1
+    PolicyActionRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          minLength: 1
+        target_ref:
+          $ref: "#/components/schemas/OpaqueRef"
+        scope_ref:
+          $ref: "#/components/schemas/OpaqueRef"
+        input_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/OpaqueRef"
+          uniqueItems: true
+        parameter_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/OpaqueRef"
           uniqueItems: true
     Worker:
       type: object
@@ -344,6 +551,277 @@ components:
         - runtime_process_id
         - container_id
         - database_primary_key
+    WorkSession:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - protocol_version
+        - created_by_actor_id
+        - objective
+        - human_worker_id
+        - agent_worker_id
+        - policy_id
+        - status
+        - revision
+        - last_event_hash
+        - event_log_ref
+        - created_at
+        - updated_at
+      properties:
+        id:
+          $ref: "#/components/schemas/JarvisId"
+        protocol_version:
+          type: string
+          const: v0.1
+        created_by_actor_id:
+          $ref: "#/components/schemas/JarvisId"
+        objective:
+          type: string
+          minLength: 1
+        human_worker_id:
+          $ref: "#/components/schemas/JarvisId"
+        agent_worker_id:
+          $ref: "#/components/schemas/JarvisId"
+        policy_id:
+          $ref: "#/components/schemas/JarvisId"
+        status:
+          $ref: "#/components/schemas/WorkSessionStatus"
+        revision:
+          type: integer
+          minimum: 0
+        last_event_hash:
+          type: string
+          minLength: 1
+        event_log_ref:
+          $ref: "#/components/schemas/OpaqueRef"
+        created_at:
+          $ref: "#/components/schemas/Timestamp"
+        updated_at:
+          $ref: "#/components/schemas/Timestamp"
+        source_ref:
+          $ref: "#/components/schemas/OpaqueRef"
+        context_manifest_ref:
+          $ref: "#/components/schemas/OpaqueRef"
+        contribution_ledger_ref:
+          $ref: "#/components/schemas/OpaqueRef"
+        evidence_manifest_ref:
+          $ref: "#/components/schemas/OpaqueRef"
+        learning_record_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/JarvisId"
+          uniqueItems: true
+      x-jarvis-forbidden-fields:
+        - database_primary_key
+        - queue_message_id
+        - runtime_session_id
+        - cloud_resource_id
+        - ui_state
+        - credential
+        - raw_auth_token
+    JarvisEvent:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - sequence
+        - type
+        - work_session_id
+        - actor_id
+        - timestamp
+        - payload
+        - previous_hash
+        - event_hash
+        - canonicalization
+      properties:
+        id:
+          $ref: "#/components/schemas/JarvisId"
+        sequence:
+          type: integer
+          minimum: 0
+        type:
+          type: string
+          minLength: 1
+        work_session_id:
+          $ref: "#/components/schemas/JarvisId"
+        actor_id:
+          $ref: "#/components/schemas/JarvisId"
+        timestamp:
+          $ref: "#/components/schemas/Timestamp"
+        payload:
+          $ref: "#/components/schemas/JarvisEventPayload"
+        previous_hash:
+          type: string
+          minLength: 1
+        event_hash:
+          type: string
+          minLength: 1
+        canonicalization:
+          $ref: "#/components/schemas/CanonicalizationProfile"
+        trace_context:
+          $ref: "#/components/schemas/ProtocolTraceContext"
+        actor_signature:
+          type: string
+          minLength: 1
+        signing_key_ref:
+          $ref: "#/components/schemas/OpaqueRef"
+      x-jarvis-forbidden-fields:
+        - raw_auth_token
+        - credential
+        - private_key
+        - database_primary_key
+        - runtime_trace_secret
+        - provider_secret
+    Policy:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - owner_worker_id
+        - created_by_actor_id
+        - autonomy_level
+        - allowed_actions
+        - denied_actions
+        - review_required_actions
+        - risk_classes
+        - escalation_rules
+        - created_at
+      properties:
+        id:
+          $ref: "#/components/schemas/JarvisId"
+        owner_worker_id:
+          $ref: "#/components/schemas/JarvisId"
+        created_by_actor_id:
+          $ref: "#/components/schemas/JarvisId"
+        autonomy_level:
+          $ref: "#/components/schemas/AutonomyLevel"
+        allowed_actions:
+          type: array
+          items:
+            $ref: "#/components/schemas/PolicyActionRule"
+        denied_actions:
+          type: array
+          items:
+            $ref: "#/components/schemas/PolicyActionRule"
+        review_required_actions:
+          type: array
+          items:
+            $ref: "#/components/schemas/PolicyActionRule"
+        risk_classes:
+          type: array
+          items:
+            $ref: "#/components/schemas/RiskClass"
+          minItems: 1
+          uniqueItems: true
+        escalation_rules:
+          type: array
+          items:
+            $ref: "#/components/schemas/EscalationRule"
+        created_at:
+          $ref: "#/components/schemas/Timestamp"
+        tool_grants:
+          type: array
+          items:
+            $ref: "#/components/schemas/OpaqueRef"
+          uniqueItems: true
+        memory_grants:
+          type: array
+          items:
+            $ref: "#/components/schemas/OpaqueRef"
+          uniqueItems: true
+        external_send_rules:
+          type: array
+          items:
+            $ref: "#/components/schemas/PolicyActionRule"
+        request_limits:
+          $ref: "#/components/schemas/PolicyRequestLimits"
+        extensions:
+          $ref: "#/components/schemas/NamespacedExtensions"
+      x-jarvis-forbidden-fields:
+        - credential
+        - raw_auth_token
+        - provider_secret
+        - billing_rule
+        - cloud_policy_id
+        - database_primary_key
+    PolicyDecision:
+      type: object
+      additionalProperties: false
+      allOf:
+        - if:
+            properties:
+              result:
+                const: deny
+          then:
+            required:
+              - request_id
+        - if:
+            properties:
+              result:
+                const: review_required
+          then:
+            required:
+              - request_id
+      required:
+        - id
+        - work_session_id
+        - actor_id
+        - policy_id
+        - requested_action
+        - normalized_action_hash
+        - risk_class
+        - result
+        - reason
+        - created_at
+      properties:
+        id:
+          $ref: "#/components/schemas/JarvisId"
+        work_session_id:
+          $ref: "#/components/schemas/JarvisId"
+        actor_id:
+          $ref: "#/components/schemas/JarvisId"
+        policy_id:
+          $ref: "#/components/schemas/JarvisId"
+        requested_action:
+          $ref: "#/components/schemas/PolicyActionRequest"
+        normalized_action_hash:
+          type: string
+          minLength: 1
+        risk_class:
+          $ref: "#/components/schemas/RiskClass"
+        result:
+          $ref: "#/components/schemas/PolicyDecisionResult"
+        reason:
+          type: string
+          minLength: 1
+        created_at:
+          $ref: "#/components/schemas/Timestamp"
+        data_sensitivity:
+          $ref: "#/components/schemas/DataSensitivity"
+        selected_grant_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/OpaqueRef"
+          uniqueItems: true
+        denied_grant_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/OpaqueRef"
+          uniqueItems: true
+        request_id:
+          $ref: "#/components/schemas/JarvisId"
+        evidence_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/OpaqueRef"
+          uniqueItems: true
+      x-jarvis-forbidden-fields:
+        - hidden_policy_trace
+        - credential
+        - provider_secret
+        - database_primary_key
+        - runtime_decision_object
   parameters: {}
   headers: {}
   requestBodies: {}
@@ -387,7 +865,7 @@ x-jarvis-protocol:
     - task marketplace
     - host workflow
   chunk_lock:
-    id: week-2-chunk-2-participant-schemas
+    id: week-2-chunk-3-worksession-policy-schemas
     locks:
       - OpenAPI 3.1.1 entry point
       - v0.1 protocol metadata
@@ -399,10 +877,13 @@ x-jarvis-protocol:
       - Actor schema
       - HumanWorker schema
       - AgentWorker schema
+      - WorkSession schema
+      - JarvisEvent schema
+      - Policy schema
+      - PolicyDecision schema
     excludes:
       - path operation bodies
       - operation-specific security requirements
-      - WorkSession schema
       - control-plane schemas
       - evidence and learning schemas
       - examples

--- a/docs/openapi/jarvis-openapi.yaml
+++ b/docs/openapi/jarvis-openapi.yaml
@@ -884,7 +884,9 @@ x-jarvis-protocol:
     excludes:
       - path operation bodies
       - operation-specific security requirements
-      - control-plane schemas
+      - Request schema
+      - Review schema
+      - Takeover schema
       - evidence and learning schemas
       - examples
       - conformance fixtures

--- a/docs/planning/week-2/README.md
+++ b/docs/planning/week-2/README.md
@@ -12,6 +12,8 @@ storage, model calls, adapters, or conformance fixtures beyond the active chunk.
    Lock the OpenAPI entry point, required buckets, tag taxonomy, and skeleton validation.
 2. [chunk-2-participant-schemas.md](./chunk-2-participant-schemas.md)
    Lock shared schema primitives, Worker, Actor, HumanWorker, and AgentWorker.
+3. [chunk-3-worksession-policy-schemas.md](./chunk-3-worksession-policy-schemas.md)
+   Lock WorkSession, JarvisEvent, Policy, and PolicyDecision schemas.
 
 ## Week 2 Done State
 

--- a/docs/planning/week-2/chunk-3-worksession-policy-schemas.md
+++ b/docs/planning/week-2/chunk-3-worksession-policy-schemas.md
@@ -1,0 +1,74 @@
+# Week 2 Chunk 3: WorkSession And Policy Schemas
+
+## Goal
+
+Encode the OpenAPI schema spine that carries WorkSession state, append-only
+events, Policy boundaries, and PolicyDecision records.
+
+## Scope
+
+This chunk locks:
+
+- `WorkSession`
+- `JarvisEvent`
+- `Policy`
+- `PolicyDecision`
+- WorkSession status enum
+- PolicyDecision result enum
+- risk and data sensitivity enums
+- canonicalization profile schema
+- policy action request and rule schemas
+- forbidden-field metadata for the new schemas
+- schema validation for locked required fields
+
+This chunk does not define:
+
+- Request schema
+- Review schema
+- Takeover schema
+- Contribution schema
+- EvidenceManifest schema
+- LearningRecord, MemoryProposal, or SkillProposal schema
+- OutcomeReport schema
+- path operation bodies
+- operation-specific security requirements
+- examples
+- conformance fixtures
+- runtime execution
+- host implementation behavior
+
+## Files
+
+- [../../openapi/jarvis-openapi.yaml](../../openapi/jarvis-openapi.yaml)
+- [../../openapi/README.md](../../openapi/README.md)
+- [../../../scripts/check_openapi_skeleton.py](../../../scripts/check_openapi_skeleton.py)
+
+## Acceptance
+
+Chunk 3 is complete when:
+
+- the OpenAPI file parses as YAML
+- `WorkSession`, `JarvisEvent`, `Policy`, and `PolicyDecision` exist under
+  `components.schemas`
+- the new schemas encode the required fields from
+  [../../protocol/11-core-protocol-objects.md](../../protocol/11-core-protocol-objects.md)
+- the new schemas reject unspecified top-level fields with
+  `additionalProperties: false`
+- the new schemas list forbidden host-private fields in
+  `x-jarvis-forbidden-fields`
+- `WorkSession` carries protocol version, lifecycle status, revision, previous
+  event hash state, event log reference, and the HumanWorker/AgentWorker pair
+- `JarvisEvent` carries ordered append-only event attribution, payload,
+  previous hash, event hash, and canonicalization profile
+- `Policy` carries the human-defined boundary for agent action
+- `PolicyDecision` records the required precondition for every AgentWorker
+  action that affects WorkSession state
+- no schema includes credentials, secrets, database ids, runtime ids, billing
+  fields, deployment ids, or UI state as protocol properties
+- local validation passes
+
+## Boundary
+
+These schemas record protocol state. They do not evaluate policy, execute
+actions, store events, authenticate callers, choose tools, run agents, or define
+host workflow.

--- a/scripts/check_openapi_skeleton.py
+++ b/scripts/check_openapi_skeleton.py
@@ -51,15 +51,31 @@ REQUIRED_SCHEMAS = {
     "ActorType",
     "ContributionRole",
     "AutonomyLevel",
+    "WorkSessionStatus",
+    "PolicyDecisionResult",
+    "RiskClass",
+    "DataSensitivity",
     "AuthorityScope",
     "AccountabilityScope",
     "CapabilityRef",
     "EventAuthority",
     "ContributionScope",
+    "CanonicalizationProfile",
+    "ProtocolTraceContext",
+    "JarvisEventPayload",
+    "PolicyConstraint",
+    "EscalationRule",
+    "PolicyActionRule",
+    "PolicyRequestLimits",
+    "PolicyActionRequest",
     "Worker",
     "Actor",
     "HumanWorker",
     "AgentWorker",
+    "WorkSession",
+    "JarvisEvent",
+    "Policy",
+    "PolicyDecision",
 }
 
 REQUIRED_SCHEMA_FIELDS = {
@@ -94,6 +110,86 @@ REQUIRED_SCHEMA_FIELDS = {
         "autonomy_level",
         "operating_constraints",
     },
+    "WorkSession": {
+        "id",
+        "protocol_version",
+        "created_by_actor_id",
+        "objective",
+        "human_worker_id",
+        "agent_worker_id",
+        "policy_id",
+        "status",
+        "revision",
+        "last_event_hash",
+        "event_log_ref",
+        "created_at",
+        "updated_at",
+    },
+    "JarvisEvent": {
+        "id",
+        "sequence",
+        "type",
+        "work_session_id",
+        "actor_id",
+        "timestamp",
+        "payload",
+        "previous_hash",
+        "event_hash",
+        "canonicalization",
+    },
+    "Policy": {
+        "id",
+        "owner_worker_id",
+        "created_by_actor_id",
+        "autonomy_level",
+        "allowed_actions",
+        "denied_actions",
+        "review_required_actions",
+        "risk_classes",
+        "escalation_rules",
+        "created_at",
+    },
+    "PolicyDecision": {
+        "id",
+        "work_session_id",
+        "actor_id",
+        "policy_id",
+        "requested_action",
+        "normalized_action_hash",
+        "risk_class",
+        "result",
+        "reason",
+        "created_at",
+    },
+}
+
+OPTIONAL_SCHEMA_FIELDS = {
+    "WorkSession": {
+        "source_ref",
+        "context_manifest_ref",
+        "contribution_ledger_ref",
+        "evidence_manifest_ref",
+        "learning_record_refs",
+    },
+    "JarvisEvent": {
+        "trace_context",
+        "actor_signature",
+        "signing_key_ref",
+    },
+    "Policy": {
+        "tool_grants",
+        "memory_grants",
+        "external_send_rules",
+        "request_limits",
+        "extensions",
+    },
+    "PolicyDecision": {
+        "data_sensitivity",
+        "selected_grant_refs",
+        "denied_grant_refs",
+        "request_id",
+        "evidence_refs",
+    },
 }
 
 REQUIRED_ENUMS = {
@@ -123,6 +219,35 @@ REQUIRED_ENUMS = {
         "bounded_execute",
         "full_execute_in_scope",
     },
+    "WorkSessionStatus": {
+        "created",
+        "active",
+        "waiting_on_human",
+        "takeover",
+        "reconciling",
+        "completed",
+        "failed",
+        "cancelled",
+        "closed",
+    },
+    "PolicyDecisionResult": {
+        "allow",
+        "deny",
+        "narrow",
+        "review_required",
+    },
+    "RiskClass": {
+        "low",
+        "medium",
+        "high",
+        "critical",
+    },
+    "DataSensitivity": {
+        "public",
+        "private",
+        "confidential",
+        "restricted",
+    },
 }
 
 REQUIRED_CLOSED_OBJECT_SCHEMAS = {
@@ -131,10 +256,22 @@ REQUIRED_CLOSED_OBJECT_SCHEMAS = {
     "CapabilityRef",
     "EventAuthority",
     "ContributionScope",
+    "CanonicalizationProfile",
+    "ProtocolTraceContext",
+    "JarvisEventPayload",
+    "PolicyConstraint",
+    "EscalationRule",
+    "PolicyActionRule",
+    "PolicyRequestLimits",
+    "PolicyActionRequest",
     "Worker",
     "Actor",
     "HumanWorker",
     "AgentWorker",
+    "WorkSession",
+    "JarvisEvent",
+    "Policy",
+    "PolicyDecision",
 }
 
 REQUIRED_FORBIDDEN_METADATA = {
@@ -170,6 +307,38 @@ REQUIRED_FORBIDDEN_METADATA = {
         "container_id",
         "database_primary_key",
     },
+    "WorkSession": {
+        "database_primary_key",
+        "queue_message_id",
+        "runtime_session_id",
+        "cloud_resource_id",
+        "ui_state",
+        "credential",
+        "raw_auth_token",
+    },
+    "JarvisEvent": {
+        "raw_auth_token",
+        "credential",
+        "private_key",
+        "database_primary_key",
+        "runtime_trace_secret",
+        "provider_secret",
+    },
+    "Policy": {
+        "credential",
+        "raw_auth_token",
+        "provider_secret",
+        "billing_rule",
+        "cloud_policy_id",
+        "database_primary_key",
+    },
+    "PolicyDecision": {
+        "hidden_policy_trace",
+        "credential",
+        "provider_secret",
+        "database_primary_key",
+        "runtime_decision_object",
+    },
 }
 
 FORBIDDEN_SCHEMA_PROPERTIES = {
@@ -188,6 +357,14 @@ FORBIDDEN_SCHEMA_PROPERTIES = {
     "raw_prompt_store",
     "runtime_process_id",
     "container_id",
+    "queue_message_id",
+    "runtime_session_id",
+    "cloud_resource_id",
+    "runtime_trace_secret",
+    "billing_rule",
+    "cloud_policy_id",
+    "hidden_policy_trace",
+    "runtime_decision_object",
 }
 
 REQUIRED_TAGS = {
@@ -203,7 +380,23 @@ REQUIRED_TAGS = {
 
 EXPECTED_TITLE = "Jarvis Human-Agent Collaboration Protocol"
 EXPECTED_PLACEHOLDER_SERVER = "https://jarvis.example.invalid"
-EXPECTED_CHUNK_ID = "week-2-chunk-2-participant-schemas"
+EXPECTED_CHUNK_ID = "week-2-chunk-3-worksession-policy-schemas"
+REQUIRED_CHUNK_LOCKS = {
+    "OpenAPI 3.1.1 entry point",
+    "v0.1 protocol metadata",
+    "required top-level buckets",
+    "tag taxonomy",
+    "host-owned server boundary",
+    "shared schema primitives",
+    "Worker schema",
+    "Actor schema",
+    "HumanWorker schema",
+    "AgentWorker schema",
+    "WorkSession schema",
+    "JarvisEvent schema",
+    "Policy schema",
+    "PolicyDecision schema",
+}
 PORTABLE_VALUE_REF = {"$ref": "#/components/schemas/PortableValue"}
 FORBIDDEN_PORTABLE_KEY_PATTERN = (
     "^(?!.*(password|credential|token|secret|private_key|session_cookie|"
@@ -223,6 +416,52 @@ PORTABLE_PROPERTY_PATTERN = (
 def fail(message: str) -> int:
     print(f"openapi skeleton check failed: {message}")
     return 1
+
+
+def schema_requires_field_when_const(
+    schema: dict, property_name: str, const_value: str, required_field: str
+) -> bool:
+    for branch in schema.get("allOf", []):
+        if not isinstance(branch, dict):
+            continue
+        condition = branch.get("if", {})
+        consequence = branch.get("then", {})
+        if not isinstance(condition, dict) or not isinstance(consequence, dict):
+            continue
+        properties = condition.get("properties", {})
+        if not isinstance(properties, dict):
+            continue
+        target = properties.get(property_name, {})
+        if not isinstance(target, dict):
+            continue
+        required = consequence.get("required", [])
+        if target.get("const") == const_value and required_field in required:
+            return True
+    return False
+
+
+def iter_refs(value, path: str = "$"):
+    if isinstance(value, dict):
+        ref = value.get("$ref")
+        if isinstance(ref, str):
+            yield path, ref
+        for key, child in value.items():
+            yield from iter_refs(child, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            yield from iter_refs(child, f"{path}[{index}]")
+
+
+def local_ref_exists(document: dict, ref: str) -> bool:
+    if not ref.startswith("#/"):
+        return True
+    current = document
+    for raw_part in ref[2:].split("/"):
+        part = raw_part.replace("~1", "/").replace("~0", "~")
+        if not isinstance(current, dict) or part not in current:
+            return False
+        current = current[part]
+    return True
 
 
 def main() -> int:
@@ -265,6 +504,13 @@ def main() -> int:
         return fail("x-jarvis-protocol.chunk_lock must be an object")
     if chunk_lock.get("id") != EXPECTED_CHUNK_ID:
         return fail(f"x-jarvis-protocol.chunk_lock.id must be {EXPECTED_CHUNK_ID}")
+    declared_locks = set(chunk_lock.get("locks", []))
+    missing_locks = REQUIRED_CHUNK_LOCKS - declared_locks
+    if missing_locks:
+        return fail(
+            "x-jarvis-protocol.chunk_lock.locks missing: "
+            + ", ".join(sorted(missing_locks))
+        )
 
     components = data["components"]
     if not isinstance(components, dict):
@@ -362,6 +608,37 @@ def main() -> int:
                 + "; got "
                 + ", ".join(sorted(forbidden_metadata))
             )
+
+    for schema_name, optional_fields in OPTIONAL_SCHEMA_FIELDS.items():
+        properties = schemas[schema_name].get("properties", {})
+        missing_optional = optional_fields - set(properties)
+        if missing_optional:
+            return fail(
+                f"{schema_name} missing locked optional fields: "
+                + ", ".join(sorted(missing_optional))
+            )
+
+    policy_decision = schemas["PolicyDecision"]
+    for result_value in ("deny", "review_required"):
+        if not schema_requires_field_when_const(
+            policy_decision, "result", result_value, "request_id"
+        ):
+            return fail(
+                "PolicyDecision must require request_id when result is "
+                + result_value
+            )
+
+    event_payload_properties = schemas["JarvisEventPayload"].get("properties", {})
+    if "extensions" in event_payload_properties:
+        return fail("JarvisEventPayload must not expose extensions")
+
+    broken_refs = [
+        f"{path} -> {ref}"
+        for path, ref in iter_refs(data)
+        if not local_ref_exists(data, ref)
+    ]
+    if broken_refs:
+        return fail("unresolved local refs: " + "; ".join(broken_refs))
 
     preferences = schemas["HumanWorker"]["properties"]["preferences"]
     if preferences.get("additionalProperties") != PORTABLE_VALUE_REF:

--- a/scripts/check_openapi_skeleton.py
+++ b/scripts/check_openapi_skeleton.py
@@ -511,6 +511,9 @@ def main() -> int:
             "x-jarvis-protocol.chunk_lock.locks missing: "
             + ", ".join(sorted(missing_locks))
         )
+    declared_excludes = set(chunk_lock.get("excludes", []))
+    if "control-plane schemas" in declared_excludes:
+        return fail("chunk_lock.excludes must name out-of-scope schemas directly")
 
     components = data["components"]
     if not isinstance(components, dict):


### PR DESCRIPTION
## Summary

- add OpenAPI schemas for WorkSession, JarvisEvent, Policy, and PolicyDecision
- add closed supporting schemas for canonicalization, event payload, policy rules, escalation rules, constraints, and action requests
- enforce conditional PolicyDecision.request_id for deny and review_required results
- extend OpenAPI validation for recursive local refs, locked optional fields, chunk locks, forbidden fields, and event payload extension rejection
- add Week 2 chunk 3 planning doc and OpenAPI README lock note

## Validation

- PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_openapi_skeleton.py
- PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_week1_wording.py
- PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_markdown_links.py
- git diff --check
- strict stale-boundary grep scan

## Reviewer lanes

- protocol alignment: PASS after requiring request_id for deny/review_required PolicyDecision
- OpenAPI correctness: PASS after recursive local ref and locked optional-field validation
- security/portable boundary: PASS after removing broad event payload extensions
- wording/public boundary: PASS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added protocol-level schemas for work sessions, append-only events, policy rules, and policy decisions.

* **Documentation**
  * Expanded protocol docs and planning materials describing the new schema chunk, its scope, boundaries, and acceptance criteria.

* **Tests**
  * Strengthened schema validation and checks (including enum values, conditional requirements, reference resolution, and forbidden-field enforcement).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->