### PR TITLE
Add OpenAPI examples and conformance entry

### DIFF
--- a/docs/conformance/README.md
+++ b/docs/conformance/README.md
@@ -1,0 +1,14 @@
+# Jarvis Conformance
+
+This directory contains the Jarvis v0.1 conformance entry documents.
+
+Conformance proves that compatible implementations preserve the protocol
+contract for governed human-agent collaboration and shared learning.
+
+## Files
+
+- [golden-path.md](./golden-path.md) - required compatible success path.
+- [failure-modes.md](./failure-modes.md) - required rejection paths.
+
+Jarvis conformance records protocol behavior. Hosts own behavior outside the
+protocol contract.

--- a/docs/conformance/failure-modes.md
+++ b/docs/conformance/failure-modes.md
@@ -1,0 +1,86 @@
+# Failure-Mode Conformance Entry
+
+Jarvis v0.1 failure-mode conformance proves that compatible implementations
+reject unsafe or incomplete protocol records.
+
+## Required Rejections
+
+A compatible implementation MUST reject:
+
+```txt
+missing protocol version
+missing Actor header
+invalid Actor authority
+missing idempotency key
+missing request timestamp
+stale request timestamp
+missing expected WorkSession revision
+missing previous event hash
+missing PolicyDecision before AgentWorker state change
+Request resolved without Review or Takeover
+approval without bounded ApprovalScope
+stale WorkSession revision
+previous event hash mismatch
+stale Takeover continuation
+EvidenceManifest export from invalid WorkSession state
+sealed WorkSession mutation
+sealed EvidenceManifest mutation
+host-private export field
+silent memory mutation
+silent skill activation
+OutcomeReport without LearningRecord
+```
+
+## Required Rejection Ids
+
+The failure-mode conformance entry MUST include these protocol error ids:
+
+```txt
+missing_protocol_version
+missing_actor
+unauthorized_actor
+missing_idempotency_key
+missing_request_timestamp
+stale_request_timestamp
+missing_expected_work_session_revision
+missing_previous_event_hash
+missing_policy_decision
+missing_review_resolution
+missing_takeover_resolution
+invalid_approval_scope
+stale_work_session_revision
+invalid_previous_event_hash
+stale_takeover_epoch
+invalid_evidence_export_state
+sealed_work_session_mutation
+sealed_evidence_mutation
+forbidden_host_private_field
+silent_memory_mutation
+silent_skill_activation
+outcome_report_without_learning_record
+```
+
+## Required Failure Boundaries
+
+The protocol rejects a record when:
+
+```txt
+AgentWorker action changes WorkSession state without PolicyDecision.
+Request reaches human-resolved state without Review or Takeover.
+Review approval lacks bounded ApprovalScope.
+Mutation headers are missing or invalid.
+Actor authority is missing or invalid.
+WorkSession revision is stale.
+Previous event hash does not match current WorkSession state.
+Takeover lock epoch is stale.
+EvidenceManifest export occurs before a valid export state.
+Sealed WorkSession is mutated.
+Sealed EvidenceManifest is mutated.
+Export contains forbidden host-private fields.
+Memory changes without governed proposal and review state.
+Skill changes without governed proposal and review state.
+OutcomeReport lacks LearningRecord reference.
+```
+
+Failure-mode conformance protects the human-agent collaboration and learning
+loop from fake compatibility.

--- a/docs/conformance/golden-path.md
+++ b/docs/conformance/golden-path.md
@@ -1,0 +1,79 @@
+# Golden-Path Conformance Entry
+
+Jarvis v0.1 golden-path conformance proves that a compatible implementation
+records governed human-agent collaboration inside the protocol contract.
+
+## Required Proof
+
+A compatible implementation MUST prove:
+
+```txt
+HumanWorker and AgentWorker are represented by Worker records.
+HumanWorker and AgentWorker are represented by Actor records.
+WorkSession records objective, policy, revision, and event hash state.
+Every WorkSession-scoped mutation validates Jarvis-Protocol-Version.
+Every WorkSession-scoped mutation validates Jarvis-Actor-Id.
+Every WorkSession-scoped mutation validates Jarvis-Idempotency-Key.
+Every WorkSession-scoped mutation validates Jarvis-Request-Timestamp.
+Every WorkSession-scoped mutation validates Jarvis-Expected-WorkSession-Revision.
+Every WorkSession-scoped mutation validates Jarvis-Previous-Event-Hash.
+Every accepted WorkSession-scoped state change records the Actor.
+Every accepted WorkSession-scoped state change verifies Actor authority.
+Every accepted WorkSession-scoped state change checks Jarvis-Expected-WorkSession-Revision.
+Every accepted WorkSession-scoped state change links Jarvis-Previous-Event-Hash.
+AgentWorker action records PolicyDecision before accepted protocol state.
+Policy-denied action creates scoped Request.
+Request resolves only through Review or Takeover.
+Review approve or narrow produces bounded ApprovalScope.
+Takeover records lock state before human direct control.
+Contribution records attributable human, agent, shared, service, or tool work.
+EvidenceManifest exports portable proof.
+LearningRecord captures human, agent, or pair learning.
+MemoryProposal and SkillProposal keep durable learning governed.
+OutcomeReport references LearningRecord without mutating sealed records.
+```
+
+## Required Object Path
+
+The golden path includes these protocol records:
+
+```txt
+Worker
+Actor
+HumanWorker
+AgentWorker
+WorkSession
+JarvisEvent
+PolicyDecision
+Request
+Review
+ApprovalScope
+Contribution
+EvidenceManifest
+LearningRecord
+MemoryProposal
+SkillProposal
+OutcomeReport
+```
+
+## Required Export Boundary
+
+EvidenceManifest export MUST exclude:
+
+```txt
+credentials
+secrets
+raw auth tokens
+session cookies
+provider keys
+raw runtime state
+host-only database ids
+deployment details
+billing data
+private scores
+UI state
+private keys
+```
+
+Jarvis conformance records the protocol proof. Hosts own behavior outside the
+protocol contract.

