### PR TITLE
Add evidence and learning OpenAPI schemas

### DIFF
--- a/docs/openapi/README.md
+++ b/docs/openapi/README.md
@@ -77,6 +77,24 @@ Takeover
 Chunk 4 does not define Contribution, EvidenceManifest, learning schemas, path
 operation bodies, examples, or conformance fixtures.
 
+Chunk 5 defines the attribution, evidence, learning, proposal, and feedback
+schemas:
+
+```txt
+Contribution
+ContributorRef
+EvidenceItemRef
+EvidenceManifest
+ExportProfile
+LearningRecord
+MemoryProposal
+SkillProposal
+OutcomeReport
+```
+
+Chunk 5 does not define path operation bodies, operation-specific security
+requirements, examples, or conformance fixtures.
+
 ## Boundary
 
 Compatible hosts publish their own server URLs, identity providers, credential

--- a/docs/openapi/jarvis-openapi.yaml
+++ b/docs/openapi/jarvis-openapi.yaml
@@ -1572,6 +1572,10 @@ components:
             $ref: "#/components/schemas/ContributorRef"
           minItems: 1
           uniqueItems: true
+          x-jarvis-unique-by:
+            - worker_id
+            - actor_id
+          x-jarvis-duplicate-rejection-id: duplicate_contributor_ref
         contributor_type:
           $ref: "#/components/schemas/ContributorType"
         contribution_type:
@@ -1649,6 +1653,9 @@ components:
           items:
             $ref: "#/components/schemas/EvidenceItemRef"
           minItems: 1
+          x-jarvis-unique-by:
+            - id
+          x-jarvis-duplicate-rejection-id: duplicate_evidence_item_ref
         policy_decision_refs:
           type: array
           items:

--- a/docs/openapi/jarvis-openapi.yaml
+++ b/docs/openapi/jarvis-openapi.yaml
@@ -191,6 +191,69 @@ components:
         - reconciliation_required
         - resumed
         - closed
+    ContributorType:
+      type: string
+      enum:
+        - human
+        - agent
+        - service
+        - tool
+        - shared
+    ContributionType:
+      type: string
+      enum:
+        - intent
+        - instruction
+        - plan
+        - research
+        - execution
+        - artifact
+        - review
+        - correction
+        - decision
+        - evidence_capture
+        - memory_proposal
+        - skill_proposal
+        - submission
+    LearningSubjectType:
+      type: string
+      enum:
+        - human
+        - agent
+        - pair
+    LearningReviewState:
+      type: string
+      enum:
+        - proposed
+        - accepted
+        - rejected
+        - superseded
+    ProposalTargetType:
+      type: string
+      enum:
+        - human
+        - agent
+        - pair
+        - project
+        - task
+    MemoryProposalStatus:
+      type: string
+      enum:
+        - proposed
+        - pending_review
+        - accepted
+        - rejected
+        - superseded
+        - expired
+    SkillProposalStatus:
+      type: string
+      enum:
+        - proposed
+        - pending_review
+        - accepted
+        - rejected
+        - superseded
+        - archived
     AuthorityScope:
       type: object
       additionalProperties: false
@@ -565,6 +628,115 @@ components:
         - credential
         - raw_auth_token
         - database_primary_key
+    ContributorRef:
+      type: object
+      additionalProperties: false
+      required:
+        - worker_id
+        - actor_id
+        - contribution_role
+      properties:
+        worker_id:
+          $ref: "#/components/schemas/JarvisId"
+        actor_id:
+          $ref: "#/components/schemas/JarvisId"
+        contribution_role:
+          $ref: "#/components/schemas/ContributionRole"
+      x-jarvis-forbidden-fields:
+        - payment_account
+        - compensation_rule
+        - private_score
+        - credential
+        - database_primary_key
+    ExportProfile:
+      type: object
+      additionalProperties: false
+      required:
+        - profile
+      properties:
+        profile:
+          type: string
+          minLength: 1
+        version:
+          type: string
+          minLength: 1
+        redaction_profile_ref:
+          $ref: "#/components/schemas/OpaqueRef"
+      x-jarvis-forbidden-fields:
+        - credential
+        - raw_auth_token
+        - provider_secret
+        - database_primary_key
+        - cloud_storage_secret
+        - unredacted_secret_value
+        - raw_runtime_state
+        - host_only_database_id
+        - deployment_detail
+        - billing_data
+        - private_score
+        - ui_state
+    EvidenceItemRef:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - work_session_id
+        - source_event_refs
+        - captured_by_actor_id
+        - evidence_type
+        - artifact_ref
+        - content_hash
+        - trust_label
+        - redaction_state
+        - captured_at
+        - limitation_refs
+      properties:
+        id:
+          $ref: "#/components/schemas/JarvisId"
+        work_session_id:
+          $ref: "#/components/schemas/JarvisId"
+        source_event_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/JarvisId"
+          minItems: 1
+          uniqueItems: true
+        captured_by_actor_id:
+          $ref: "#/components/schemas/JarvisId"
+        evidence_type:
+          type: string
+          minLength: 1
+        artifact_ref:
+          $ref: "#/components/schemas/OpaqueRef"
+        content_hash:
+          type: string
+          minLength: 1
+        trust_label:
+          type: string
+          minLength: 1
+        redaction_state:
+          type: string
+          minLength: 1
+        captured_at:
+          $ref: "#/components/schemas/Timestamp"
+        limitation_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/OpaqueRef"
+          uniqueItems: true
+      x-jarvis-forbidden-fields:
+        - credential
+        - raw_auth_token
+        - provider_secret
+        - database_primary_key
+        - cloud_storage_secret
+        - unredacted_secret_value
+        - raw_runtime_state
+        - host_only_database_id
+        - deployment_detail
+        - billing_data
+        - private_score
+        - ui_state
     Worker:
       type: object
       additionalProperties: false
