### PR TITLE
Start Week 3 fixture architecture

### DIFF
--- a/docs/planning/week-3/README.md
+++ b/docs/planning/week-3/README.md
@@ -1,0 +1,77 @@
+# Week 3: Protocol Compatibility Mapping And Conformance Fixtures
+
+Week 3 proves the Week 2 OpenAPI contract through protocol compatibility
+mapping and conformance fixtures.
+
+Week 3 does not build adapters, wrappers, host runtimes, UI, model calls, tool
+execution, storage, auth, billing, scoring, payment, or deployment behavior.
+
+Jarvis records the protocol proof. Hosts provide the implementation.
+
+## Goal
+
+Prove that existing human-agent work maps into Jarvis protocol records without
+rewriting the agent runtime or moving host behavior into Jarvis.
+
+## Inputs
+
+Week 3 starts from:
+
+- [../../openapi/jarvis-openapi.yaml](../../openapi/jarvis-openapi.yaml)
+- [../../conformance/golden-path.md](../../conformance/golden-path.md)
+- [../../conformance/failure-modes.md](../../conformance/failure-modes.md)
+- [../week-2/closeout.md](../week-2/closeout.md)
+- [../../protocol/14-protocol-lock.md](../../protocol/14-protocol-lock.md)
+- [../../protocol/15-openapi-communication-binding.md](../../protocol/15-openapi-communication-binding.md)
+
+## Week 3 Outputs
+
+Week 3 produces:
+
+- protocol compatibility mapping rules
+- fixture architecture
+- valid conformance fixtures
+- invalid conformance fixtures
+- fixture validator checks
+- existing-agent compatibility proof plan
+- Week 3 closeout
+
+## Chunk Plan
+
+1. [chunk-1-fixture-architecture.md](./chunk-1-fixture-architecture.md)
+   Define Week 3 execution, fixture architecture, fixture envelope, assertion
+   classes, and validator scope.
+2. [chunk-2-compatibility-mapping.md](./chunk-2-compatibility-mapping.md)
+   Define how existing human-agent work maps into Jarvis protocol records.
+3. [chunk-3-golden-path-fixture.md](./chunk-3-golden-path-fixture.md)
+   Add the valid golden-path fixture.
+4. [chunk-4-failure-fixtures.md](./chunk-4-failure-fixtures.md)
+   Add invalid fixtures for required rejection paths.
+5. [chunk-5-fixture-validator.md](./chunk-5-fixture-validator.md)
+   Add validator checks for fixture structure and expected protocol outcomes.
+6. [chunk-6-existing-agent-proof-plan.md](./chunk-6-existing-agent-proof-plan.md)
+   Define the existing-agent compatibility proof plan without adapter code.
+7. [chunk-7-closeout.md](./chunk-7-closeout.md)
+   Close Week 3 and define readiness for compatible examples.
+
+## Done State
+
+Week 3 is complete when:
+
+- valid fixtures prove the golden path
+- invalid fixtures prove required rejection ids
+- compatibility mapping preserves host-owned execution
+- fixture validation runs locally
+- two host shapes map to equivalent Jarvis records on paper
+- compatible examples stay behind the conformance gate
+
+## Boundary
+
+Jarvis owns protocol records and conformance expectations.
+
+Hosts own execution, storage, identity, UI, runtime behavior, model calls, tool
+execution, billing, monitoring, and workflow.
+
+Week 3 strengthens Jarvis only when a change improves compatibility mapping,
+fixture correctness, conformance rejection, portable evidence, or governed
+learning.