--- a/docs/openapi/README.md
+++ b/docs/openapi/README.md
@@ -4,9 +4,9 @@ This directory contains the machine-readable OpenAPI 3.1 communication binding
 for Jarvis v0.1.
 
 Jarvis is the human-agent collaboration and learning-loop protocol. OpenAPI
-defines how compatible hosts exchange Jarvis protocol records. OpenAPI does not
-make Jarvis a runtime, host implementation, auth system, storage system, cloud stack, tool
-protocol, frontend protocol, or agent framework.
+defines how compatible hosts exchange Jarvis protocol records.
+
+OpenAPI defines Jarvis protocol record exchange only.
 
 ## Files
 
@@ -99,13 +99,22 @@ Chunk 6 defines the path layout, reusable protocol header parameters, request
 bodies, responses, `ProtocolError`, and HostAuth security binding for the v0.1
 operations.
 
-Chunk 6 does not define full examples, conformance fixtures, adapter contracts,
-runtime execution, host implementation behavior, auth provider behavior,
-storage behavior, model calls, tool execution, UI behavior, billing, payment,
-scoring, settlement, or marketplace logic.
+Chunk 7 defines the first OpenAPI examples and conformance entry documents:
+
+```txt
+WorkSessionCreateExample
+PolicyDecisionDeniedExample
+RequestBlockedActionExample
+ReviewApproveRequestExample
+EvidenceManifestExportExample
+ProtocolErrorExample
+docs/conformance/golden-path.md
+docs/conformance/failure-modes.md
+```
+
+Chunk 7 does not define executable conformance fixtures.
 
 ## Boundary
 
-Compatible hosts publish their own server URLs, identity providers, credential
-handling, storage, execution, deployment, billing, and UI. Jarvis defines
-protocol records and conformance requirements only.
+Compatible hosts publish their own server URLs. Jarvis defines protocol records
+and conformance requirements only.

--- a/docs/openapi/jarvis-openapi.yaml
+++ b/docs/openapi/jarvis-openapi.yaml
@@ -7,9 +7,7 @@ info:
     Jarvis defines the protocol records and operations for governed
     collaboration between HumanWorkers and AgentWorkers.
 
-    Jarvis does not define runtime execution, UI, authentication
-    provider, storage, model calls, isolation behavior, cloud deployment, billing,
-    task routing, or marketplace logic.
+    Jarvis defines protocol records and operations only.
   version: 0.1.0
 servers:
   - url: https://jarvis.example.invalid
@@ -2696,7 +2694,155 @@ components:
       in: header
       name: Authorization
       description: Host-owned caller authentication. Jarvis requires caller authentication for protocol operations and does not define credential format, token type, session store, or account system.