@@ -1369,6 +1541,488 @@ components:
         - credential
         - raw_auth_token
         - ui_session_id
+    Contribution:
+      type: object
+      additionalProperties: false
+      allOf:
+        - if:
+            properties:
+              contributor_type:
+                const: shared
+          then:
+            properties:
+              contributor_refs:
+                minItems: 2
+      required:
+        - id
+        - work_session_id
+        - contributor_refs
+        - contributor_type
+        - contribution_type
+        - event_refs
+        - created_at
+      properties:
+        id:
+          $ref: "#/components/schemas/JarvisId"
+        work_session_id:
+          $ref: "#/components/schemas/JarvisId"
+        contributor_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/ContributorRef"
+          minItems: 1
+          uniqueItems: true
+        contributor_type:
+          $ref: "#/components/schemas/ContributorType"
+        contribution_type:
+          $ref: "#/components/schemas/ContributionType"
+        event_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/JarvisId"
+          minItems: 1
+          uniqueItems: true
+        created_at:
+          $ref: "#/components/schemas/Timestamp"
+        artifact_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/OpaqueRef"
+          uniqueItems: true
+        review_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/JarvisId"
+          uniqueItems: true
+        evidence_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/JarvisId"
+          uniqueItems: true
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        limitations:
+          type: array
+          items:
+            $ref: "#/components/schemas/OpaqueRef"
+          uniqueItems: true
+      x-jarvis-forbidden-fields:
+        - payment_account
+        - compensation_rule
+        - private_score
+        - credential
+        - database_primary_key
+    EvidenceManifest:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - work_session_id
+        - generated_by_actor_id
+        - objective
+        - event_chain_root
+        - evidence_item_refs
+        - policy_decision_refs
+        - request_refs
+        - review_refs
+        - takeover_refs
+        - contribution_refs
+        - export_profile
+        - generated_at
+      properties:
+        id:
+          $ref: "#/components/schemas/JarvisId"
+        work_session_id:
+          $ref: "#/components/schemas/JarvisId"
+        generated_by_actor_id:
+          $ref: "#/components/schemas/JarvisId"
+        objective:
+          type: string
+          minLength: 1
+        event_chain_root:
+          type: string
+          minLength: 1
+        evidence_item_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/EvidenceItemRef"
+          minItems: 1
+        policy_decision_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/JarvisId"
+          uniqueItems: true
+        request_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/JarvisId"
+          uniqueItems: true
+        review_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/JarvisId"
+          uniqueItems: true
+        takeover_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/JarvisId"
+          uniqueItems: true
+        contribution_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/JarvisId"
+          minItems: 1
+          uniqueItems: true
+        export_profile:
+          $ref: "#/components/schemas/ExportProfile"
+        generated_at:
+          $ref: "#/components/schemas/Timestamp"
+        artifact_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/OpaqueRef"
+          uniqueItems: true
+        limitation_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/OpaqueRef"
+          uniqueItems: true
+        redaction_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/OpaqueRef"
+          uniqueItems: true
+      x-jarvis-forbidden-fields:
+        - credential
+        - raw_auth_token
+        - provider_secret
+        - database_primary_key
+        - cloud_storage_secret
+        - unredacted_secret_value
+        - raw_runtime_state
+        - host_only_database_id
+        - deployment_detail
+        - billing_data
+        - private_score
+        - ui_state
+      x-jarvis-invariants:
+        - final_export_requires_terminal_work_session_state
+        - sealed_evidence_manifest_rejects_mutation
+        - redaction_never_replaces_source_evidence
+    LearningRecord:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - work_session_id
+        - created_by_actor_id
+        - subject_type
+        - subject_ref
+        - lesson_type
+        - source_event_refs
+        - review_state
+        - scope
+        - created_at
+      properties:
+        id:
+          $ref: "#/components/schemas/JarvisId"
+        work_session_id:
+          $ref: "#/components/schemas/JarvisId"
+        created_by_actor_id:
+          $ref: "#/components/schemas/JarvisId"
+        subject_type:
+          $ref: "#/components/schemas/LearningSubjectType"
+        subject_ref:
+          $ref: "#/components/schemas/OpaqueRef"
+        lesson_type:
+          type: string
+          minLength: 1
+        source_event_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/JarvisId"
+          minItems: 1
+          uniqueItems: true
+        review_state:
+          $ref: "#/components/schemas/LearningReviewState"
+        scope:
+          $ref: "#/components/schemas/OpaqueRef"
+        created_at:
+          $ref: "#/components/schemas/Timestamp"
+        proposed_change:
+          $ref: "#/components/schemas/PortableValue"
+        memory_proposal_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/JarvisId"
+          uniqueItems: true
+        skill_proposal_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/JarvisId"
+          uniqueItems: true
+        outcome_report_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/JarvisId"
+          uniqueItems: true
+      x-jarvis-forbidden-fields:
+        - silent_memory_write
+        - unreviewed_skill_activation
+        - credential
+        - raw_auth_token
+        - database_primary_key
+    MemoryProposal:
+      type: object
+      additionalProperties: false
+      allOf:
+        - if:
+            properties:
+              status:
+                const: accepted
+          then:
+            required:
+              - review_refs
+      required:
+        - id
+        - work_session_id
+        - proposed_by_actor_id
+        - proposed_for
+        - memory_scope
+        - memory_type
+        - content
+        - provenance
+        - confidence
+        - review_required
+        - status
+        - created_at
+      properties:
+        id:
+          $ref: "#/components/schemas/JarvisId"
+        work_session_id:
+          $ref: "#/components/schemas/JarvisId"
+        proposed_by_actor_id:
+          $ref: "#/components/schemas/JarvisId"
+        proposed_for:
+          $ref: "#/components/schemas/ProposalTargetType"
+        memory_scope:
+          $ref: "#/components/schemas/OpaqueRef"
+        memory_type:
+          type: string
+          minLength: 1
+        content:
+          $ref: "#/components/schemas/PortableValue"
+        provenance:
+          type: array
+          items:
+            $ref: "#/components/schemas/OpaqueRef"
+          minItems: 1
+          uniqueItems: true
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        review_required:
+          type: boolean
+          const: true
+        status:
+          $ref: "#/components/schemas/MemoryProposalStatus"
+        created_at:
+          $ref: "#/components/schemas/Timestamp"
+        source_event_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/JarvisId"
+          uniqueItems: true
+        review_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/JarvisId"
+          minItems: 1
+          uniqueItems: true
+        expires_at:
+          $ref: "#/components/schemas/Timestamp"
+        learning_record_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/JarvisId"
+          uniqueItems: true
+      x-jarvis-forbidden-fields:
+        - silent_memory_write
+        - credential
+        - raw_auth_token
+        - private_embedding_store_id
+        - database_primary_key
+      x-jarvis-invariants:
+        - accepted_memory_requires_review_refs
+        - model_derived_memory_cannot_self_confirm
+        - tool_derived_memory_cannot_self_confirm
+    SkillProposal:
+      type: object
+      additionalProperties: false
+      allOf:
+        - if:
+            properties:
+              status:
+                const: accepted
+          then:
+            required:
+              - review_refs
+      required:
+        - id
+        - work_session_id
+        - proposed_by_actor_id
+        - proposed_for
+        - skill_scope
+        - skill_name
+        - trigger_conditions
+        - procedure
+        - review_checks
+        - failure_cases
+        - provenance
+        - status
+        - created_at
+      properties:
+        id:
+          $ref: "#/components/schemas/JarvisId"
+        work_session_id:
+          $ref: "#/components/schemas/JarvisId"
+        proposed_by_actor_id:
+          $ref: "#/components/schemas/JarvisId"
+        proposed_for:
+          $ref: "#/components/schemas/ProposalTargetType"
+        skill_scope:
+          $ref: "#/components/schemas/OpaqueRef"
+        skill_name:
+          type: string
+          minLength: 1
+        trigger_conditions:
+          type: array
+          items:
+            type: string
+            minLength: 1
+          minItems: 1
+        procedure:
+          type: array
+          items:
+            type: string
+            minLength: 1
+          minItems: 1
+        review_checks:
+          type: array
+          items:
+            type: string
+            minLength: 1
+          minItems: 1
+        failure_cases:
+          type: array
+          items:
+            type: string
+            minLength: 1
+          minItems: 1
+        provenance:
+          type: array
+          items:
+            $ref: "#/components/schemas/OpaqueRef"
+          minItems: 1
+          uniqueItems: true
+        status:
+          $ref: "#/components/schemas/SkillProposalStatus"
+        created_at:
+          $ref: "#/components/schemas/Timestamp"
+        required_tools:
+          type: array
+          items:
+            $ref: "#/components/schemas/OpaqueRef"
+          uniqueItems: true
+        source_event_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/JarvisId"
+          uniqueItems: true
+        review_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/JarvisId"
+          minItems: 1
+          uniqueItems: true
+        learning_record_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/JarvisId"
+          uniqueItems: true
+      x-jarvis-forbidden-fields:
+        - automatic_tool_grant
+        - unreviewed_skill_activation
+        - credential
+        - raw_auth_token
+        - database_primary_key
+      x-jarvis-invariants:
+        - accepted_skill_requires_review_refs
+        - skill_tool_access_expansion_requires_policy_review
+        - unreviewed_skill_change_cannot_activate
+    OutcomeReport:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - work_session_id
+        - source_ref
+        - reporter_ref
+        - accepted_by_actor_id
+        - outcome
+        - learning_record_refs
+        - received_at
+      properties:
+        id:
+          $ref: "#/components/schemas/JarvisId"
+        work_session_id:
+          $ref: "#/components/schemas/JarvisId"
+        source_ref:
+          $ref: "#/components/schemas/OpaqueRef"
+        reporter_ref:
+          $ref: "#/components/schemas/OpaqueRef"
+        accepted_by_actor_id:
+          $ref: "#/components/schemas/JarvisId"
+        outcome:
+          type: string
+          minLength: 1
+        learning_record_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/JarvisId"
+          minItems: 1
+          uniqueItems: true
+        received_at:
+          $ref: "#/components/schemas/Timestamp"
+        external_system_ref:
+          $ref: "#/components/schemas/OpaqueRef"
+        reporter_actor_id:
+          $ref: "#/components/schemas/JarvisId"
+        reason:
+          type: string
+          minLength: 1
+        reviewer_feedback_refs:
+          type: array
+          items:
+            $ref: "#/components/schemas/OpaqueRef"
+          uniqueItems: true
+      x-jarvis-forbidden-fields:
+        - task_marketplace_score_rule
+        - payment_status
+        - settlement_account
+        - credential
+        - raw_auth_token
+        - database_primary_key
+        - sealed_work_session_mutation
+        - sealed_evidence_mutation
+      x-jarvis-invariants:
+        - outcome_report_requires_terminal_source
+        - outcome_report_does_not_mutate_sealed_work_session
+        - outcome_report_does_not_mutate_sealed_evidence_manifest
+        - outcome_report_requires_learning_record_refs
   parameters: {}
   headers: {}
   requestBodies: {}
