### PR TITLE
[codex] Align audit status and SDK boundary docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,39 @@ Outside Jarvis: Host implementation
 OpenAPI 3.1 is the primary machine-readable communication contract. Separate
 schema-file packages are not the primary contract.
 
+## SDK Boundary
+
+A Jarvis SDK is a protocol implementation kit.
+
+A Jarvis SDK helps compatible implementations create, validate, sign, hash,
+export, and test Jarvis protocol records.
+
+A Jarvis SDK does not run agents. A Jarvis SDK does not orchestrate models. A
+Jarvis SDK does not execute tools. A Jarvis SDK does not own memory engines,
+planning loops, UI, auth, storage, sandboxing, queues, billing, deployment, or
+host workflow.
+
+Jarvis SDK work is accepted only when it strengthens protocol implementation:
+
+- generated OpenAPI clients
+- protocol types
+- event envelope helpers
+- event hash-chain helpers
+- idempotency helpers
+- mutation-header helpers
+- EvidenceManifest helpers
+- Request, Review, and Takeover validators
+- conformance fixture runners
+- protocol error helpers
+- example record mappers
+
+Jarvis SDK work is rejected when it becomes an agent framework, runtime,
+planner, model router, tool executor, memory engine, host adapter, wrapper, UI
+kit, auth provider, storage backend, sandbox, or workflow engine.
+
+The adoption test is strict: an existing agent must be able to participate in
+Jarvis through protocol records without being rewritten as a Jarvis agent.
+
 ## Zero-Trust Requirement
 
 Jarvis starts from zero trust.

--- a/README.md
+++ b/README.md
@@ -229,6 +229,24 @@ Jarvis does not own host implementation:
 - monitoring
 - host-specific workflow
 
