### PR TITLE
Add control-plane OpenAPI schemas

### DIFF
--- a/docs/openapi/README.md
+++ b/docs/openapi/README.md
@@ -65,6 +65,18 @@ Chunk 3 does not define Request, Review, Takeover, Contribution,
 EvidenceManifest, learning schemas, path operation bodies, examples, or
 conformance fixtures.
 
+Chunk 4 defines the control-plane schemas:
+
+```txt
+Request
+Review
+ApprovalScope
+Takeover
+```
+
+Chunk 4 does not define Contribution, EvidenceManifest, learning schemas, path
+operation bodies, examples, or conformance fixtures.
+
 ## Boundary
 
 Compatible hosts publish their own server URLs, identity providers, credential

--- a/docs/openapi/jarvis-openapi.yaml
+++ b/docs/openapi/jarvis-openapi.yaml
@@ -139,6 +139,58 @@ components:
         - private
         - confidential
         - restricted
+    RequestType:
+      type: string
+      enum:
+        - permission
+        - context
+        - judgment
+        - review
+        - correction
+        - takeover
+        - escalation
+    RequestStatus:
+      type: string
+      enum:
+        - pending
+        - acknowledged
+        - approved
+        - denied
+        - narrowed
+        - answered
+        - needs_revision
+        - takeover
+        - expired
+        - cancelled
+        - superseded
+    BlockingScope:
+      type: string
+      enum:
+        - action
+        - branch
+        - artifact
+        - tool_call
+        - external_send
+        - final_submission
+        - work_session
+    ReviewDecision:
+      type: string
+      enum:
+        - approve
+        - deny
+        - narrow
+        - correct
+        - takeover
+        - needs_revision
+    TakeoverState:
+      type: string
+      enum:
+        - requested
+        - locked
+        - human_active
+        - reconciliation_required
+        - resumed
+        - closed
     AuthorityScope:
       type: object
       additionalProperties: false
@@ -377,6 +429,142 @@ components:
           items:
             $ref: "#/components/schemas/OpaqueRef"
           uniqueItems: true
+    RequestOption:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - label
+        - effect
+      properties:
+        id:
+          $ref: "#/components/schemas/JarvisId"
+        label:
+          type: string
+          minLength: 1
+        effect:
+          type: string
+          minLength: 1
+        risk_class:
+          $ref: "#/components/schemas/RiskClass"
+        scope_ref:
+          $ref: "#/components/schemas/OpaqueRef"
+    SafeFallback:
+      type: object
+      additionalProperties: false
+      required:
+        - action
+        - reason
+      properties:
+        action:
+          type: string
+          enum:
+            - continue_unrelated_safe_work
+            - continue_with_limited_evidence
+            - cancel_blocked_scope
+            - keep_blocked_scope_stopped
+        reason:
+          type: string
+          minLength: 1
+        limitation_ref:
+          $ref: "#/components/schemas/OpaqueRef"
+    ApprovalBoundary:
+      type: object
+      additionalProperties: false
+      required:
+        - scope_ref
+      properties:
+        scope_ref:
+          $ref: "#/components/schemas/OpaqueRef"
+        grant_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/OpaqueRef"
+          uniqueItems: true
+        constraint_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/OpaqueRef"
+          uniqueItems: true
+    TakeoverScope:
+      type: object
+      additionalProperties: false
+      required:
+        - blocking_scope
+        - scope_ref
+      properties:
+        blocking_scope:
+          $ref: "#/components/schemas/BlockingScope"
+        scope_ref:
+          $ref: "#/components/schemas/OpaqueRef"
+        normalized_action_hash:
+          type: string
+          minLength: 1
+        artifact_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/OpaqueRef"
+          uniqueItems: true
+      x-jarvis-forbidden-fields:
+        - runtime_lock_id
+        - database_primary_key
+        - credential
+        - raw_auth_token
+        - ui_session_id
+    ApprovalScope:
+      type: object
+      additionalProperties: false
+      required:
+        - request_id
+        - review_id
+        - policy_decision_id
+        - request_revision
+        - request_event_hash
+        - normalized_action_hash
+        - approved_action
+        - allowed_scope
+        - denied_scope
+        - expires_at
+        - max_uses
+        - applies_to_work_session_id
+        - applies_to_actor_id
+      properties:
+        request_id:
+          $ref: "#/components/schemas/JarvisId"
+        review_id:
+          $ref: "#/components/schemas/JarvisId"
+        policy_decision_id:
+          $ref: "#/components/schemas/JarvisId"
+        request_revision:
+          type: integer
+          minimum: 0
+        request_event_hash:
+          type: string
+          minLength: 1
+        normalized_action_hash:
+          type: string
+          minLength: 1
+        approved_action:
+          $ref: "#/components/schemas/PolicyActionRequest"
+        allowed_scope:
+          $ref: "#/components/schemas/ApprovalBoundary"
+        denied_scope:
+          $ref: "#/components/schemas/ApprovalBoundary"
+        expires_at:
+          $ref: "#/components/schemas/Timestamp"
+        max_uses:
+          type: integer
+          minimum: 1
+        applies_to_work_session_id:
+          $ref: "#/components/schemas/JarvisId"
+        applies_to_actor_id:
+          $ref: "#/components/schemas/JarvisId"
+      x-jarvis-forbidden-fields:
+        - unbounded_approval
+        - implicit_authority_grant
+        - credential
+        - raw_auth_token
+        - database_primary_key
     Worker:
       type: object
       additionalProperties: false