@@ -1412,7 +2066,7 @@ x-jarvis-protocol:
     - task marketplace
     - host workflow
   chunk_lock:
-    id: week-2-chunk-4-control-plane-schemas
+    id: week-2-chunk-5-evidence-learning-schemas
     locks:
       - OpenAPI 3.1.1 entry point
       - v0.1 protocol metadata
@@ -1432,10 +2086,15 @@ x-jarvis-protocol:
       - Review schema
       - ApprovalScope schema
       - Takeover schema
+      - Contribution schema
+      - EvidenceItemRef schema
+      - EvidenceManifest schema
+      - LearningRecord schema
+      - MemoryProposal schema
+      - SkillProposal schema
+      - OutcomeReport schema
     excludes:
       - path operation bodies
       - operation-specific security requirements
-      - Contribution schema
-      - evidence and learning schemas
       - examples
       - conformance fixtures

--- a/docs/planning/week-2/README.md
+++ b/docs/planning/week-2/README.md
@@ -16,6 +16,9 @@ storage, model calls, adapters, or conformance fixtures beyond the active chunk.
    Lock WorkSession, JarvisEvent, Policy, and PolicyDecision schemas.
 4. [chunk-4-control-plane-schemas.md](./chunk-4-control-plane-schemas.md)
    Lock Request, Review, ApprovalScope, and Takeover schemas.