+## SDK Boundary
+
+A Jarvis SDK is a protocol implementation kit.
+
+It helps compatible implementations create protocol records, attach required
+headers, preserve event hash chains, validate Request/Review/Takeover state,
+export EvidenceManifest records, run conformance fixtures, and map example
+work into Jarvis records.
+
+A Jarvis SDK does not run agents, orchestrate models, execute tools, own memory
+engines, provide UI, manage auth, store records, run sandboxes, schedule work,
+or become a host adapter.
+
+Existing agents remain first-class. Jarvis succeeds when existing agents and
+hosts produce compatible WorkSession, Request, Review, Contribution,
+EvidenceManifest, and LearningRecord records without being rewritten as
+Jarvis-owned agents.
+
 ## What Jarvis v0.1 Must Prove
 
 ```txt

--- a/docs/conformance/existing-agent-proof-plan.md
+++ b/docs/conformance/existing-agent-proof-plan.md
@@ -16,6 +16,14 @@ billing, scoring, payment, deployment behavior, or host-specific workflow.
 Compatible implementations MUST preserve host-owned execution and record only
 Jarvis protocol state.
 
+A Jarvis SDK, when used, acts only as a protocol implementation kit. It helps
+the host create, validate, export, and test Jarvis records. It does not run the
+agent, replace the native agent, orchestrate models, execute tools, own memory,
+provide UI, manage auth, store records, or become the host adapter.
+
+The proof rejects compatibility claims that require rewriting an existing agent
+as a Jarvis-owned agent.
+
 ## Proof Inputs
 
 Existing-agent compatibility proof starts from these protocol records:

--- a/docs/planning/12-30-day-roadmap.md
+++ b/docs/planning/12-30-day-roadmap.md
@@ -26,6 +26,12 @@ The practical proof is simple: a human and an existing agent complete real
 work through a WorkSession, produce evidence, record who did what, and leave
 behind learning that improves the next WorkSession.
 
+Jarvis protocol implementation helpers, including SDKs, exist only to help
+compatible implementations produce, validate, export, and test Jarvis records.
+Jarvis SDKs do not become agent frameworks, runtimes, planners, model
+orchestrators, tool executors, memory engines, host adapters, UI kits, auth
+providers, storage backends, sandboxes, or workflow engines.
+
 ## Current Protocol Landscape
 
 Jarvis sits beside existing standards:
@@ -183,6 +189,7 @@ Deliverables:
 - protocol examples for WorkSession, Request, Review, EvidenceManifest, and
   LearningRecord
 - conformance checklist published
+- Jarvis SDK boundary note: protocol implementation kit, not agent framework
 - GitHub Pages simulation updated to show the OpenAPI proof path
 - short public narrative: why Jarvis exists and what it does not replace
 
@@ -229,6 +236,7 @@ Daily checks:
 - Jarvis remains protocol-only.
 - Compatible examples stay outside the protocol core.
 - Existing agents remain first-class.
+- Jarvis SDKs implement protocol helpers only.
 - HumanWorker and AgentWorker are both actors.
 - Learning belongs to the human, agent, and pair.
 - Evidence is captured during work.

--- a/docs/planning/ROADMAP.md
+++ b/docs/planning/ROADMAP.md
@@ -208,7 +208,7 @@ Done when:
 
 ## Milestone 2: WorkSession Lifecycle
 
-Status: active.
+Status: complete.
 
 Owner: Protocol
 
@@ -228,6 +228,8 @@ Done when:
 - events remain attributable to an Actor
 
 ## Milestone 3: Policy, Request, Review, Takeover
+
+Status: complete.
 
 Owner: Safety
 
@@ -251,6 +253,8 @@ Done when:
 
 ## Milestone 4: Contribution And Evidence
 
+Status: complete.
+
 Owner: Evidence
 
 Output:
@@ -270,6 +274,8 @@ Done when:
 - evidence is captured during work, not reconstructed after completion
 
 ## Milestone 5: Governed Learning
+
+Status: complete.
 
 Owner: Learning
 
@@ -292,6 +298,8 @@ Done when:
 
 ## Milestone 6: Conformance Suite
 
+Status: complete.
+
 Owner: Developer Experience
 
 Output:
@@ -313,6 +321,8 @@ Done when a host proves:
 - learning is governed
 
 ## Milestone 7: Examples And Public Docs
+
+Status: active.
 
 Owner: Developer Experience
 

--- a/docs/planning/ROADMAP.md
+++ b/docs/planning/ROADMAP.md
@@ -59,6 +59,7 @@ Jarvis owns:
 - capability negotiation rules
 - conformance tests
 - interoperability rules
+- protocol implementation helper rules
 
 Jarvis does not own:
 
@@ -79,6 +80,12 @@ Jarvis does not own:
 - operational monitoring
 
 Hosts own those responsibilities.
+
+Jarvis SDKs are protocol implementation kits. They help compatible
+implementations create, validate, export, and test Jarvis records. They do not
+run agents, orchestrate models, execute tools, own memory engines, provide UI,
+manage auth, store records, run sandboxes, schedule work, or become host
+adapters.
 
 ## Release Strategy
 
@@ -143,10 +150,12 @@ MemoryProposal and SkillProposal remain governed
 - version and capability negotiation
 - one protocol simulation that visualizes the proof path
 - compatible implementation guide
+- protocol implementation helper boundary
 
 ### v0.1 Excludes
 
 - execution packages
+- agent framework packages
 - cloud implementation
 - local execution implementation
 - model calls
@@ -353,6 +362,7 @@ v0.1 is accepted when:
   platform
 - public docs describe Jarvis as protocol only
 - live simulation describes Jarvis as protocol only
+- any Jarvis SDK surface is limited to protocol implementation helpers
 
 ## v0.2 Evidence And Learning Beta
 
@@ -448,6 +458,17 @@ Risk: agent memory mutates without human review.
 
 Control: learning becomes MemoryProposal or SkillProposal until reviewed.
 
+### SDK Creep
+
+Risk: Jarvis SDK work becomes an agent framework, runtime, planner, model
+orchestrator, tool executor, memory engine, host adapter, UI kit, auth
+provider, storage backend, sandbox, or workflow engine.
+
+Control: Jarvis SDK work stays limited to protocol types, OpenAPI clients,
+event helpers, hash-chain helpers, header helpers, validation helpers,
+EvidenceManifest helpers, conformance fixture runners, protocol error helpers,
+and example record mappers.
+
 ## Immediate Next Actions
 
 1. Keep the repository protocol-only.
@@ -460,3 +481,4 @@ Control: learning becomes MemoryProposal or SkillProposal until reviewed.
 7. Update the public simulation to show the OpenAPI proof path.
 8. Keep adapter code, wrappers, host behavior, and integration code outside
    Jarvis.
+9. Keep every Jarvis SDK discussion limited to protocol implementation helpers.

--- a/docs/planning/week-2/chunk-6-path-security-binding.md
+++ b/docs/planning/week-2/chunk-6-path-security-binding.md
@@ -47,7 +47,7 @@ POST /outcome-reports
 ```
 
 This chunk does not define behavior outside the path and security binding.