--- a/docs/planning/week-3/chunk-1-fixture-architecture.md
+++ b/docs/planning/week-3/chunk-1-fixture-architecture.md
@@ -1,0 +1,246 @@
+# Chunk 1: Fixture Architecture
+
+Chunk 1 defines the Week 3 conformance fixture architecture.
+
+This chunk does not create valid or invalid fixture files. Later chunks add
+fixtures after this architecture is locked.
+
+## Purpose
+
+Conformance fixtures turn the OpenAPI contract into executable protocol proof.
+
+Fixtures prove:
+
+- a compatible implementation records the golden human-agent collaboration loop
+- unsafe or incomplete records reject with the required protocol error id
+- host-owned implementation details stay outside portable Jarvis records
+- existing agent work maps into protocol objects without runtime ownership
+
+## Fixture Directory
+
+Week 3 fixture work uses this directory shape:
+
+```txt
+docs/conformance/fixtures/
+  README.md
+  valid/
+    golden-path.json
+  invalid/
+    missing-protocol-version.json
+    missing-actor.json
+    unauthorized-actor.json
+    missing-idempotency-key.json
+    missing-request-timestamp.json
+    stale-request-timestamp.json
+    missing-expected-work-session-revision.json
+    missing-previous-event-hash.json
+    missing-policy-decision.json
+    missing-review-resolution.json
+    missing-takeover-resolution.json
+    invalid-approval-scope.json
+    stale-work-session-revision.json
+    invalid-previous-event-hash.json
+    stale-takeover-continuation.json
+    invalid-evidence-export-state.json
+    sealed-work-session-mutation.json
+    sealed-evidence-mutation.json
+    forbidden-host-private-export-field.json
+    silent-memory-mutation.json
+    silent-skill-activation.json
+    outcome-report-without-learning-record.json
+    unresolved-request.json
+```
+
+Chunk 3 opens `valid/`.
+Chunk 4 opens `invalid/`.
+Chunk 5 adds validator checks.
+
+## Fixture Envelope
+
+Every fixture uses one envelope:
+
+```txt
+fixture_id
+protocol_version
+kind
+title
+description
+source_contract_refs
+host_shape_ref
+records
+operations
+assertions
+expected_result
+expected_error_id
+expected_error_field
+```
+
+Rules:
+
+- `fixture_id` is stable.
+- `protocol_version` is `0.1`.
+- `kind` is `valid` or `invalid`.
+- `source_contract_refs` points to the protocol docs or OpenAPI components that
+  define the behavior under test.
+- `host_shape_ref` identifies the implementation shape used for compatibility
+  mapping.
+- `records` contains protocol records only.
+- `operations` contains protocol operation attempts and required headers.
+- `assertions` contains the expected protocol checks.
+- `expected_result` is `pass` or `reject`.
+- `expected_error_id` is present only when `expected_result` is `reject`.
+- `expected_error_field` is present when the rejection belongs to a specific
+  field.
+- `host_shape_ref` never records host-private behavior.
+
+## Operation Entry
+
+Every operation entry records:
+
+```txt
+operation_id
+method
+path
+headers
+body_ref
+actor_id
+work_session_id
+expected_status
+expected_event_ref
+expected_error_id
+```
+
+Rules:
+
+- `operation_id`, `method`, `path`, `headers`, `actor_id`, and
+  `expected_status` are required.
+- `work_session_id` is present only for WorkSession-scoped operations.
+- `body_ref` is present only when the operation has a request body.
+- `expected_event_ref` is present only when an accepted operation creates or
+  appends a JarvisEvent.
+- `expected_error_id` is present only when the operation rejects.
+- WorkSession-scoped mutations include all six zero-trust headers.
+- Non-WorkSession mutations include the non-WorkSession mutation headers.
+- Read operations include protocol version, actor id, and caller auth.
+- Accepted WorkSession-scoped mutations link to the previous event hash.
+- Rejected operations record the protocol error id.
+
+## Assertion Classes
+
+Fixtures use these assertion classes:
+
+```txt
+header_gate
+actor_authority_gate
+event_chain_gate
+policy_decision_gate
+request_resolution_gate
+approval_scope_gate
+takeover_epoch_gate
+contribution_attribution_gate
+evidence_export_gate
+learning_governance_gate
+host_private_boundary_gate
+```
+
+Each assertion records:
+
+```txt
+assertion_id
+class
+target_ref
+required_state
+expected_result
+expected_error_id
+```
+
+Rules:
+
+- `assertion_id`, `class`, `target_ref`, `required_state`, and
+  `expected_result` are required.
+- `expected_error_id` is present only when `expected_result` is `reject`.
+- `target_ref` resolves to an operation, record, event, export item, or
+  assertion dependency in the fixture.
+
+## Valid Fixture Requirements
+
+The golden-path fixture proves:
+
+- HumanWorker and AgentWorker exist as Worker records
+- HumanWorker and AgentWorker exist as Actor records
+- WorkSession starts with objective, policy, revision, and event hash state
+- AgentWorker action records PolicyDecision before accepted protocol state
+- Policy-denied action creates scoped Request
+- Review or Takeover resolves Request
+- Review approval or narrowing creates bounded ApprovalScope
+- Takeover records lock state before human direct control
+- Contribution records attributable work
+- EvidenceManifest exports portable proof
+- LearningRecord captures human, agent, or pair learning
+- MemoryProposal and SkillProposal keep durable learning governed
+- OutcomeReport references LearningRecord without mutating sealed records
+
+## Invalid Fixture Requirements
+
+Invalid fixtures prove every required failure-mode rejection id:
+
+- missing protocol version
+- missing Actor header
+- invalid Actor authority
+- missing idempotency key
+- missing request timestamp
+- stale request timestamp
+- missing expected WorkSession revision
+- missing previous event hash
+- missing PolicyDecision before AgentWorker state change
+- missing Review resolution
+- missing Takeover resolution
+- invalid ApprovalScope
+- stale WorkSession revision
+- previous event hash mismatch
+- stale Takeover continuation
+- invalid EvidenceManifest export state
+- sealed WorkSession mutation
+- sealed EvidenceManifest mutation
+- forbidden host-private export field
+- silent memory mutation
+- silent skill activation
+- OutcomeReport without LearningRecord
+
+Invalid fixtures also include an OpenAPI-backed unresolved Request fixture.
+
+Each invalid fixture maps to one primary protocol error id.
+
+## Validator Scope
+
+The Week 3 validator checks:
+
+- fixture envelope fields
+- fixture ids
+- protocol version
+- operation headers
+- operation entry field rules
+- required records
+- required assertions
+- assertion entry field rules
+- assertion target refs
+- expected result
+- expected error id
+- required failure-mode coverage
+- forbidden host-private export fields
+- OpenAPI component names referenced by fixtures
+
+The validator does not execute host behavior. It validates protocol fixture
+shape, compatibility shape reference, and expected protocol outcome.
+
+## Done Criteria
+
+Chunk 1 is complete when:
+
+- Week 3 execution spec exists
+- all Week 3 chunks are named
+- fixture directory shape is defined
+- fixture envelope is defined
+- assertion classes are defined
+- validator scope is defined
+- host-owned implementation remains outside the fixture architecture