-  examples: {}
+  examples:
+    WorkSessionCreateExample:
+      summary: WorkSession created for governed human-agent work.
+      value:
+        id: ws-protocol-001
+        protocol_version: v0.1
+        created_by_actor_id: actor-human-001
+        objective: Produce a reviewed evidence-backed answer under bounded policy.
+        human_worker_id: worker-human-001
+        agent_worker_id: worker-agent-001
+        policy_id: policy-bounded-001
+        status: active
+        revision: 0
+        last_event_hash: hash:genesis
+        event_log_ref: event-log:ws-protocol-001
+        created_at: "2026-06-12T18:00:00Z"
+        updated_at: "2026-06-12T18:00:00Z"
+    PolicyDecisionDeniedExample:
+      summary: PolicyDecision recorded before denied AgentWorker action creates Request.
+      value:
+        id: pd-network-001
+        work_session_id: ws-protocol-001
+        actor_id: actor-agent-001
+        policy_id: policy-bounded-001
+        requested_action:
+          action: fetch_external_source
+          target_ref: source:external-reference
+          scope_ref: scope:source-collection
+        normalized_action_hash: hash:action-fetch-external-source
+        risk_class: medium
+        result: deny
+        reason: External source access requires HumanWorker review before continuation.
+        request_id: req-network-001
+        created_at: "2026-06-12T18:05:00Z"
+    RequestBlockedActionExample:
+      summary: Scoped Request blocks one action branch and waits for human judgment.
+      value:
+        id: req-network-001
+        protocol_version: v0.1
+        work_session_id: ws-protocol-001
+        requester_actor_id: actor-agent-001
+        requester_worker_id: worker-agent-001
+        target_human_worker_id: worker-human-001
+        policy_decision_id: pd-network-001
+        type: permission
+        blocking_scope: action
+        reason_code: policy_denied
+        reason_summary: External source access is outside current policy.
+        requested_action:
+          action: fetch_external_source
+          target_ref: source:external-reference
+          scope_ref: scope:source-collection
+        requested_outcome: Allow source collection for the current WorkSession only.
+        risk_class: medium
+        human_decision_needed: Approve, narrow, deny, correct, or take over this action branch.
+        options:
+          - id: option-approve-current-session
+            label: Approve current WorkSession scope
+            effect: AgentWorker collects the referenced source for this WorkSession only after bounded approval.
+            risk_class: medium
+            scope_ref: scope:source-collection
+          - id: option-deny
+            label: Deny source collection
+            effect: AgentWorker continues with existing evidence and records the limitation.
+            risk_class: low
+            scope_ref: scope:existing-evidence
+        default_if_no_response:
+          action: continue_with_limited_evidence
+          reason: The blocked action remains stopped and the WorkSession records an evidence limitation.
+          limitation_ref: limitation:external-source-not-reviewed
+        status: pending
+        created_at: "2026-06-12T18:06:00Z"
+        expires_at: "2026-06-12T18:36:00Z"
+    ReviewApproveRequestExample:
+      summary: HumanWorker Review resolves Request with bounded ApprovalScope.
+      value:
+        id: review-network-001
+        work_session_id: ws-protocol-001
+        reviewer_actor_id: actor-human-001
+        reviewer_worker_id: worker-human-001
+        target_ref: request:req-network-001
+        decision: approve
+        approval_scope:
+          request_id: req-network-001
+          review_id: review-network-001
+          policy_decision_id: pd-network-001
+          request_revision: 1
+          request_event_hash: hash:event-request-network
+          normalized_action_hash: hash:action-fetch-external-source
+          approved_action:
+            action: fetch_external_source
+            target_ref: source:external-reference
+            scope_ref: scope:source-collection
+          allowed_scope:
+            scope_ref: scope:source-collection
+            grant_refs:
+              - grant:read-source
+          denied_scope:
+            scope_ref: scope:any-other-external-source
+          expires_at: "2026-06-12T18:36:00Z"
+          max_uses: 1
+          applies_to_work_session_id: ws-protocol-001
+          applies_to_actor_id: actor-agent-001
+        created_at: "2026-06-12T18:08:00Z"
+    EvidenceManifestExportExample:
+      summary: EvidenceManifest exports portable proof from the WorkSession.
+      value:
+        id: evidence-manifest-001
+        work_session_id: ws-protocol-001
+        generated_by_actor_id: actor-human-001
+        objective: Produce a reviewed evidence-backed answer under bounded policy.
+        event_chain_root: hash:event-chain-root
+        evidence_item_refs:
+          - id: evidence-source-001
+            work_session_id: ws-protocol-001
+            source_event_refs:
+              - event-source-captured-001
+            captured_by_actor_id: actor-agent-001
+            evidence_type: source_summary
+            artifact_ref: artifact:source-summary-001
+            content_hash: hash:source-summary-001
+            trust_label: reviewed
+            redaction_state: redacted
+            captured_at: "2026-06-12T18:10:00Z"
+            limitation_refs:
+              - limitation:none-recorded
+        policy_decision_refs:
+          - pd-network-001
+        request_refs:
+          - req-network-001
+        review_refs:
+          - review-network-001
+        takeover_refs: []
+        contribution_refs:
+          - contribution-shared-001
+        export_profile:
+          profile: portable_evidence_manifest
+          version: v0.1
+        generated_at: "2026-06-12T18:20:00Z"
+    ProtocolErrorExample:
+      summary: ProtocolError reports typed rejection without host-private fields.
+      value:
+        error_id: missing_policy_decision
+        protocol_version: v0.1
+        object_type: jarvis_event
+        field: policy_decision_id
+        reason: AgentWorker action affected WorkSession state without prior PolicyDecision.
+        remediation: Record PolicyDecision before accepting the AgentWorker action as protocol state.
+        trace_id: trace:protocol-error-001
 x-jarvis-protocol:
   version: v0.1
   layer: OpenAPI 3.1 communication binding