+5. [chunk-5-evidence-learning-schemas.md](./chunk-5-evidence-learning-schemas.md)
+   Lock Contribution, EvidenceManifest, LearningRecord, MemoryProposal,
+   SkillProposal, and OutcomeReport schemas.
 
 ## Week 2 Done State
 

--- a/docs/planning/week-2/chunk-5-evidence-learning-schemas.md
+++ b/docs/planning/week-2/chunk-5-evidence-learning-schemas.md
@@ -65,8 +65,11 @@ Chunk 5 is complete when:
 - the new schemas list forbidden host-private fields in
   `x-jarvis-forbidden-fields`
 - shared Contribution requires multiple contributor refs
+- Contribution contributor refs declare identity uniqueness by `worker_id` and
+  `actor_id`
 - EvidenceItemRef requires at least one source event ref
 - EvidenceManifest requires evidence item refs and contribution refs
+- EvidenceManifest evidence item refs declare identity uniqueness by `id`
 - LearningRecord requires at least one source event ref
 - accepted MemoryProposal requires review refs
 - accepted SkillProposal requires review refs

--- a/docs/planning/week-2/chunk-5-evidence-learning-schemas.md
+++ b/docs/planning/week-2/chunk-5-evidence-learning-schemas.md
@@ -1,0 +1,92 @@
+# Week 2 Chunk 5: Evidence And Learning Schemas
+
+## Goal
+
+Encode the OpenAPI schemas that make attribution, portable evidence, governed
+learning, memory proposals, skill proposals, and post-session feedback explicit
+protocol records.
+
+## Scope
+
+This chunk locks:
+
+- `Contribution`
+- `ContributorRef`
+- `EvidenceItemRef`
+- `EvidenceManifest`
+- `ExportProfile`
+- `LearningRecord`
+- `MemoryProposal`
+- `SkillProposal`
+- `OutcomeReport`
+- contribution type enum
+- contributor type enum
+- learning subject type enum
+- learning review state enum
+- proposal target type enum
+- memory proposal status enum
+- skill proposal status enum
+- forbidden-field metadata for the new schemas
+- invariant metadata for sealed evidence, governed memory, governed skills, and
+  OutcomeReport boundaries
+- schema validation for locked required fields
+- conditional validation for shared Contribution attribution
+- conditional validation for accepted MemoryProposal and SkillProposal review
+  refs
+
+This chunk does not define:
+
+- path operation bodies
+- operation-specific security requirements
+- examples
+- conformance fixtures
+- runtime execution
+- host implementation behavior
+- payment, compensation, scoring, settlement, or marketplace logic
+
+## Files
+
+- [../../openapi/jarvis-openapi.yaml](../../openapi/jarvis-openapi.yaml)
+- [../../openapi/README.md](../../openapi/README.md)
+- [../../../scripts/check_openapi_skeleton.py](../../../scripts/check_openapi_skeleton.py)
+
+## Acceptance
+
+Chunk 5 is complete when:
+
+- the OpenAPI file parses as YAML
+- `Contribution`, `ContributorRef`, `EvidenceItemRef`, `EvidenceManifest`,
+  `ExportProfile`, `LearningRecord`, `MemoryProposal`, `SkillProposal`, and
+  `OutcomeReport` exist under `components.schemas`
+- the new schemas encode the required fields from
+  [../../protocol/11-core-protocol-objects.md](../../protocol/11-core-protocol-objects.md)
+- the new schemas reject unspecified top-level fields with
+  `additionalProperties: false`
+- the new schemas list forbidden host-private fields in
+  `x-jarvis-forbidden-fields`
+- shared Contribution requires multiple contributor refs
+- EvidenceItemRef requires at least one source event ref
+- EvidenceManifest requires evidence item refs and contribution refs
+- LearningRecord requires at least one source event ref
+- accepted MemoryProposal requires review refs
+- accepted SkillProposal requires review refs
+- OutcomeReport requires at least one LearningRecord ref
+- EvidenceManifest declares terminal-state export, sealed mutation rejection,
+  and redaction-source preservation invariants
+- MemoryProposal declares review and self-confirmation rejection invariants
+- SkillProposal declares review, tool-access policy review, and unreviewed
+  activation rejection invariants
+- OutcomeReport declares terminal-source, sealed WorkSession, sealed
+  EvidenceManifest, and learning-record invariants
+- no schema includes credentials, secrets, database ids, raw runtime state,
+  billing fields, deployment details, payment fields, settlement fields,
+  private scores, unreviewed memory writes, unreviewed skill activation, or UI
+  state as protocol properties
+- local validation passes
+
+## Boundary
+
+These schemas record attribution, evidence, learning, proposal, and feedback
+contracts for human-agent collaboration. They do not store files, execute
+work, activate memory, activate skills, evaluate tasks, calculate scores,
+settle payments, authenticate callers, or define host workflow.