--- a/docs/planning/week-3/chunk-2-compatibility-mapping.md
+++ b/docs/planning/week-3/chunk-2-compatibility-mapping.md
@@ -1,0 +1,38 @@
+# Chunk 2: Compatibility Mapping Rules
+
+Chunk 2 defines how existing human-agent work maps into Jarvis protocol
+records.
+
+## Scope
+
+This chunk defines protocol mapping rules only.
+
+It does not add adapter code, wrapper code, runtime behavior, host workflow, UI,
+storage, auth, model calls, or tool execution.
+
+## Required Mapping Surface
+
+Chunk 2 maps:
+
+```txt
+human participant              -> HumanWorker + Actor
+agent participant              -> AgentWorker + Actor
+work objective                 -> WorkSession.objective
+agent action                   -> PolicyDecision + JarvisEvent
+blocked action                 -> Request
+human approval or correction   -> Review
+human direct control           -> Takeover
+work performed                 -> Contribution
+source, artifact, output       -> EvidenceManifest item
+confirmed improvement          -> LearningRecord / MemoryProposal / SkillProposal
+post-session feedback          -> OutcomeReport
+```
+
+## Done Criteria
+
+Chunk 2 is complete when:
+
+- every required mapping has a protocol object target
+- unsupported native host concepts map to explicit limitations
+- host-owned execution remains outside Jarvis records
+- mapping rules support the Week 3 fixtures

--- a/docs/planning/week-3/chunk-3-golden-path-fixture.md
+++ b/docs/planning/week-3/chunk-3-golden-path-fixture.md
@@ -1,0 +1,44 @@
+# Chunk 3: Golden-Path Fixture
+
+Chunk 3 adds the valid golden-path fixture.
+
+## Scope
+
+This chunk creates the fixture files required for a passing WorkSession proof.
+
+It does not build a host, adapter, runtime, UI, model integration, or tool
+integration.
+
+## Required Fixture
+
+Chunk 3 adds:
+
+```txt
+docs/conformance/fixtures/README.md
+docs/conformance/fixtures/valid/golden-path.json
+```
+
+## Required Proof
+
+The golden-path fixture records:
+
+- Worker and Actor records for HumanWorker and AgentWorker
+- WorkSession creation with genesis revision and event hash
+- PolicyDecision before AgentWorker action
+- Request for blocked work
+- Review resolving Request
+- ApprovalScope for approved or narrowed authority
+- Contribution records
+- EvidenceManifest export
+- LearningRecord
+- MemoryProposal or SkillProposal
+- OutcomeReport hook
+
+## Done Criteria
+
+Chunk 3 is complete when:
+
+- the valid fixture follows the Chunk 1 envelope
+- the fixture references OpenAPI components by name
+- the fixture proves the golden-path conformance entry
+- local checks pass