@@ -2715,22 +2861,9 @@ x-jarvis-protocol:
     - portable export boundary
     - conformance entry
   outside_jarvis:
-    - runtime execution
-    - UI
-    - authentication provider
-    - authorization backend
-    - storage
-    - queues
-    - cloud provider
-    - sandbox implementation
-    - model provider
-    - tool execution
-    - billing
-    - deployment
-    - task marketplace
-    - host workflow
+    - host-owned behavior outside the protocol contract
   chunk_lock:
-    id: week-2-chunk-6-path-security-binding
+    id: week-2-chunk-7-examples-conformance-entry
     locks:
       - OpenAPI 3.1.1 entry point
       - v0.1 protocol metadata
@@ -2764,6 +2897,7 @@ x-jarvis-protocol:
       - protocol header parameters
       - HostAuth security scheme
       - protocol error response
+      - protocol examples
+      - conformance entry documents
     excludes:
-      - examples
-      - conformance fixtures
+      - executable conformance fixtures

--- a/docs/planning/week-2/README.md
+++ b/docs/planning/week-2/README.md
@@ -3,8 +3,7 @@
 Week 2 turns the locked protocol into the first OpenAPI 3.1 contract shape and
 conformance entry.
 
-This week does not build a host implementation, runtime features, UI, auth,
-storage, model calls, adapters, or conformance fixtures beyond the active chunk.
+This week locks the OpenAPI protocol contract and conformance entry only.
 
 ## Chunks
 
@@ -22,6 +21,8 @@ storage, model calls, adapters, or conformance fixtures beyond the active chunk.
 6. [chunk-6-path-security-binding.md](./chunk-6-path-security-binding.md)
    Lock path operations, protocol header parameters, request bodies, responses,
    HostAuth security binding, and ProtocolError.
+7. [chunk-7-examples-conformance-entry.md](./chunk-7-examples-conformance-entry.md)
+   Lock OpenAPI examples and conformance entry documents.
 
 ## Week 2 Done State
 