@@ -822,6 +1010,365 @@ components:
         - provider_secret
         - database_primary_key
         - runtime_decision_object
+    Request:
+      type: object
+      additionalProperties: false
+      allOf:
+        - if:
+            properties:
+              status:
+                enum:
+                  - pending
+                  - acknowledged
+          then:
+            not:
+              anyOf:
+                - required:
+                    - resolved_at
+                - required:
+                    - resolved_by_review_id
+                - required:
+                    - resolved_by_takeover_id
+                - required:
+                    - closed_by_event_ref
+                - required:
+                    - superseded_by_request_id
+        - if:
+            properties:
+              status:
+                enum:
+                  - approved
+                  - denied
+                  - narrowed
+                  - answered
+                  - needs_revision
+                  - takeover
+                  - expired
+                  - cancelled
+                  - superseded
+          then:
+            required:
+              - resolved_at
+        - if:
+            properties:
+              status:
+                enum:
+                  - approved
+                  - denied
+                  - narrowed
+                  - answered
+                  - needs_revision
+          then:
+            required:
+              - resolved_by_review_id
+        - if:
+            properties:
+              status:
+                const: takeover
+          then:
+            required:
+              - resolved_by_takeover_id
+        - if:
+            properties:
+              status:
+                enum:
+                  - expired
+                  - cancelled
+                  - superseded
+          then:
+            required:
+              - closed_by_event_ref
+        - if:
+            properties:
+              status:
+                const: superseded
+          then:
+            required:
+              - superseded_by_request_id
+      required:
+        - id
+        - protocol_version
+        - work_session_id
+        - requester_actor_id
+        - requester_worker_id
+        - target_human_worker_id
+        - policy_decision_id
+        - type
+        - blocking_scope
+        - reason_code
+        - reason_summary
+        - requested_action
+        - requested_outcome
+        - risk_class
+        - human_decision_needed
+        - options
+        - default_if_no_response
+        - status
+        - created_at
+        - expires_at
+      properties:
+        id:
+          $ref: "#/components/schemas/JarvisId"
+        protocol_version:
+          type: string
+          const: v0.1
+        work_session_id:
+          $ref: "#/components/schemas/JarvisId"
+        requester_actor_id:
+          $ref: "#/components/schemas/JarvisId"
+        requester_worker_id:
+          $ref: "#/components/schemas/JarvisId"
+        target_human_worker_id:
+          $ref: "#/components/schemas/JarvisId"
+        policy_decision_id:
+          $ref: "#/components/schemas/JarvisId"
+        type:
+          $ref: "#/components/schemas/RequestType"
+        blocking_scope:
+          $ref: "#/components/schemas/BlockingScope"
+        reason_code:
+          type: string
+          minLength: 1
+        reason_summary:
+          type: string
+          minLength: 1
+        requested_action:
+          $ref: "#/components/schemas/PolicyActionRequest"
+        requested_outcome:
+          type: string
+          minLength: 1
+        risk_class:
+          $ref: "#/components/schemas/RiskClass"
+        human_decision_needed:
+          type: string
+          minLength: 1
+        options:
+          type: array
+          items:
+            $ref: "#/components/schemas/RequestOption"
+          minItems: 1
+        default_if_no_response:
+          $ref: "#/components/schemas/SafeFallback"
+        status:
+          $ref: "#/components/schemas/RequestStatus"
+        created_at:
+          $ref: "#/components/schemas/Timestamp"
+        expires_at:
+          $ref: "#/components/schemas/Timestamp"
+        missing_permission_or_context:
+          type: string
+          minLength: 1
+        policy_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/OpaqueRef"
+          uniqueItems: true
+        data_sensitivity:
+          $ref: "#/components/schemas/DataSensitivity"
+        recommended_option:
+          $ref: "#/components/schemas/JarvisId"
+        safer_alternatives:
+          type: array
+          items:
+            $ref: "#/components/schemas/RequestOption"
+          uniqueItems: true
+        evidence_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/OpaqueRef"
+          uniqueItems: true
+        artifact_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/OpaqueRef"
+          uniqueItems: true
+        contribution_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/JarvisId"
+          uniqueItems: true
+        resolved_at:
+          $ref: "#/components/schemas/Timestamp"
+        resolved_by_review_id:
+          $ref: "#/components/schemas/JarvisId"
+        resolved_by_takeover_id:
+          $ref: "#/components/schemas/JarvisId"
+        closed_by_event_ref:
+          $ref: "#/components/schemas/OpaqueRef"
+        superseded_by_request_id:
+          $ref: "#/components/schemas/JarvisId"
+        duplicate_of_request_id:
+          $ref: "#/components/schemas/JarvisId"
+      x-jarvis-forbidden-fields:
+        - private_inbox_id
+        - notification_provider_id
+        - credential
+        - raw_auth_token
+        - database_primary_key
+        - runtime_state
+        - provider_secret
+        - billing_field
+        - deployment_field
+        - ui_state
+        - hidden_policy_trace
+        - unbounded_approval
+        - implicit_authority_grant
+    Review:
+      type: object
+      additionalProperties: false
+      allOf:
+        - if:
+            properties:
+              decision:
+                enum:
+                  - approve
+                  - narrow
+          then:
+            required:
+              - approval_scope
+        - if:
+            properties:
+              decision:
+                enum:
+                  - deny
+                  - correct
+                  - takeover
+                  - needs_revision
+          then:
+            not:
+              required:
+                - approval_scope
+        - if:
+            properties:
+              decision:
+                const: takeover
+          then:
+            required:
+              - takeover_id
+      required:
+        - id
+        - work_session_id
+        - reviewer_actor_id
+        - reviewer_worker_id
+        - target_ref
+        - decision
+        - created_at
+      properties:
+        id:
+          $ref: "#/components/schemas/JarvisId"
+        work_session_id:
+          $ref: "#/components/schemas/JarvisId"
+        reviewer_actor_id:
+          $ref: "#/components/schemas/JarvisId"
+        reviewer_worker_id:
+          $ref: "#/components/schemas/JarvisId"
+        target_ref:
+          $ref: "#/components/schemas/OpaqueRef"
+        decision:
+          $ref: "#/components/schemas/ReviewDecision"
+        created_at:
+          $ref: "#/components/schemas/Timestamp"
+        comments:
+          type: string
+          minLength: 1
+        required_changes:
+          type: array
+          items:
+            type: string
+            minLength: 1
+        approval_scope:
+          $ref: "#/components/schemas/ApprovalScope"
+        takeover_id:
+          $ref: "#/components/schemas/JarvisId"
+      x-jarvis-forbidden-fields:
+        - private_comment_thread_id
+        - credential
+        - raw_auth_token
+        - database_primary_key
+        - ui_state
+        - unbounded_approval
+        - implicit_authority_grant
+    Takeover:
+      type: object
+      additionalProperties: false
+      allOf:
+        - if:
+            properties:
+              state:
+                const: resumed
+          then:
+            required:
+              - reconciliation_refs
+              - resumed_by_actor_id
+              - resolved_at
+        - if:
+            properties:
+              state:
+                enum:
+                  - requested
+                  - locked
+                  - human_active
+          then:
+            not:
+              anyOf:
+                - required:
+                    - resumed_by_actor_id
+                - required:
+                    - reconciliation_refs
+                - required:
+                    - resolved_at
+      required:
+        - id
+        - work_session_id
+        - requested_by_actor_id
+        - controlling_actor_id
+        - affected_scope
+        - reason
+        - lock_epoch
+        - state
+        - created_at
+      properties:
+        id:
+          $ref: "#/components/schemas/JarvisId"
+        work_session_id:
+          $ref: "#/components/schemas/JarvisId"
+        requested_by_actor_id:
+          $ref: "#/components/schemas/JarvisId"
+        controlling_actor_id:
+          $ref: "#/components/schemas/JarvisId"
+        request_id:
+          $ref: "#/components/schemas/JarvisId"
+        affected_scope:
+          $ref: "#/components/schemas/TakeoverScope"
+        reason:
+          type: string
+          minLength: 1
+        lock_epoch:
+          type: integer
+          minimum: 0
+        state:
+          $ref: "#/components/schemas/TakeoverState"
+        created_at:
+          $ref: "#/components/schemas/Timestamp"
+        resumed_by_actor_id:
+          $ref: "#/components/schemas/JarvisId"
+        reconciliation_notes:
+          type: string
+          minLength: 1
+        reconciliation_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/OpaqueRef"
+          minItems: 1
+          uniqueItems: true
+        resolved_at:
+          $ref: "#/components/schemas/Timestamp"
+      x-jarvis-forbidden-fields:
+        - runtime_lock_id
+        - database_primary_key
+        - credential
+        - raw_auth_token
+        - ui_session_id
   parameters: {}
   headers: {}
   requestBodies: {}