-Chunk 7 locked examples and conformance entry. Week 3 handles protocol
+Chunk 7 locked examples and conformance entry. Week 3 handled protocol
 compatibility mapping and conformance fixtures.
 
 ## Header Classes

--- a/docs/planning/week-2/closeout.md
+++ b/docs/planning/week-2/closeout.md
@@ -42,15 +42,14 @@ how Contribution and EvidenceManifest records are exported
 how OutcomeReport feeds post-session learning
 ```
 
-## Week 3 Entry
+## Week 3 Result
 
-Week 3 starts from this contract.
+Week 3 started from this contract.
 
-Week 3 proves the contract through protocol compatibility mapping and
+Week 3 proved the contract through protocol compatibility mapping and
 conformance fixtures.
 
 Jarvis does not add or own adapters, runtimes, wrappers, host behavior, or
 integration code.
 
-Week 3 does not reopen Week 1 protocol locks or Week 2 OpenAPI structure unless
-a concrete conformance contradiction blocks progress.
+Week 3 did not reopen Week 1 protocol locks or Week 2 OpenAPI structure.

--- a/docs/planning/week-3/README.md
+++ b/docs/planning/week-3/README.md
@@ -1,6 +1,6 @@
 # Week 3: Protocol Compatibility Mapping And Conformance Fixtures
 
-Week 3 proves the Week 2 OpenAPI contract through protocol compatibility
+Week 3 proved the Week 2 OpenAPI contract through protocol compatibility
 mapping and conformance fixtures.
 
 Status: complete.
@@ -17,7 +17,7 @@ rewriting the agent runtime or moving host behavior into Jarvis.
 
 ## Inputs
 
-Week 3 starts from:
+Week 3 started from:
 
 - [../../openapi/jarvis-openapi.yaml](../../openapi/jarvis-openapi.yaml)
 - [../../conformance/golden-path.md](../../conformance/golden-path.md)
@@ -28,7 +28,7 @@ Week 3 starts from:
 
 ## Week 3 Outputs
 
-Week 3 produces:
+Week 3 produced:
 
 - protocol compatibility mapping rules
 - fixture architecture

--- a/docs/protocol/08-package-contracts.md
+++ b/docs/protocol/08-package-contracts.md
@@ -1,6 +1,12 @@
-# Protocol Artifact Contracts
+# Protocol Artifact And SDK Contracts
 
-Jarvis v0.1 publishes protocol artifacts, not implementation packages.
+Jarvis v0.1 publishes protocol artifacts.
+
+Future Jarvis SDKs are protocol implementation kits. They help compatible
+implementations produce, validate, export, and test Jarvis records. They do
+not become agent frameworks, runtimes, host adapters, wrappers, planners,
+model orchestrators, tool executors, memory engines, UI kits, auth providers,
+storage backends, sandboxes, or workflow engines.
 
 OpenAPI 3.1 is the primary machine-readable communication contract. Supporting
 artifacts exist only to keep the protocol readable, testable, and
@@ -19,11 +25,14 @@ Jarvis owns:
 - conformance checklists
 - conformance fixtures
 - examples
+- protocol implementation helper packages
 
 Hosts own:
 
-- SDKs
-- clients
+- agent SDKs
+- runtime SDKs
+- host SDKs
+- host clients
 - engines
 - factories
 - storage clients
@@ -35,8 +44,51 @@ Hosts own:
 - runtime adapters
 - deployment packages
 
-Jarvis artifacts MUST NOT expose implementation APIs, host service APIs,
-storage clients, runtime adapters, or tool executors.
+Jarvis artifacts and SDKs MUST NOT expose implementation APIs, host service
+APIs, storage clients, runtime adapters, model routers, planning loops, memory
+engines, or tool executors.
+
+## SDK Boundary
+
+A Jarvis SDK contains only:
+
+```txt
+generated OpenAPI clients
+protocol types
+event envelope helpers
+event hash-chain helpers
+idempotency helpers
+mutation-header helpers
+EvidenceManifest helpers
+Request validators
+Review validators
+Takeover validators
+protocol error helpers
+conformance fixture runners
+example record mappers
+```
+
+A Jarvis SDK is rejected when it owns:
+
+```txt
+agent runtime
+planner
+model orchestration
+tool execution
+memory engine
+host adapter
+wrapper runtime
+UI
+auth provider
+storage backend
+sandbox
+workflow engine
+billing
+deployment
+```
+
+Compatible implementations use a Jarvis SDK to implement Jarvis records. They
+do not replace existing agents with a Jarvis-owned agent.
 
 ## OpenAPI Contract
 

--- a/docs/protocol/14-protocol-lock.md
+++ b/docs/protocol/14-protocol-lock.md
@@ -8,7 +8,7 @@ reviews, takeovers, contributions, evidence, and learning that happen inside a
 WorkSession.
 
 This is the v0.1 protocol lock. Week 2 converted this lock into the OpenAPI
-3.1 contract and conformance entry. Week 3 builds protocol compatibility
+3.1 contract and conformance entry. Week 3 built protocol compatibility
 mapping and conformance fixtures on top of that contract.
 
 ## Locked Status
@@ -40,7 +40,7 @@ Week 2 completed:
 - OpenAPI examples
 - conformance entry documents
 
-Week 3 uses this contract for:
+Week 3 used this contract for:
 
 - protocol compatibility mapping
 - conformance fixtures
@@ -543,7 +543,7 @@ Week 2 converted this protocol lock into:
    EvidenceManifest, LearningRecord, MemoryProposal, SkillProposal, and
    OutcomeReport.
 
-Week 3 builds protocol compatibility mapping and conformance fixtures on this
+Week 3 built protocol compatibility mapping and conformance fixtures on this
 contract.
 
 The thesis is locked. The object model is locked. The lifecycle is locked. The

--- a/docs/protocol/16-positioning-adoption-lock.md
+++ b/docs/protocol/16-positioning-adoption-lock.md
@@ -73,6 +73,18 @@ Hosts provide UI, auth, storage, execution, connectors, notifications,
 monitoring, support, and deployment. Jarvis defines the records that hosts
 exchange. Jarvis does not become the host.
 
+## SDK Boundary
+
+A Jarvis SDK is a protocol implementation kit.
+
+It helps compatible implementations create, validate, export, and test Jarvis
+records. It does not run agents, orchestrate models, execute tools, own memory
+engines, provide UI, manage auth, store records, run sandboxes, schedule work,
+or become a host adapter.
+
+SDK support does not change the category. Jarvis remains the human-agent
+collaboration and learning-loop protocol.
+
 ## Non-Replacement Rule
 
 Compatible implementations MUST NOT require developers to abandon their


### PR DESCRIPTION
## Summary
- Mark roadmap milestones 2-6 complete and milestone 7 active so the roadmap matches the Week 4 entry state.
- Update stale Week 3 future/current-tense wording in the Week 2 closeout, Week 3 README, Week 2 chunk 6, and protocol lock.
- Lock the Jarvis SDK boundary across contributor rules, README, package contracts, positioning lock, roadmap, and existing-agent proof plan.
- Define Jarvis SDKs as protocol implementation kits only: protocol types, OpenAPI clients, event/hash/header helpers, validators, EvidenceManifest helpers, conformance runners, protocol errors, and example record mappers.
- Reject SDK drift into agent frameworks, runtimes, model orchestration, tool execution, memory engines, host adapters, UI, auth, storage, sandboxes, billing, deployment, or workflow engines.

## Validation
- python3 scripts/check_conformance_fixtures.py
- python3 scripts/check_openapi_skeleton.py
- python3 scripts/check_markdown_links.py
- python3 scripts/check_week1_wording.py
- git diff --check
- OpenAPI/fixture consistency check: duplicate YAML keys, missing required schema properties, fixture operation IDs, invalid fixture error IDs