--- a/docs/planning/week-2/chunk-7-examples-conformance-entry.md
+++ b/docs/planning/week-2/chunk-7-examples-conformance-entry.md
@@ -1,0 +1,305 @@
+# Week 2 Chunk 7: Examples And Conformance Entry
+
+Chunk 7 locks the first protocol examples and conformance entry checks for the
+Jarvis v0.1 OpenAPI contract.
+
+This chunk turns the schema and path contract into readable protocol proof
+records.
+
+This chunk adds protocol examples and conformance entry checks only. It does
+not add behavior outside the Jarvis contract.
+
+## Scope
+
+This chunk adds:
+
+```txt
+components.examples.WorkSessionCreateExample
+components.examples.PolicyDecisionDeniedExample
+components.examples.RequestBlockedActionExample
+components.examples.ReviewApproveRequestExample
+components.examples.EvidenceManifestExportExample
+components.examples.ProtocolErrorExample
+docs/conformance/golden-path.md
+docs/conformance/failure-modes.md
+validator checks for required examples and conformance documents
+```
+
+## Example Rules
+
+OpenAPI examples MUST be portable protocol records.
+
+Examples MUST NOT contain:
+
+```txt
+host database ids
+credentials
+secrets
+raw auth tokens
+session cookies
+provider keys
+runtime state
+container ids
+deployment details
+billing data
+private scores
+UI state
+model provider internals
+tool execution internals
+```
+
+Each example MUST demonstrate one protocol fact:
+
+```txt
+WorkSessionCreateExample
+  HumanWorker and AgentWorker enter a WorkSession under policy.
+
+PolicyDecisionDeniedExample
+  AgentWorker action outside policy records PolicyDecision before Request.
+
+RequestBlockedActionExample
+  blocked action creates a scoped Request, not chat or notification.
+
+ReviewApproveRequestExample
+  HumanWorker judgment resolves Request through Review and bounded approval.
+
+EvidenceManifestExportExample
+  completed work exports portable evidence with policy, request, review,
+  contribution, evidence item, and limitation refs.
+
+ProtocolErrorExample
+  rejection uses the protocol error envelope and a typed error id.
+```
+
+## Required Example Fields
+
+The validator checks structural and protocol-specific example requirements. It
+does not perform full JSON Schema validation in Chunk 7.
+
+Required fields:
+
+```txt
+WorkSessionCreateExample
+  id
+  protocol_version
+  created_by_actor_id
+  objective
+  human_worker_id
+  agent_worker_id
+  policy_id
+  status
+  revision
+  last_event_hash
+  event_log_ref
+  created_at
+  updated_at
+
+PolicyDecisionDeniedExample
+  id
+  work_session_id
+  actor_id
+  policy_id
+  requested_action
+  normalized_action_hash
+  risk_class
+  result
+  reason
+  created_at
+
+RequestBlockedActionExample
+  id
+  protocol_version
+  work_session_id
+  requester_actor_id
+  requester_worker_id
+  target_human_worker_id
+  policy_decision_id
+  type
+  blocking_scope
+  reason_code
+  reason_summary
+  requested_action
+  requested_outcome
+  risk_class
+  human_decision_needed
+  options
+  default_if_no_response
+  status
+  created_at
+  expires_at
+
+ReviewApproveRequestExample
+  id
+  work_session_id
+  reviewer_actor_id
+  reviewer_worker_id
+  target_ref
+  decision
+  approval_scope
+  created_at
+
+EvidenceManifestExportExample
+  id
+  work_session_id
+  generated_by_actor_id
+  objective
+  event_chain_root
+  evidence_item_refs
+  policy_decision_refs
+  request_refs
+  review_refs
+  takeover_refs
+  contribution_refs
+  export_profile
+  generated_at
+
+ProtocolErrorExample
+  error_id
+  protocol_version
+  object_type
+  field
+  reason
+  remediation
+  trace_id
+```
+
+Required semantic checks:
+
+```txt
+PolicyDecisionDeniedExample.result == deny
+RequestBlockedActionExample.status == pending
+RequestBlockedActionExample.blocking_scope is not empty
+ReviewApproveRequestExample.decision == approve
+ReviewApproveRequestExample.approval_scope exists
+EvidenceManifestExportExample.evidence_item_refs is not empty
+EvidenceManifestExportExample.policy_decision_refs is not empty
+EvidenceManifestExportExample.request_refs is not empty
+EvidenceManifestExportExample.review_refs is not empty
+EvidenceManifestExportExample.contribution_refs is not empty
+ProtocolErrorExample.error_id exists in ProtocolErrorId enum
+```
+
+## Conformance Entry Rules
+
+The golden-path conformance entry MUST prove:
+
+```txt
+HumanWorker and AgentWorker are represented by Worker and Actor records.
+WorkSession is created with objective, policy, revision, and event hash state.
+WorkSession-scoped mutations validate Jarvis-Protocol-Version.
+WorkSession-scoped mutations validate Jarvis-Actor-Id.
+WorkSession-scoped mutations validate Jarvis-Idempotency-Key.
+WorkSession-scoped mutations validate Jarvis-Request-Timestamp.
+WorkSession-scoped mutations validate Jarvis-Expected-WorkSession-Revision.
+WorkSession-scoped mutations validate Jarvis-Previous-Event-Hash.
+Every accepted WorkSession-scoped state change records the Actor, verifies
+authority, checks Jarvis-Expected-WorkSession-Revision, and links
+Jarvis-Previous-Event-Hash.
+AgentWorker action records PolicyDecision before accepted protocol state.
+Policy-denied action creates scoped Request.
+Request is resolved only by Review or Takeover.
+Approved Request produces bounded ApprovalScope.
+Contribution records attributable work.
+EvidenceManifest exports portable proof.
+LearningRecord, MemoryProposal, or SkillProposal carries governed learning.
+```
+
+The failure-mode conformance entry MUST reject:
+
+```txt
+missing protocol version
+missing Actor header
+invalid Actor authority
+missing idempotency key
+missing request timestamp
+stale request timestamp
+missing expected WorkSession revision
+missing previous event hash
+missing PolicyDecision before AgentWorker state change
+Request resolved without Review or Takeover
+approval without bounded ApprovalScope
+stale WorkSession revision
+previous event hash mismatch
+stale Takeover continuation
+EvidenceManifest export from invalid WorkSession state
+sealed WorkSession mutation
+sealed EvidenceManifest mutation
+host-private export field
+silent memory mutation
+silent skill activation
+OutcomeReport without LearningRecord
+```
+
+## Validator Rules
+
+The OpenAPI validator MUST enforce:
+
+```txt
+required examples exist in components.examples
+each required example uses summary and value
+each required example value is an object
+required examples contain the expected fields
+required examples avoid forbidden host-private keys
+golden-path conformance document exists
+failure-mode conformance document exists
+conformance documents include zero-trust header rejection ids
+conformance documents include Actor authority rejection ids
+conformance documents include revision and event-hash rejection ids
+conformance documents include forbidden host-private export rejection ids
+```
+
+The failure-mode conformance document MUST include these rejection ids:
+
+```txt
+missing_protocol_version
+missing_actor
+unauthorized_actor
+missing_idempotency_key
+missing_request_timestamp
+stale_request_timestamp
+missing_expected_work_session_revision
+missing_previous_event_hash
+missing_policy_decision
+missing_review_resolution
+missing_takeover_resolution
+invalid_approval_scope
+stale_work_session_revision
+invalid_previous_event_hash
+stale_takeover_epoch
+invalid_evidence_export_state
+sealed_work_session_mutation
+sealed_evidence_mutation
+forbidden_host_private_field
+silent_memory_mutation
+silent_skill_activation
+outcome_report_without_learning_record
+```
+
+## Out Of Scope
+
+This chunk does not add executable implementation work.
+
+It locks:
+
+```txt
+portable protocol examples
+conformance entry documents
+validator checks for examples and conformance entry
+```
+
+Executable proof work starts after the conformance entry is stable.
+
+## Done State
+
+Chunk 7 is complete when:
+
+```txt
+OpenAPI contains the required protocol examples.
+The examples are portable protocol records.
+The conformance entry documents exist.
+The validator rejects missing examples and missing conformance entry docs.
+The wording guard passes.
+The markdown link checker passes.
+The OpenAPI validator passes.
+Reviewer agents approve protocol boundary, security, OpenAPI shape, and wording.
+```