--- a/scripts/check_openapi_skeleton.py
+++ b/scripts/check_openapi_skeleton.py
@@ -60,6 +60,13 @@ REQUIRED_SCHEMAS = {
     "BlockingScope",
     "ReviewDecision",
     "TakeoverState",
+    "ContributorType",
+    "ContributionType",
+    "LearningSubjectType",
+    "LearningReviewState",
+    "ProposalTargetType",
+    "MemoryProposalStatus",
+    "SkillProposalStatus",
     "AuthorityScope",
     "AccountabilityScope",
     "CapabilityRef",
@@ -78,6 +85,9 @@ REQUIRED_SCHEMAS = {
     "ApprovalBoundary",
     "TakeoverScope",
     "ApprovalScope",
+    "ContributorRef",
+    "ExportProfile",
+    "EvidenceItemRef",
     "Worker",
     "Actor",
     "HumanWorker",
@@ -89,6 +99,12 @@ REQUIRED_SCHEMAS = {
     "Request",
     "Review",
     "Takeover",
+    "Contribution",
+    "EvidenceManifest",
+    "LearningRecord",
+    "MemoryProposal",
+    "SkillProposal",
+    "OutcomeReport",
 }
 
 REQUIRED_SCHEMA_FIELDS = {
@@ -235,6 +251,102 @@ REQUIRED_SCHEMA_FIELDS = {
         "state",
         "created_at",
     },
+    "ContributorRef": {
+        "worker_id",
+        "actor_id",
+        "contribution_role",
+    },
+    "ExportProfile": {
+        "profile",
+    },
+    "EvidenceItemRef": {
+        "id",
+        "work_session_id",
+        "source_event_refs",
+        "captured_by_actor_id",
+        "evidence_type",
+        "artifact_ref",
+        "content_hash",
+        "trust_label",
+        "redaction_state",
+        "captured_at",
+        "limitation_refs",
+    },
+    "Contribution": {
+        "id",
+        "work_session_id",
+        "contributor_refs",
+        "contributor_type",
+        "contribution_type",
+        "event_refs",
+        "created_at",
+    },
+    "EvidenceManifest": {
+        "id",
+        "work_session_id",
+        "generated_by_actor_id",
+        "objective",
+        "event_chain_root",
+        "evidence_item_refs",
+        "policy_decision_refs",
+        "request_refs",
+        "review_refs",
+        "takeover_refs",
+        "contribution_refs",
+        "export_profile",
+        "generated_at",
+    },
+    "LearningRecord": {
+        "id",
+        "work_session_id",
+        "created_by_actor_id",
+        "subject_type",
+        "subject_ref",
+        "lesson_type",
+        "source_event_refs",
+        "review_state",
+        "scope",
+        "created_at",
+    },
+    "MemoryProposal": {
+        "id",
+        "work_session_id",
+        "proposed_by_actor_id",
+        "proposed_for",
+        "memory_scope",
+        "memory_type",
+        "content",
+        "provenance",
+        "confidence",
+        "review_required",
+        "status",
+        "created_at",
+    },
+    "SkillProposal": {
+        "id",
+        "work_session_id",
+        "proposed_by_actor_id",
+        "proposed_for",
+        "skill_scope",
+        "skill_name",
+        "trigger_conditions",
+        "procedure",
+        "review_checks",
+        "failure_cases",
+        "provenance",
+        "status",
+        "created_at",
+    },
+    "OutcomeReport": {
+        "id",
+        "work_session_id",
+        "source_ref",
+        "reporter_ref",
+        "accepted_by_actor_id",
+        "outcome",
+        "learning_record_refs",
+        "received_at",
+    },
 }
 
 OPTIONAL_SCHEMA_FIELDS = {
@@ -296,6 +408,46 @@ OPTIONAL_SCHEMA_FIELDS = {
         "reconciliation_notes",
         "reconciliation_refs",
         "resolved_at",
+    },
+    "ExportProfile": {
+        "version",
+        "redaction_profile_ref",
+    },
+    "Contribution": {
+        "artifact_refs",
+        "review_refs",
+        "evidence_refs",
+        "confidence",
+        "limitations",
+    },
+    "EvidenceManifest": {
+        "artifact_refs",
+        "limitation_refs",
+        "redaction_refs",
+    },
+    "LearningRecord": {
+        "proposed_change",
+        "memory_proposal_refs",
+        "skill_proposal_refs",
+        "outcome_report_refs",
+    },
+    "MemoryProposal": {
+        "source_event_refs",
+        "review_refs",
+        "expires_at",
+        "learning_record_refs",
+    },
+    "SkillProposal": {
+        "required_tools",
+        "source_event_refs",
+        "review_refs",
+        "learning_record_refs",
+    },
+    "OutcomeReport": {
+        "external_system_ref",
+        "reporter_actor_id",
+        "reason",
+        "reviewer_feedback_refs",
     },
 }
 
@@ -402,6 +554,62 @@ REQUIRED_ENUMS = {
         "resumed",
         "closed",
     },
+    "ContributorType": {
+        "human",
+        "agent",
+        "service",
+        "tool",
+        "shared",
+    },
+    "ContributionType": {
+        "intent",
+        "instruction",
+        "plan",
+        "research",
+        "execution",
+        "artifact",
+        "review",
+        "correction",
+        "decision",
+        "evidence_capture",
+        "memory_proposal",
+        "skill_proposal",
+        "submission",
+    },
+    "LearningSubjectType": {
+        "human",
+        "agent",
+        "pair",
+    },
+    "LearningReviewState": {
+        "proposed",
+        "accepted",
+        "rejected",
+        "superseded",
+    },
+    "ProposalTargetType": {
+        "human",
+        "agent",
+        "pair",
+        "project",
+        "task",
+    },
+    "MemoryProposalStatus": {
+        "proposed",
+        "pending_review",
+        "accepted",
+        "rejected",
+        "superseded",
+        "expired",
+    },
+    "SkillProposalStatus": {
+        "proposed",
+        "pending_review",
+        "accepted",
+        "rejected",
+        "superseded",
+        "archived",
+    },
 }
 
 REQUIRED_CLOSED_OBJECT_SCHEMAS = {
@@ -423,6 +631,9 @@ REQUIRED_CLOSED_OBJECT_SCHEMAS = {
     "ApprovalBoundary",
     "TakeoverScope",
     "ApprovalScope",
+    "ContributorRef",
+    "ExportProfile",
+    "EvidenceItemRef",
     "Worker",
     "Actor",
     "HumanWorker",
@@ -434,6 +645,12 @@ REQUIRED_CLOSED_OBJECT_SCHEMAS = {
     "Request",
     "Review",
     "Takeover",
+    "Contribution",
+    "EvidenceManifest",
+    "LearningRecord",
+    "MemoryProposal",
+    "SkillProposal",
+    "OutcomeReport",
 }
 
 REQUIRED_FORBIDDEN_METADATA = {
@@ -546,6 +763,117 @@ REQUIRED_FORBIDDEN_METADATA = {
         "raw_auth_token",
         "ui_session_id",
     },
+    "ContributorRef": {
+        "payment_account",
+        "compensation_rule",
+        "private_score",
+        "credential",
+        "database_primary_key",
+    },
+    "ExportProfile": {
+        "credential",
+        "raw_auth_token",
+        "provider_secret",
+        "database_primary_key",
+        "cloud_storage_secret",
+        "unredacted_secret_value",
+        "raw_runtime_state",
+        "host_only_database_id",
+        "deployment_detail",
+        "billing_data",
+        "private_score",
+        "ui_state",
+    },
+    "EvidenceItemRef": {
+        "credential",
+        "raw_auth_token",
+        "provider_secret",
+        "database_primary_key",
+        "cloud_storage_secret",
+        "unredacted_secret_value",
+        "raw_runtime_state",
+        "host_only_database_id",
+        "deployment_detail",
+        "billing_data",
+        "private_score",
+        "ui_state",
+    },
+    "Contribution": {
+        "payment_account",
+        "compensation_rule",
+        "private_score",
+        "credential",
+        "database_primary_key",
+    },
+    "EvidenceManifest": {
+        "credential",
+        "raw_auth_token",
+        "provider_secret",
+        "database_primary_key",
+        "cloud_storage_secret",
+        "unredacted_secret_value",
+        "raw_runtime_state",
+        "host_only_database_id",
+        "deployment_detail",
+        "billing_data",
+        "private_score",
+        "ui_state",
+    },
+    "LearningRecord": {
+        "silent_memory_write",
+        "unreviewed_skill_activation",
+        "credential",
+        "raw_auth_token",
+        "database_primary_key",
+    },
+    "MemoryProposal": {
+        "silent_memory_write",
+        "credential",
+        "raw_auth_token",
+        "private_embedding_store_id",
+        "database_primary_key",
+    },
+    "SkillProposal": {
+        "automatic_tool_grant",
+        "unreviewed_skill_activation",
+        "credential",
+        "raw_auth_token",
+        "database_primary_key",
+    },
+    "OutcomeReport": {
+        "task_marketplace_score_rule",
+        "payment_status",
+        "settlement_account",
+        "credential",
+        "raw_auth_token",
+        "database_primary_key",
+        "sealed_work_session_mutation",
+        "sealed_evidence_mutation",
+    },
+}
+
+REQUIRED_SCHEMA_INVARIANTS = {
+    "EvidenceManifest": {
+        "final_export_requires_terminal_work_session_state",
+        "sealed_evidence_manifest_rejects_mutation",
+        "redaction_never_replaces_source_evidence",
+    },
+    "MemoryProposal": {
+        "accepted_memory_requires_review_refs",
+        "model_derived_memory_cannot_self_confirm",
+        "tool_derived_memory_cannot_self_confirm",
+    },
+    "SkillProposal": {
+        "accepted_skill_requires_review_refs",
+        "skill_tool_access_expansion_requires_policy_review",
+        "unreviewed_skill_change_cannot_activate",
+    },
+    "OutcomeReport": {
+        "outcome_report_requires_terminal_source",
+        "outcome_report_does_not_mutate_sealed_work_session",
+        "outcome_report_does_not_mutate_sealed_evidence_manifest",
+        "outcome_report_requires_learning_record_refs",
+    },
 }
 
 FORBIDDEN_SCHEMA_PROPERTIES = {
@@ -582,6 +910,24 @@ FORBIDDEN_SCHEMA_PROPERTIES = {
     "private_comment_thread_id",
     "runtime_lock_id",
     "ui_session_id",
+    "payment_account",
+    "compensation_rule",
+    "private_score",
+    "cloud_storage_secret",
+    "unredacted_secret_value",
+    "raw_runtime_state",
+    "host_only_database_id",
+    "deployment_detail",
+    "billing_data",
+    "silent_memory_write",
+    "unreviewed_skill_activation",
+    "private_embedding_store_id",
+    "automatic_tool_grant",
+    "task_marketplace_score_rule",
+    "payment_status",
+    "settlement_account",
+    "sealed_work_session_mutation",
+    "sealed_evidence_mutation",
 }
 
 REQUIRED_TAGS = {
@@ -597,7 +943,7 @@ REQUIRED_TAGS = {
 
 EXPECTED_TITLE = "Jarvis Human-Agent Collaboration Protocol"
 EXPECTED_PLACEHOLDER_SERVER = "https://jarvis.example.invalid"
-EXPECTED_CHUNK_ID = "week-2-chunk-4-control-plane-schemas"
+EXPECTED_CHUNK_ID = "week-2-chunk-5-evidence-learning-schemas"
 REQUIRED_CHUNK_LOCKS = {
     "OpenAPI 3.1.1 entry point",
     "v0.1 protocol metadata",
@@ -617,6 +963,13 @@ REQUIRED_CHUNK_LOCKS = {
     "Review schema",
     "ApprovalScope schema",
     "Takeover schema",
+    "Contribution schema",
+    "EvidenceItemRef schema",
+    "EvidenceManifest schema",
+    "LearningRecord schema",
+    "MemoryProposal schema",
+    "SkillProposal schema",
+    "OutcomeReport schema",
 }
 PORTABLE_VALUE_REF = {"$ref": "#/components/schemas/PortableValue"}
 FORBIDDEN_PORTABLE_KEY_PATTERN = (
@@ -747,6 +1100,31 @@ def schema_forbids_fields_when_enum(
             negative_schema_forbids_field(negative_schema, forbidden_field)
             for forbidden_field in forbidden_fields
         ):
+            return True
+    return False
+
+
+def schema_requires_min_items_when_const(
+    schema: dict, property_name: str, const_value: str, array_field: str, min_items: int
+) -> bool:
+    for branch in schema.get("allOf", []):
+        if not isinstance(branch, dict):
+            continue
+        condition = branch.get("if", {})
+        consequence = branch.get("then", {})
+        if not isinstance(condition, dict) or not isinstance(consequence, dict):
+            continue
+        properties = condition.get("properties", {})
+        if not isinstance(properties, dict):
+            continue
+        target = properties.get(property_name, {})
+        if not isinstance(target, dict) or target.get("const") != const_value:
+            continue
+        consequence_properties = consequence.get("properties", {})
+        if not isinstance(consequence_properties, dict):
+            continue
+        array_schema = consequence_properties.get(array_field, {})
+        if isinstance(array_schema, dict) and array_schema.get("minItems") == min_items:
             return True
     return False
 
@@ -923,6 +1301,16 @@ def main() -> int:
                 + ", ".join(sorted(forbidden_metadata))
             )
 
+    for schema_name, expected_invariants in REQUIRED_SCHEMA_INVARIANTS.items():
+        actual_invariants = set(schemas[schema_name].get("x-jarvis-invariants", []))
+        if actual_invariants != expected_invariants:
+            return fail(
+                f"{schema_name} x-jarvis-invariants mismatch. expected "
+                + ", ".join(sorted(expected_invariants))
+                + "; got "
+                + ", ".join(sorted(actual_invariants))
+            )
+
     for schema_name, optional_fields in OPTIONAL_SCHEMA_FIELDS.items():
         properties = schemas[schema_name].get("properties", {})
         missing_optional = optional_fields - set(properties)
@@ -1049,6 +1437,55 @@ def main() -> int:
         takeover, "state", active_takeover_states, active_takeover_forbidden_fields
     ):
         return fail("Takeover must forbid resume refs before reconciliation states")
+
+    contribution = schemas["Contribution"]
+    if contribution["properties"]["contributor_refs"].get("minItems") != 1:
+        return fail("Contribution.contributor_refs must require at least one item")
+    if contribution["properties"]["contributor_refs"].get("uniqueItems") is not True:
+        return fail("Contribution.contributor_refs must be unique")
+    if contribution["properties"]["event_refs"].get("minItems") != 1:
+        return fail("Contribution.event_refs must require at least one event")
+    if not schema_requires_min_items_when_const(
+        contribution, "contributor_type", "shared", "contributor_refs", 2
+    ):
+        return fail("Contribution must require multiple refs for shared contribution")
+
+    evidence_item_ref = schemas["EvidenceItemRef"]
+    source_event_refs = evidence_item_ref["properties"]["source_event_refs"]
+    if source_event_refs.get("minItems") != 1:
+        return fail("EvidenceItemRef.source_event_refs must require at least one event")
+
+    evidence_manifest = schemas["EvidenceManifest"]
+    if evidence_manifest["properties"]["evidence_item_refs"].get("minItems") != 1:
+        return fail("EvidenceManifest.evidence_item_refs must require at least one item")
+    if evidence_manifest["properties"]["contribution_refs"].get("minItems") != 1:
+        return fail("EvidenceManifest.contribution_refs must require at least one item")
+
+    learning_record = schemas["LearningRecord"]
+    if learning_record["properties"]["source_event_refs"].get("minItems") != 1:
+        return fail("LearningRecord.source_event_refs must require at least one event")
+
+    memory_proposal = schemas["MemoryProposal"]
+    if not schema_requires_field_when_const(
+        memory_proposal, "status", "accepted", "review_refs"
+    ):
+        return fail("MemoryProposal must require review_refs when accepted")
+    if memory_proposal["properties"]["review_refs"].get("minItems") != 1:
+        return fail("MemoryProposal.review_refs must require at least one item")
+    if memory_proposal["properties"]["review_required"].get("const") is not True:
+        return fail("MemoryProposal.review_required must be true")
+
+    skill_proposal = schemas["SkillProposal"]
+    if not schema_requires_field_when_const(
+        skill_proposal, "status", "accepted", "review_refs"
+    ):
+        return fail("SkillProposal must require review_refs when accepted")
+    if skill_proposal["properties"]["review_refs"].get("minItems") != 1:
+        return fail("SkillProposal.review_refs must require at least one item")
+
+    outcome_report = schemas["OutcomeReport"]
+    if outcome_report["properties"]["learning_record_refs"].get("minItems") != 1:
+        return fail("OutcomeReport.learning_record_refs must require at least one item")
 
     event_payload_properties = schemas["JarvisEventPayload"].get("properties", {})
     if "extensions" in event_payload_properties:

--- a/scripts/check_openapi_skeleton.py
+++ b/scripts/check_openapi_skeleton.py
@@ -876,6 +876,17 @@ REQUIRED_SCHEMA_INVARIANTS = {
     },
 }
 
+REQUIRED_IDENTITY_UNIQUE_ARRAYS = {
+    ("Contribution", "contributor_refs"): {
+        "unique_by": ["worker_id", "actor_id"],
+        "duplicate_rejection_id": "duplicate_contributor_ref",
+    },
+    ("EvidenceManifest", "evidence_item_refs"): {
+        "unique_by": ["id"],
+        "duplicate_rejection_id": "duplicate_evidence_item_ref",
+    },
+}
+
 FORBIDDEN_SCHEMA_PROPERTIES = {
     "password",
     "credential",
@@ -1309,6 +1320,22 @@ def main() -> int:
                 + ", ".join(sorted(expected_invariants))
                 + "; got "
                 + ", ".join(sorted(actual_invariants))
+            )
+
+    for (schema_name, property_name), expected in REQUIRED_IDENTITY_UNIQUE_ARRAYS.items():
+        property_schema = schemas[schema_name]["properties"][property_name]
+        if property_schema.get("x-jarvis-unique-by") != expected["unique_by"]:
+            return fail(
+                f"{schema_name}.{property_name} must declare identity uniqueness by "
+                + ", ".join(expected["unique_by"])
+            )
+        if (
+            property_schema.get("x-jarvis-duplicate-rejection-id")
+            != expected["duplicate_rejection_id"]
+        ):
+            return fail(
+                f"{schema_name}.{property_name} must declare duplicate rejection id "
+                + expected["duplicate_rejection_id"]
             )
 
     for schema_name, optional_fields in OPTIONAL_SCHEMA_FIELDS.items():


### PR DESCRIPTION
## Summary
- add Contribution, ContributorRef, EvidenceItemRef, EvidenceManifest, ExportProfile, LearningRecord, MemoryProposal, SkillProposal, and OutcomeReport schemas
- lock attribution/evidence/learning/proposal enums and forbidden-field metadata
- enforce shared Contribution refs, evidence source refs, accepted proposal review refs, OutcomeReport learning refs, and schema invariant metadata in the OpenAPI validator
- document Week 2 Chunk 5 scope and OpenAPI chunk lock

## Validation
- PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_openapi_skeleton.py
- PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_week1_wording.py
- PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_markdown_links.py
- git diff --check
- public-boundary grep only matched the wording guard blocked-term list

## Reviewer lanes
- protocol object alignment: PASS after removing the unapproved OutcomeReport outcome enum and locking contributor ref uniqueness
- OpenAPI engineering: PASS after adding min-item validator checks
- zero-trust/export/learning safety: PASS after adding validator-required invariant metadata
- public wording and boundary: PASS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added detailed OpenAPI documentation for evidence tracking, contributions, learning records, proposals, and outcome reporting; expanded README and planning notes with goals, scope, and acceptance criteria.

* **Tests**
  * Strengthened schema validation tooling to enforce new enums, required fields, closed-object rules, invariants, uniqueness, and conditional validation for evidence and learning workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->