@@ -865,7 +1412,7 @@ x-jarvis-protocol:
     - task marketplace
     - host workflow
   chunk_lock:
-    id: week-2-chunk-3-worksession-policy-schemas
+    id: week-2-chunk-4-control-plane-schemas
     locks:
       - OpenAPI 3.1.1 entry point
       - v0.1 protocol metadata
@@ -881,12 +1428,14 @@ x-jarvis-protocol:
       - JarvisEvent schema
       - Policy schema
       - PolicyDecision schema
+      - Request schema
+      - Review schema
+      - ApprovalScope schema
+      - Takeover schema
     excludes:
       - path operation bodies
       - operation-specific security requirements
-      - Request schema
-      - Review schema
-      - Takeover schema
+      - Contribution schema
       - evidence and learning schemas
       - examples
       - conformance fixtures

--- a/docs/planning/week-2/README.md
+++ b/docs/planning/week-2/README.md
@@ -14,6 +14,8 @@ storage, model calls, adapters, or conformance fixtures beyond the active chunk.
    Lock shared schema primitives, Worker, Actor, HumanWorker, and AgentWorker.
 3. [chunk-3-worksession-policy-schemas.md](./chunk-3-worksession-policy-schemas.md)
    Lock WorkSession, JarvisEvent, Policy, and PolicyDecision schemas.
+4. [chunk-4-control-plane-schemas.md](./chunk-4-control-plane-schemas.md)
+   Lock Request, Review, ApprovalScope, and Takeover schemas.
 
 ## Week 2 Done State
 