--- a/docs/planning/week-3/chunk-4-failure-fixtures.md
+++ b/docs/planning/week-3/chunk-4-failure-fixtures.md
@@ -1,0 +1,55 @@
+# Chunk 4: Failure Fixtures
+
+Chunk 4 adds invalid fixtures for required rejection paths.
+
+## Scope
+
+This chunk creates protocol fixture files that the protocol MUST reject.
+
+It does not simulate host behavior or execute runtime code.
+
+## Required Fixtures
+
+Chunk 4 adds required failure-mode fixtures with these file names and expected
+error ids:
+
+```txt
+missing-protocol-version.json                  -> missing_protocol_version
+missing-actor.json                             -> missing_actor
+unauthorized-actor.json                        -> unauthorized_actor
+missing-idempotency-key.json                   -> missing_idempotency_key
+missing-request-timestamp.json                 -> missing_request_timestamp
+stale-request-timestamp.json                   -> stale_request_timestamp
+missing-expected-work-session-revision.json    -> missing_expected_work_session_revision
+missing-previous-event-hash.json               -> missing_previous_event_hash
+missing-policy-decision.json                   -> missing_policy_decision
+missing-review-resolution.json                 -> missing_review_resolution
+missing-takeover-resolution.json               -> missing_takeover_resolution
+invalid-approval-scope.json                    -> invalid_approval_scope
+stale-work-session-revision.json               -> stale_work_session_revision
+invalid-previous-event-hash.json               -> invalid_previous_event_hash
+stale-takeover-continuation.json               -> stale_takeover_epoch
+invalid-evidence-export-state.json             -> invalid_evidence_export_state
+sealed-work-session-mutation.json              -> sealed_work_session_mutation
+sealed-evidence-mutation.json                  -> sealed_evidence_mutation
+forbidden-host-private-export-field.json       -> forbidden_host_private_field
+silent-memory-mutation.json                    -> silent_memory_mutation
+silent-skill-activation.json                   -> silent_skill_activation
+outcome-report-without-learning-record.json    -> outcome_report_without_learning_record
+```
+
+Chunk 4 also adds this OpenAPI-backed fixture:
+
+```txt
+unresolved-request.json                        -> request_unresolved
+```
+
+## Done Criteria
+
+Chunk 4 is complete when:
+
+- every invalid fixture has one primary expected error id
+- every invalid fixture follows the Chunk 1 envelope
+- required failure-mode rejection ids are covered
+- rejection ids match the OpenAPI ProtocolError model
+- local checks pass

--- a/docs/planning/week-3/chunk-5-fixture-validator.md
+++ b/docs/planning/week-3/chunk-5-fixture-validator.md
@@ -1,0 +1,34 @@
+# Chunk 5: Fixture Validator
+
+Chunk 5 adds local validator checks for conformance fixtures.
+
+## Scope
+
+This chunk validates fixture structure and expected protocol outcomes.
+
+It does not execute host behavior, runtime behavior, model calls, tool calls, or
+adapter code.
+
+## Validator Requirements
+
+The validator checks:
+
+- fixture envelope fields
+- fixture id format
+- protocol version
+- valid versus invalid fixture kind
+- expected result
+- expected error id for invalid fixtures
+- required operation headers
+- required assertion classes
+- forbidden host-private export fields
+- OpenAPI component references
+
+## Done Criteria
+
+Chunk 5 is complete when:
+
+- validator script exists
+- valid fixture passes
+- invalid fixtures fail for their expected protocol error ids
+- validator runs in the local check sequence