--- a/scripts/check_openapi_skeleton.py
+++ b/scripts/check_openapi_skeleton.py
@@ -9,6 +9,8 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 OPENAPI_PATH = ROOT / "docs" / "openapi" / "jarvis-openapi.yaml"
+GOLDEN_PATH_CONFORMANCE = ROOT / "docs" / "conformance" / "golden-path.md"
+FAILURE_MODE_CONFORMANCE = ROOT / "docs" / "conformance" / "failure-modes.md"
 
 REQUIRED_TOP_LEVEL = {
     "openapi",
@@ -162,6 +164,114 @@ REQUIRED_RESPONSES = {
     "EvidenceManifestResponse": "EvidenceManifest",
     "OutcomeReportResponse": "OutcomeReport",
     "ProtocolErrorResponse": "ProtocolError",
+}
+
+REQUIRED_EXAMPLES = {
+    "WorkSessionCreateExample": {
+        "id",
+        "protocol_version",
+        "created_by_actor_id",
+        "objective",
+        "human_worker_id",
+        "agent_worker_id",
+        "policy_id",
+        "status",
+        "revision",
+        "last_event_hash",
+        "event_log_ref",
+        "created_at",
+        "updated_at",
+    },
+    "PolicyDecisionDeniedExample": {
+        "id",
+        "work_session_id",
+        "actor_id",
+        "policy_id",
+        "requested_action",
+        "normalized_action_hash",
+        "risk_class",
+        "result",
+        "reason",
+        "created_at",
+    },
+    "RequestBlockedActionExample": {
+        "id",
+        "protocol_version",
+        "work_session_id",
+        "requester_actor_id",
+        "requester_worker_id",
+        "target_human_worker_id",
+        "policy_decision_id",
+        "type",
+        "blocking_scope",
+        "reason_code",
+        "reason_summary",
+        "requested_action",
+        "requested_outcome",
+        "risk_class",
+        "human_decision_needed",
+        "options",
+        "default_if_no_response",
+        "status",
+        "created_at",
+        "expires_at",
+    },
+    "ReviewApproveRequestExample": {
+        "id",
+        "work_session_id",
+        "reviewer_actor_id",
+        "reviewer_worker_id",
+        "target_ref",
+        "decision",
+        "approval_scope",
+        "created_at",
+    },
+    "EvidenceManifestExportExample": {
+        "id",
+        "work_session_id",
+        "generated_by_actor_id",
+        "objective",
+        "event_chain_root",
+        "evidence_item_refs",
+        "policy_decision_refs",
+        "request_refs",
+        "review_refs",
+        "takeover_refs",
+        "contribution_refs",
+        "export_profile",
+        "generated_at",
+    },
+    "ProtocolErrorExample": {
+        "error_id",
+        "protocol_version",
+        "object_type",
+        "field",
+        "reason",
+        "remediation",
+        "trace_id",
+    },
+}
+
+EXAMPLE_REQUIRED_VALUES = {
+    ("PolicyDecisionDeniedExample", "result"): "deny",
+    ("RequestBlockedActionExample", "status"): "pending",
+    ("ReviewApproveRequestExample", "decision"): "approve",
+}
+
+EXAMPLE_REQUIRED_OBJECTS = {
+    ("ReviewApproveRequestExample", "approval_scope"),
+}
+
+EXAMPLE_REQUIRED_NON_EMPTY_FIELDS = {
+    ("RequestBlockedActionExample", "blocking_scope"),
+}
+
+EXAMPLE_REQUIRED_NON_EMPTY_ARRAYS = {
+    ("EvidenceManifestExportExample", "evidence_item_refs"),
+    ("EvidenceManifestExportExample", "policy_decision_refs"),
+    ("EvidenceManifestExportExample", "request_refs"),
+    ("EvidenceManifestExportExample", "review_refs"),
+    ("EvidenceManifestExportExample", "contribution_refs"),
 }
 
 WORKSESSION_MUTATION_HEADERS = {
@@ -1253,7 +1363,7 @@ REQUIRED_TAGS = {
 
 EXPECTED_TITLE = "Jarvis Human-Agent Collaboration Protocol"
 EXPECTED_PLACEHOLDER_SERVER = "https://jarvis.example.invalid"
-EXPECTED_CHUNK_ID = "week-2-chunk-6-path-security-binding"
+EXPECTED_CHUNK_ID = "week-2-chunk-7-examples-conformance-entry"
 REQUIRED_CHUNK_LOCKS = {
     "OpenAPI 3.1.1 entry point",
     "v0.1 protocol metadata",
@@ -1287,6 +1397,32 @@ REQUIRED_CHUNK_LOCKS = {
     "protocol header parameters",
     "HostAuth security scheme",
     "protocol error response",
+    "protocol examples",
+    "conformance entry documents",
+}
+REQUIRED_CONFORMANCE_REJECTION_IDS = {
+    "missing_protocol_version",
+    "missing_actor",
+    "unauthorized_actor",
+    "missing_idempotency_key",
+    "missing_request_timestamp",
+    "stale_request_timestamp",
+    "missing_expected_work_session_revision",
+    "missing_previous_event_hash",
+    "missing_policy_decision",
+    "missing_review_resolution",
+    "missing_takeover_resolution",
+    "invalid_approval_scope",
+    "stale_work_session_revision",
+    "invalid_previous_event_hash",
+    "stale_takeover_epoch",
+    "invalid_evidence_export_state",
+    "sealed_work_session_mutation",
+    "sealed_evidence_mutation",
+    "forbidden_host_private_field",
+    "silent_memory_mutation",
+    "silent_skill_activation",
+    "outcome_report_without_learning_record",
 }
 PORTABLE_VALUE_REF = {"$ref": "#/components/schemas/PortableValue"}
 FORBIDDEN_PORTABLE_KEY_PATTERN = (
@@ -1503,6 +1639,48 @@ def operation_parameter_names(operation: dict) -> set[str]:
     return names
 
 
+def iter_keys(value, path: str = "$"):
+    if isinstance(value, dict):
+        for key, child in value.items():
+            yield path, str(key)
+            yield from iter_keys(child, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            yield from iter_keys(child, f"{path}[{index}]")
+
+
+def forbidden_example_keys(value) -> list[str]:
+    forbidden_terms = {
+        "password",
+        "credential",
+        "token",
+        "secret",
+        "private_key",
+        "session_cookie",
+        "cookie",
+        "api_key",
+        "access_key",
+        "auth_header",
+        "oauth",
+        "database",
+        "billing",
+        "runtime",
+        "container",
+        "deployment",
+        "model_api_key",
+        "raw_prompt",
+        "host_account",
+        "ui_state",
+        "private_score",
+    }
+    failures = []
+    for path, key in iter_keys(value):
+        normalized = key.lower()
+        if any(term in normalized for term in forbidden_terms):
+            failures.append(f"{path}.{key}")
+    return failures
+
+
 def main() -> int:
     if not OPENAPI_PATH.exists():
         return fail(f"missing {OPENAPI_PATH.relative_to(ROOT)}")
@@ -1565,6 +1743,49 @@ def main() -> int:
     for bucket in REQUIRED_COMPONENTS:
         if not isinstance(components[bucket], dict):
             return fail(f"components.{bucket} must be an object")
+
+    examples = components["examples"]
+    missing_examples = set(REQUIRED_EXAMPLES) - set(examples)
+    if missing_examples:
+        return fail("missing examples: " + ", ".join(sorted(missing_examples)))
+    for example_name, required_fields in REQUIRED_EXAMPLES.items():
+        example = examples[example_name]
+        if not isinstance(example, dict):
+            return fail(f"{example_name} must be an object")
+        if not example.get("summary"):
+            return fail(f"{example_name} must define summary")
+        value = example.get("value")
+        if not isinstance(value, dict):
+            return fail(f"{example_name}.value must be an object")
+        missing_example_fields = required_fields - set(value)
+        if missing_example_fields:
+            return fail(
+                f"{example_name}.value missing fields: "
+                + ", ".join(sorted(missing_example_fields))
+            )
+        forbidden_keys = forbidden_example_keys(value)
+        if forbidden_keys:
+            return fail(
+                f"{example_name}.value contains forbidden host-private keys: "
+                + ", ".join(forbidden_keys)
+            )
+
+    for (example_name, field), expected_value in EXAMPLE_REQUIRED_VALUES.items():
+        actual_value = examples[example_name]["value"].get(field)
+        if actual_value != expected_value:
+            return fail(
+                f"{example_name}.value.{field} must be {expected_value!r}"
+            )
+    for example_name, field in EXAMPLE_REQUIRED_OBJECTS:
+        if not isinstance(examples[example_name]["value"].get(field), dict):
+            return fail(f"{example_name}.value.{field} must be an object")
+    for example_name, field in EXAMPLE_REQUIRED_NON_EMPTY_FIELDS:
+        if not examples[example_name]["value"].get(field):
+            return fail(f"{example_name}.value.{field} must be non-empty")
+    for example_name, field in EXAMPLE_REQUIRED_NON_EMPTY_ARRAYS:
+        value = examples[example_name]["value"].get(field)
+        if not isinstance(value, list) or not value:
+            return fail(f"{example_name}.value.{field} must be a non-empty array")
 
     schemas = components["schemas"]
     missing_schemas = REQUIRED_SCHEMAS - set(schemas)
@@ -1966,6 +2187,55 @@ def main() -> int:
         return fail(
             "ProtocolErrorId missing security errors: "
             + ", ".join(sorted(missing_security_error_ids))
+        )
+
+    protocol_error_example_id = examples["ProtocolErrorExample"]["value"].get(
+        "error_id"
+    )
+    if protocol_error_example_id not in error_ids:
+        return fail("ProtocolErrorExample.error_id must exist in ProtocolErrorId")
+
+    for conformance_path in (GOLDEN_PATH_CONFORMANCE, FAILURE_MODE_CONFORMANCE):
+        if not conformance_path.exists():
+            return fail(f"missing {conformance_path.relative_to(ROOT)}")
+    golden_text = GOLDEN_PATH_CONFORMANCE.read_text(encoding="utf-8")
+    required_golden_phrases = {
+        "Every WorkSession-scoped mutation validates Jarvis-Protocol-Version.",
+        "Every WorkSession-scoped mutation validates Jarvis-Actor-Id.",
+        "Every WorkSession-scoped mutation validates Jarvis-Idempotency-Key.",
+        "Every WorkSession-scoped mutation validates Jarvis-Request-Timestamp.",
+        "Every WorkSession-scoped mutation validates Jarvis-Expected-WorkSession-Revision.",
+        "Every WorkSession-scoped mutation validates Jarvis-Previous-Event-Hash.",
+        "Every accepted WorkSession-scoped state change verifies Actor authority.",
+        "AgentWorker action records PolicyDecision before accepted protocol state.",
+        "Request resolves only through Review or Takeover.",
+        "Review approve or narrow produces bounded ApprovalScope.",
+        "EvidenceManifest exports portable proof.",
+    }
+    missing_golden_phrases = [
+        phrase for phrase in sorted(required_golden_phrases) if phrase not in golden_text
+    ]
+    if missing_golden_phrases:
+        return fail(
+            "golden-path conformance missing phrases: "
+            + "; ".join(missing_golden_phrases)
+        )
+    failure_text = FAILURE_MODE_CONFORMANCE.read_text(encoding="utf-8")
+    missing_conformance_ids = [
+        rejection_id
+        for rejection_id in sorted(REQUIRED_CONFORMANCE_REJECTION_IDS)
+        if rejection_id not in failure_text
+    ]
+    if missing_conformance_ids:
+        return fail(
+            "failure-mode conformance missing rejection ids: "
+            + ", ".join(missing_conformance_ids)
+        )
+    unknown_conformance_ids = REQUIRED_CONFORMANCE_REJECTION_IDS - error_ids
+    if unknown_conformance_ids:
+        return fail(
+            "failure-mode conformance ids missing from ProtocolErrorId: "
+            + ", ".join(sorted(unknown_conformance_ids))
         )
 
     paths = data["paths"]


### PR DESCRIPTION
## Summary
- add Chunk 7 spec for OpenAPI examples and conformance entry
- add required OpenAPI examples for WorkSession, PolicyDecision, Request, Review, EvidenceManifest, and ProtocolError
- add golden-path and failure-mode conformance entry docs
- extend OpenAPI validator to enforce required examples, semantic checks, conformance docs, and rejection ids
- tighten public boundary wording in OpenAPI docs and metadata

## Validation
- PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_openapi_skeleton.py
- PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_week1_wording.py
- PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_markdown_links.py
- git diff --check

## Reviewer Agents
- protocol-boundary/public-scope: PASS
- OpenAPI/conformance: PASS
- zero-trust/security: PASS
- direct wording/public docs: PASS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive conformance documentation defining protocol golden-path requirements and failure-mode scenarios.
  * Updated OpenAPI specification with concrete protocol examples, conformance bindings, and refined scope boundaries.
  * Added Week 2 conformance entry requirements and detailed chunk specifications.

* **Tests**
  * Enhanced conformance validation script to verify example payloads and protocol artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->