--- a/docs/planning/week-2/chunk-4-control-plane-schemas.md
+++ b/docs/planning/week-2/chunk-4-control-plane-schemas.md
@@ -1,0 +1,79 @@
+# Week 2 Chunk 4: Control-Plane Schemas
+
+## Goal
+
+Encode the OpenAPI schemas that make blocked work, human judgment, bounded
+approval, and human takeover explicit protocol records.
+
+## Scope
+
+This chunk locks:
+
+- `Request`
+- `Review`
+- `ApprovalScope`
+- `Takeover`
+- Request type enum
+- Request status enum
+- blocking scope enum
+- Review decision enum
+- Takeover state enum
+- request option schema
+- safe fallback schema
+- approval boundary schema
+- forbidden-field metadata for the new schemas
+- schema validation for locked required fields
+- conditional validation for Request, Review, and Takeover lifecycle rules
+
+This chunk does not define:
+
+- Contribution schema
+- EvidenceManifest schema
+- LearningRecord, MemoryProposal, or SkillProposal schema
+- OutcomeReport schema
+- path operation bodies
+- operation-specific security requirements
+- examples
+- conformance fixtures
+- runtime execution
+- host implementation behavior
+
+## Files
+
+- [../../openapi/jarvis-openapi.yaml](../../openapi/jarvis-openapi.yaml)
+- [../../openapi/README.md](../../openapi/README.md)
+- [../../../scripts/check_openapi_skeleton.py](../../../scripts/check_openapi_skeleton.py)
+
+## Acceptance
+
+Chunk 4 is complete when:
+
+- the OpenAPI file parses as YAML
+- `Request`, `Review`, `ApprovalScope`, and `Takeover` exist under
+  `components.schemas`
+- the new schemas encode the required fields from
+  [../../protocol/11-core-protocol-objects.md](../../protocol/11-core-protocol-objects.md)
+- the new schemas reject unspecified top-level fields with
+  `additionalProperties: false`
+- the new schemas list forbidden host-private fields in
+  `x-jarvis-forbidden-fields`
+- resolved Request statuses require resolver or closing refs
+- pending and acknowledged Requests reject resolver and closing refs
+- superseded Requests require `superseded_by_request_id`
+- Review decisions `approve` and `narrow` require `ApprovalScope`
+- Review decisions `deny`, `correct`, `takeover`, and `needs_revision` reject
+  `ApprovalScope`
+- Review decision `takeover` requires `takeover_id`
+- Takeover records `affected_scope.blocking_scope` and `affected_scope.scope_ref`
+- Takeover state `resumed` requires reconciliation refs
+- Takeover states `requested`, `locked`, and `human_active` reject resume refs
+- no schema includes credentials, secrets, database ids, runtime ids, billing
+  fields, deployment ids, notification provider ids, inbox ids, unbounded
+  approval, implicit authority grants, or UI state as protocol properties
+- local validation passes
+
+## Boundary
+
+These schemas record the control plane for human-agent collaboration. They do
+not deliver notifications, render inboxes, execute approvals, lock runtime
+processes, store events, authenticate callers, or define host workflow.

--- a/docs/protocol/11-core-protocol-objects.md
+++ b/docs/protocol/11-core-protocol-objects.md
@@ -493,6 +493,13 @@ resolved_by_takeover_id
 
 closed_by_event_ref
   required when status is expired, cancelled, or superseded
+
+superseded_by_request_id
+  required when status is superseded
+
+resolved_at, resolved_by_review_id, resolved_by_takeover_id,
+closed_by_event_ref, and superseded_by_request_id
+  forbidden when status is pending or acknowledged
 ```
 
 Forbidden fields:
@@ -535,6 +542,7 @@ Optional fields:
 ```txt
 comments
 required_changes
+takeover_id
 ```
 
 Conditionally required fields:
@@ -543,6 +551,9 @@ Conditionally required fields:
 approval_scope
   required when decision is approve or narrow
   forbidden when decision is deny, correct, takeover, or needs_revision
+
+takeover_id
+  required when decision is takeover
 ```
 
 Nested component:
@@ -585,6 +596,7 @@ id
 work_session_id
 requested_by_actor_id
 controlling_actor_id
+affected_scope
 reason
 lock_epoch
 state
@@ -599,7 +611,9 @@ Optional fields:
 
 ```txt
 resumed_by_actor_id
+request_id
 reconciliation_notes
+reconciliation_refs
 resolved_at
 ```
 
@@ -608,6 +622,22 @@ Conditionally required fields:
 ```txt
 reconciliation_refs
   required before state becomes resumed
+
+resumed_by_actor_id and resolved_at
+  required when state is resumed
+
+resumed_by_actor_id, reconciliation_refs, and resolved_at
+  forbidden when state is requested, locked, or human_active
+```
+
+Nested component:
+
+```txt
+TakeoverScope
+  blocking_scope
+  scope_ref
+  normalized_action_hash
+  artifact_refs
 ```
 
 Forbidden fields:
@@ -1345,6 +1375,7 @@ Rules:
 - Resolved Request status records `resolved_by_review_id` or
   `resolved_by_takeover_id`.
 - Closed Request status records `closed_by_event_ref`.
+- Superseded Request status records `superseded_by_request_id`.
 - Approval is narrower than the requested action when the human restricts scope.
 - Every Request includes options, risk, and default behavior when the human does
   not respond.
@@ -1373,6 +1404,7 @@ Review
   comments
   required_changes
   approval_scope