--- a/docs/planning/week-3/chunk-6-existing-agent-proof-plan.md
+++ b/docs/planning/week-3/chunk-6-existing-agent-proof-plan.md
@@ -1,0 +1,32 @@
+# Chunk 6: Existing-Agent Compatibility Proof Plan
+
+Chunk 6 defines the existing-agent compatibility proof plan.
+
+## Scope
+
+This chunk proves protocol mapping on paper.
+
+It does not add adapter code, wrapper code, integration code, runtime behavior,
+model calls, tool execution, UI, storage, auth, billing, scoring, or deployment
+behavior.
+
+## Required Proof
+
+Chunk 6 proves:
+
+- an existing agent interaction maps to Worker and Actor records
+- agent actions map to PolicyDecision and JarvisEvent records
+- blocked action maps to Request
+- human answer maps to Review or Takeover
+- performed work maps to Contribution
+- artifacts and sources map to EvidenceManifest records
+- confirmed improvement maps to LearningRecord, MemoryProposal, or SkillProposal
+- unsupported host concepts map to limitations
+
+## Done Criteria
+
+Chunk 6 is complete when:
+
+- two host shapes map to equivalent Jarvis records on paper
+- neither host shape requires Jarvis-owned runtime behavior
+- compatibility proof supports Week 4 compatible examples

--- a/docs/planning/week-3/chunk-7-closeout.md
+++ b/docs/planning/week-3/chunk-7-closeout.md
@@ -1,0 +1,32 @@
+# Chunk 7: Week 3 Closeout
+
+Chunk 7 closes Week 3 and defines readiness for compatible examples.
+
+## Scope
+
+This chunk records the Week 3 result.
+
+It does not start compatible examples. Compatible examples stay behind the
+conformance gate.
+
+## Required Closeout
+
+Chunk 7 records:
+
+- completed compatibility mapping
+- completed fixture architecture
+- completed valid fixture
+- completed invalid fixtures
+- completed validator checks
+- completed existing-agent proof plan
+- remaining protocol gaps
+- Week 4 entry conditions
+
+## Done Criteria
+
+Chunk 7 is complete when:
+
+- Week 3 outputs are linked from the closeout
+- local checks pass
+- automated and human review have no actionable comments
+- Week 4 work starts from conformance evidence, not speculation

--- a/docs/planning/week-3/chunk-7-closeout.md
+++ b/docs/planning/week-3/chunk-7-closeout.md
@@ -22,6 +22,21 @@ Chunk 7 records:
 - remaining protocol gaps
 - Week 4 entry conditions
 
+## Week 4 Entry Conditions
+
+Week 4 starts only when Week 3 records:
+
+- completed fixture architecture
+- completed compatibility mapping
+- passing golden-path fixture
+- invalid fixtures for required rejection ids
+- validator checks for fixture envelope, operations, assertions, and error ids
+- existing-agent compatibility proof plan
+- unresolved protocol gaps, if any
+
+Week 4 compatible examples start from these records. They do not start from
+unvalidated implementation assumptions.
+
 ## Done Criteria
 
 Chunk 7 is complete when:


### PR DESCRIPTION
## Summary

This PR starts Week 3 by defining the execution spec and fixture architecture before any fixture files are added.

It adds the Week 3 planning directory, names all seven chunks, locks the fixture envelope, defines operation and assertion entry rules, maps the required invalid fixture set to protocol error ids, and keeps adapters, runtimes, wrappers, host behavior, and integration code outside Jarvis.

## What Changed

- Added `docs/planning/week-3/README.md`.
- Added Chunk 1 fixture architecture with fixture directory shape, envelope, operation entry, assertion classes, valid/invalid requirements, and validator scope.
- Added scoped specs for Week 3 Chunks 2-7 so the full week path is visible before implementation starts.
- Expanded failure-fixture planning to cover every required `failure-modes.md` error id, plus an additional OpenAPI-backed unresolved Request fixture.

## Validation

- `python3 scripts/check_week1_wording.py`
- `python3 scripts/check_markdown_links.py`
- `python3 scripts/check_openapi_skeleton.py`
- `git diff --check HEAD~1 HEAD`
- custom failure fixture coverage check against OpenAPI `ProtocolErrorId` and `docs/conformance/failure-modes.md`

## Reviewer Agents

- Protocol boundary review: PASS
- Fixture architecture review: PASS after tightening conditional field rules
- OpenAPI/error-id alignment review: PASS after covering all required failure-mode ids
- Wording/public-doc readiness review: PASS after replacing tool-specific review wording


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Week 3 planning documentation for protocol conformance testing, including fixture architecture and envelope specifications, expected fixture directory structure, and protocol compatibility mapping rules.
  * Documented the golden-path valid fixture scope and required artifacts, plus failure fixtures and their expected error ID mappings.
  * Added requirements for a local fixture validator and an existing-agent compatibility proof plan, along with Week 3 closeout/readiness criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->