+  takeover_id
   created_at
 ```
 
@@ -1389,6 +1421,7 @@ Rules:
   Actor, and to the Request revision, Request event hash, PolicyDecision, and
   normalized action hash.
 - Review creates Takeover only when the decision is `takeover`.
+- Review with decision `takeover` records `takeover_id`.
 - Review does not silently mutate Policy, MemoryProposal, SkillProposal, or
   durable learning.
 - Review creates LearningRecord, MemoryProposal, SkillProposal, or policy
@@ -1405,6 +1438,8 @@ Takeover
   work_session_id
   requested_by_actor_id
   controlling_actor_id
+  request_id
+  affected_scope
   reason
   lock_epoch
   state
@@ -1429,6 +1464,10 @@ closed
 Rules:
 
 - Takeover pauses autonomous continuation for the affected WorkSession scope.
+- `affected_scope` declares the blocked WorkSession scope under direct human
+  control through `blocking_scope` and `scope_ref`.
+- `request_id` links the Takeover to the Request it resolves when the Takeover
+  is created from a Request.
 - Takeover increments the lock epoch.
 - Agent actions from an old lock epoch are stale and rejected.
 - Resume requires reconciliation.

--- a/docs/protocol/12-request-protocol.md
+++ b/docs/protocol/12-request-protocol.md
@@ -312,6 +312,7 @@ cancelled
 superseded
   A newer Request replaces this Request while preserving the blocked action
   hash, policy decision, blocking scope, risk, and event references.
+  `superseded_by_request_id` identifies the replacement Request.
 ```
 
 Human resolution of a Request requires Review or Takeover. Expiry,
@@ -331,6 +332,13 @@ resolved_by_takeover_id
 
 closed_by_event_ref
   required when status is expired, cancelled, or superseded
+
+superseded_by_request_id
+  required when status is superseded
+
+resolved_at, resolved_by_review_id, resolved_by_takeover_id,
+closed_by_event_ref, and superseded_by_request_id
+  forbidden when status is pending or acknowledged
 ```
 
 Missing resolver refs reject with these errors:
@@ -346,6 +354,9 @@ missing_takeover_resolution
 missing_jarvis_event
   Request status is expired, cancelled, or superseded without
   closed_by_event_ref.
+
+missing_superseding_request
+  Request status is superseded without superseded_by_request_id.
 ```
 
 Allowed transitions:
@@ -467,6 +478,7 @@ correct
 
 takeover
   resolves the target Request by creating or referencing Takeover.
+  `takeover_id` records the Takeover that carries the lock epoch.
 
 needs_revision
   resolves the target Request and requires AgentWorker revision before the
@@ -481,6 +493,9 @@ remain governed.
 ## Takeover Lifecycle
 
 Takeover is temporary direct HumanWorker control over a declared scope.
+Every Takeover records `affected_scope.blocking_scope` and
+`affected_scope.scope_ref`. Takeover records `request_id` when it resolves a
+Request.
 
 Takeover states:
 

--- a/scripts/check_openapi_skeleton.py
+++ b/scripts/check_openapi_skeleton.py
@@ -55,6 +55,11 @@ REQUIRED_SCHEMAS = {
     "PolicyDecisionResult",
     "RiskClass",
     "DataSensitivity",
+    "RequestType",
+    "RequestStatus",
+    "BlockingScope",
+    "ReviewDecision",
+    "TakeoverState",
     "AuthorityScope",
     "AccountabilityScope",
     "CapabilityRef",
@@ -68,6 +73,11 @@ REQUIRED_SCHEMAS = {
     "PolicyActionRule",
     "PolicyRequestLimits",
     "PolicyActionRequest",
+    "RequestOption",
+    "SafeFallback",
+    "ApprovalBoundary",
+    "TakeoverScope",
+    "ApprovalScope",
     "Worker",
     "Actor",
     "HumanWorker",
@@ -76,6 +86,9 @@ REQUIRED_SCHEMAS = {
     "JarvisEvent",
     "Policy",
     "PolicyDecision",
+    "Request",
+    "Review",
+    "Takeover",
 }
 
 REQUIRED_SCHEMA_FIELDS = {
@@ -161,6 +174,67 @@ REQUIRED_SCHEMA_FIELDS = {
         "reason",
         "created_at",
     },
+    "ApprovalScope": {
+        "request_id",
+        "review_id",
+        "policy_decision_id",
+        "request_revision",
+        "request_event_hash",
+        "normalized_action_hash",
+        "approved_action",
+        "allowed_scope",
+        "denied_scope",
+        "expires_at",
+        "max_uses",
+        "applies_to_work_session_id",
+        "applies_to_actor_id",
+    },
+    "TakeoverScope": {
+        "blocking_scope",
+        "scope_ref",
+    },
+    "Request": {
+        "id",
+        "protocol_version",
+        "work_session_id",
+        "requester_actor_id",
+        "requester_worker_id",
+        "target_human_worker_id",
+        "policy_decision_id",
+        "type",
+        "blocking_scope",
+        "reason_code",
+        "reason_summary",
+        "requested_action",
+        "requested_outcome",
+        "risk_class",
+        "human_decision_needed",
+        "options",
+        "default_if_no_response",
+        "status",
+        "created_at",
+        "expires_at",
+    },
+    "Review": {
+        "id",
+        "work_session_id",
+        "reviewer_actor_id",
+        "reviewer_worker_id",
+        "target_ref",
+        "decision",
+        "created_at",
+    },
+    "Takeover": {
+        "id",
+        "work_session_id",
+        "requested_by_actor_id",
+        "controlling_actor_id",
+        "affected_scope",
+        "reason",
+        "lock_epoch",
+        "state",
+        "created_at",
+    },
 }
 
 OPTIONAL_SCHEMA_FIELDS = {
@@ -189,6 +263,39 @@ OPTIONAL_SCHEMA_FIELDS = {
         "denied_grant_refs",
         "request_id",
         "evidence_refs",
+    },
+    "Request": {
+        "missing_permission_or_context",
+        "policy_refs",
+        "data_sensitivity",
+        "recommended_option",
+        "safer_alternatives",
+        "evidence_refs",
+        "artifact_refs",
+        "contribution_refs",
+        "resolved_at",
+        "resolved_by_review_id",
+        "resolved_by_takeover_id",
+        "closed_by_event_ref",
+        "superseded_by_request_id",
+        "duplicate_of_request_id",
+    },
+    "Review": {
+        "comments",
+        "required_changes",
+        "approval_scope",
+        "takeover_id",
+    },
+    "TakeoverScope": {
+        "normalized_action_hash",
+        "artifact_refs",
+    },
+    "Takeover": {
+        "request_id",
+        "resumed_by_actor_id",
+        "reconciliation_notes",
+        "reconciliation_refs",
+        "resolved_at",
     },
 }
 
@@ -248,6 +355,53 @@ REQUIRED_ENUMS = {
         "confidential",
         "restricted",
     },
+    "RequestType": {
+        "permission",
+        "context",
+        "judgment",
+        "review",
+        "correction",
+        "takeover",
+        "escalation",
+    },
+    "RequestStatus": {
+        "pending",
+        "acknowledged",
+        "approved",
+        "denied",
+        "narrowed",
+        "answered",
+        "needs_revision",
+        "takeover",
+        "expired",
+        "cancelled",
+        "superseded",
+    },
+    "BlockingScope": {
+        "action",
+        "branch",
+        "artifact",
+        "tool_call",
+        "external_send",
+        "final_submission",
+        "work_session",
+    },
+    "ReviewDecision": {
+        "approve",
+        "deny",
+        "narrow",
+        "correct",
+        "takeover",
+        "needs_revision",
+    },
+    "TakeoverState": {
+        "requested",
+        "locked",
+        "human_active",
+        "reconciliation_required",
+        "resumed",
+        "closed",
+    },
 }
 
 REQUIRED_CLOSED_OBJECT_SCHEMAS = {
@@ -264,6 +418,11 @@ REQUIRED_CLOSED_OBJECT_SCHEMAS = {
     "PolicyActionRule",
     "PolicyRequestLimits",
     "PolicyActionRequest",
+    "RequestOption",
+    "SafeFallback",
+    "ApprovalBoundary",
+    "TakeoverScope",
+    "ApprovalScope",
     "Worker",
     "Actor",
     "HumanWorker",
@@ -272,6 +431,9 @@ REQUIRED_CLOSED_OBJECT_SCHEMAS = {
     "JarvisEvent",
     "Policy",
     "PolicyDecision",
+    "Request",
+    "Review",
+    "Takeover",
 }
 
 REQUIRED_FORBIDDEN_METADATA = {
@@ -339,6 +501,51 @@ REQUIRED_FORBIDDEN_METADATA = {
         "database_primary_key",
         "runtime_decision_object",
     },
+    "TakeoverScope": {
+        "runtime_lock_id",
+        "database_primary_key",
+        "credential",
+        "raw_auth_token",
+        "ui_session_id",
+    },
+    "ApprovalScope": {
+        "unbounded_approval",
+        "implicit_authority_grant",
+        "credential",
+        "raw_auth_token",
+        "database_primary_key",
+    },
+    "Request": {
+        "private_inbox_id",
+        "notification_provider_id",
+        "credential",
+        "raw_auth_token",
+        "database_primary_key",
+        "runtime_state",
+        "provider_secret",
+        "billing_field",
+        "deployment_field",
+        "ui_state",
+        "hidden_policy_trace",
+        "unbounded_approval",
+        "implicit_authority_grant",
+    },
+    "Review": {
+        "private_comment_thread_id",
+        "credential",
+        "raw_auth_token",
+        "database_primary_key",
+        "ui_state",
+        "unbounded_approval",
+        "implicit_authority_grant",
+    },
+    "Takeover": {
+        "runtime_lock_id",
+        "database_primary_key",
+        "credential",
+        "raw_auth_token",
+        "ui_session_id",
+    },
 }
 
 FORBIDDEN_SCHEMA_PROPERTIES = {
@@ -365,6 +572,16 @@ FORBIDDEN_SCHEMA_PROPERTIES = {
     "cloud_policy_id",
     "hidden_policy_trace",
     "runtime_decision_object",
+    "private_inbox_id",
+    "notification_provider_id",
+    "runtime_state",
+    "billing_field",
+    "deployment_field",
+    "unbounded_approval",
+    "implicit_authority_grant",
+    "private_comment_thread_id",
+    "runtime_lock_id",
+    "ui_session_id",
 }
 
 REQUIRED_TAGS = {
@@ -380,7 +597,7 @@ REQUIRED_TAGS = {
 
 EXPECTED_TITLE = "Jarvis Human-Agent Collaboration Protocol"
 EXPECTED_PLACEHOLDER_SERVER = "https://jarvis.example.invalid"
-EXPECTED_CHUNK_ID = "week-2-chunk-3-worksession-policy-schemas"
+EXPECTED_CHUNK_ID = "week-2-chunk-4-control-plane-schemas"
 REQUIRED_CHUNK_LOCKS = {
     "OpenAPI 3.1.1 entry point",
     "v0.1 protocol metadata",
@@ -396,6 +613,10 @@ REQUIRED_CHUNK_LOCKS = {
     "JarvisEvent schema",
     "Policy schema",
     "PolicyDecision schema",
+    "Request schema",
+    "Review schema",
+    "ApprovalScope schema",
+    "Takeover schema",
 }
 PORTABLE_VALUE_REF = {"$ref": "#/components/schemas/PortableValue"}
 FORBIDDEN_PORTABLE_KEY_PATTERN = (
@@ -436,6 +657,80 @@ def schema_requires_field_when_const(
             continue
         required = consequence.get("required", [])
         if target.get("const") == const_value and required_field in required:
+            return True
+    return False
+
+
+def schema_requires_field_when_enum(
+    schema: dict, property_name: str, enum_values: set[str], required_field: str
+) -> bool:
+    for branch in schema.get("allOf", []):
+        if not isinstance(branch, dict):
+            continue
+        condition = branch.get("if", {})
+        consequence = branch.get("then", {})
+        if not isinstance(condition, dict) or not isinstance(consequence, dict):
+            continue
+        properties = condition.get("properties", {})
+        if not isinstance(properties, dict):
+            continue
+        target = properties.get(property_name, {})
+        if not isinstance(target, dict):
+            continue
+        actual_values = set(target.get("enum", []))
+        required = consequence.get("required", [])
+        if actual_values == enum_values and required_field in required:
+            return True
+    return False
+
+
+def schema_forbids_field_when_enum(
+    schema: dict, property_name: str, enum_values: set[str], forbidden_field: str
+) -> bool:
+    for branch in schema.get("allOf", []):
+        if not isinstance(branch, dict):
+            continue
+        condition = branch.get("if", {})
+        consequence = branch.get("then", {})
+        if not isinstance(condition, dict) or not isinstance(consequence, dict):
+            continue
+        properties = condition.get("properties", {})
+        if not isinstance(properties, dict):
+            continue
+        target = properties.get(property_name, {})
+        if not isinstance(target, dict):
+            continue
+        actual_values = set(target.get("enum", []))
+        forbidden_required = consequence.get("not", {}).get("required", [])
+        if actual_values == enum_values and forbidden_field in forbidden_required:
+            return True
+    return False
+
+
+def schema_forbids_fields_when_enum(
+    schema: dict, property_name: str, enum_values: set[str], forbidden_fields: set[str]
+) -> bool:
+    for branch in schema.get("allOf", []):
+        if not isinstance(branch, dict):
+            continue
+        condition = branch.get("if", {})
+        consequence = branch.get("then", {})
+        if not isinstance(condition, dict) or not isinstance(consequence, dict):
+            continue
+        properties = condition.get("properties", {})
+        if not isinstance(properties, dict):
+            continue
+        target = properties.get(property_name, {})
+        if not isinstance(target, dict):
+            continue
+        actual_values = set(target.get("enum", []))
+        if actual_values != enum_values:
+            continue
+        forbidden = set()
+        for item in consequence.get("not", {}).get("anyOf", []):
+            if isinstance(item, dict):
+                forbidden.update(item.get("required", []))
+        if forbidden_fields <= forbidden:
             return True
     return False
 
@@ -630,6 +925,114 @@ def main() -> int:
                 "PolicyDecision must require request_id when result is "
                 + result_value
             )
+
+    request = schemas["Request"]
+    resolved_statuses = {
+        "approved",
+        "denied",
+        "narrowed",
+        "answered",
+        "needs_revision",
+        "takeover",
+        "expired",
+        "cancelled",
+        "superseded",
+    }
+    review_resolved_statuses = {
+        "approved",
+        "denied",
+        "narrowed",
+        "answered",
+        "needs_revision",
+    }
+    closed_statuses = {
+        "expired",
+        "cancelled",
+        "superseded",
+    }
+    unresolved_statuses = {
+        "pending",
+        "acknowledged",
+    }
+    unresolved_forbidden_fields = {
+        "resolved_at",
+        "resolved_by_review_id",
+        "resolved_by_takeover_id",
+        "closed_by_event_ref",
+        "superseded_by_request_id",
+    }
+    if not schema_forbids_fields_when_enum(
+        request, "status", unresolved_statuses, unresolved_forbidden_fields
+    ):
+        return fail("Request must forbid resolver refs for unresolved statuses")
+    if not schema_requires_field_when_enum(
+        request, "status", resolved_statuses, "resolved_at"
+    ):
+        return fail("Request must require resolved_at for resolved statuses")
+    if not schema_requires_field_when_enum(
+        request, "status", review_resolved_statuses, "resolved_by_review_id"
+    ):
+        return fail(
+            "Request must require resolved_by_review_id for review-resolved statuses"
+        )
+    if not schema_requires_field_when_const(
+        request, "status", "takeover", "resolved_by_takeover_id"
+    ):
+        return fail(
+            "Request must require resolved_by_takeover_id when status is takeover"
+        )
+    if not schema_requires_field_when_enum(
+        request, "status", closed_statuses, "closed_by_event_ref"
+    ):
+        return fail("Request must require closed_by_event_ref for closed statuses")
+    if not schema_requires_field_when_const(
+        request, "status", "superseded", "superseded_by_request_id"
+    ):
+        return fail(
+            "Request must require superseded_by_request_id when status is superseded"
+        )
+
+    review = schemas["Review"]
+    approval_decisions = {"approve", "narrow"}
+    non_approval_decisions = {"deny", "correct", "takeover", "needs_revision"}
+    if not schema_requires_field_when_enum(
+        review, "decision", approval_decisions, "approval_scope"
+    ):
+        return fail("Review must require approval_scope for approve and narrow")
+    if not schema_forbids_field_when_enum(
+        review, "decision", non_approval_decisions, "approval_scope"
+    ):
+        return fail(
+            "Review must forbid approval_scope for non-approval decisions"
+        )
+    if not schema_requires_field_when_const(
+        review, "decision", "takeover", "takeover_id"
+    ):
+        return fail("Review must require takeover_id when decision is takeover")
+
+    takeover = schemas["Takeover"]
+    if not schema_requires_field_when_const(
+        takeover, "state", "resumed", "reconciliation_refs"
+    ):
+        return fail("Takeover must require reconciliation_refs when state is resumed")
+    if not schema_requires_field_when_const(
+        takeover, "state", "resumed", "resumed_by_actor_id"
+    ):
+        return fail("Takeover must require resumed_by_actor_id when state is resumed")
+    if not schema_requires_field_when_const(
+        takeover, "state", "resumed", "resolved_at"
+    ):
+        return fail("Takeover must require resolved_at when state is resumed")
+    active_takeover_states = {"requested", "locked", "human_active"}
+    active_takeover_forbidden_fields = {
+        "resumed_by_actor_id",
+        "reconciliation_refs",
+        "resolved_at",
+    }
+    if not schema_forbids_fields_when_enum(
+        takeover, "state", active_takeover_states, active_takeover_forbidden_fields
+    ):
+        return fail("Takeover must forbid resume refs before reconciliation states")
 
     event_payload_properties = schemas["JarvisEventPayload"].get("properties", {})
     if "extensions" in event_payload_properties:

--- a/scripts/check_openapi_skeleton.py
+++ b/scripts/check_openapi_skeleton.py
@@ -701,9 +701,25 @@ def schema_forbids_field_when_enum(
         if not isinstance(target, dict):
             continue
         actual_values = set(target.get("enum", []))
-        forbidden_required = consequence.get("not", {}).get("required", [])
-        if actual_values == enum_values and forbidden_field in forbidden_required:
+        negative_schema = consequence.get("not")
+        if actual_values == enum_values and negative_schema_forbids_field(
+            negative_schema, forbidden_field
+        ):
             return True
+    return False
+
+
+def negative_schema_forbids_field(negative_schema, forbidden_field: str) -> bool:
+    if not isinstance(negative_schema, dict):
+        return False
+    if forbidden_field in negative_schema.get("required", []):
+        return True
+    for keyword in ("anyOf", "oneOf"):
+        for subschema in negative_schema.get(keyword, []):
+            if isinstance(subschema, dict) and forbidden_field in subschema.get(
+                "required", []
+            ):
+                return True
     return False
 
 
@@ -726,11 +742,11 @@ def schema_forbids_fields_when_enum(
         actual_values = set(target.get("enum", []))
         if actual_values != enum_values:
             continue
-        forbidden = set()
-        for item in consequence.get("not", {}).get("anyOf", []):
-            if isinstance(item, dict):
-                forbidden.update(item.get("required", []))
-        if forbidden_fields <= forbidden:
+        negative_schema = consequence.get("not")
+        if all(
+            negative_schema_forbids_field(negative_schema, forbidden_field)
+            for forbidden_field in forbidden_fields
+        ):
             return True
     return False
 


### PR DESCRIPTION
## Summary

- add OpenAPI schemas for Request, Review, ApprovalScope, Takeover, and supporting control-plane objects
- encode Request resolver/closure lifecycle rules, supersession rules, Review approval/takeover rules, and Takeover scope/resume rules
- add concrete TakeoverScope with blocking_scope and scope_ref
- extend OpenAPI validation for control-plane enums, required fields, locked optional fields, forbidden metadata, local refs, and lifecycle conditionals
- update protocol docs and Week 2 planning docs to match the locked control-plane contract

## Validation

- PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_openapi_skeleton.py
- PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_week1_wording.py
- PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_markdown_links.py
- git diff --check
- strict stale-boundary grep scan

## Reviewer lanes

- protocol lifecycle alignment: PASS
- OpenAPI correctness and validator coverage: PASS
- security / portable boundary: PASS after adding concrete TakeoverScope and stricter state guards
- public wording / boundary drift: PASS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added formal control‑plane schemas for Requests, Reviews, Takeovers plus related enums and scope/boundary objects to model approvals, decisions, and takeovers.

* **Documentation**
  * Clarified protocol and planning docs with explicit field requirements, lifecycle rules, and acceptance criteria for control‑plane records.

* **Validation**
  * Strengthened spec validation to enforce required fields, conditional rules, closed‑object constraints, forbidden host fields, and the updated chunk‑lock metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->