### PR TITLE
[codex] Add Week 4 execution plan

### DIFF
--- a/docs/planning/week-4/README.md
+++ b/docs/planning/week-4/README.md
@@ -1,0 +1,93 @@
+# Week 4: Compatible Examples And Public Story
+
+Week 4 turns the locked protocol, OpenAPI contract, conformance fixtures, and
+existing-agent proof plan into public compatibility artifacts.
+
+Status: active.
+
+Week 4 does not build adapters, wrappers, host runtimes, UI, model calls, tool
+execution, storage, auth, billing, scoring, payment, deployment behavior, or
+SDK implementation.
+
+Jarvis records the protocol proof. Hosts provide the implementation.
+
+## Goal
+
+Prove that existing human-agent work maps into Jarvis protocol records in a
+way that developers understand, verify, and adopt without rewriting their
+agents or moving host behavior into Jarvis.
+
+## Inputs
+
+Week 4 starts from:
+
+- [../../openapi/jarvis-openapi.yaml](../../openapi/jarvis-openapi.yaml)
+- [../../conformance/compatibility-mapping.md](../../conformance/compatibility-mapping.md)
+- [../../conformance/existing-agent-proof-plan.md](../../conformance/existing-agent-proof-plan.md)
+- [../../conformance/fixtures/README.md](../../conformance/fixtures/README.md)
+- [../week-3/closeout.md](../week-3/closeout.md)
+- [../../protocol/08-package-contracts.md](../../protocol/08-package-contracts.md)
+- [../../protocol/14-protocol-lock.md](../../protocol/14-protocol-lock.md)
+- [../../protocol/15-openapi-communication-binding.md](../../protocol/15-openapi-communication-binding.md)
+- [../../protocol/16-positioning-adoption-lock.md](../../protocol/16-positioning-adoption-lock.md)
+
+## Week 4 Outputs
+
+Week 4 produces:
+
+- compatible host mapping example
+- existing-agent compatibility example
+- public conformance checklist
+- protocol record examples
+- public README tightening
+- public story note
+- simulation OpenAPI proof-path update
+- Week 4 closeout
+
+## Chunk Plan
+
+1. [chunk-1-execution-spec.md](./chunk-1-execution-spec.md)
+   Lock Week 4 scope, gates, chunks, review lanes, and done state.
+2. [chunk-2-compatible-host-mapping.md](./chunk-2-compatible-host-mapping.md)
+   Define the host-shape mapping example from native human-agent work into
+   Jarvis records.
+3. [chunk-3-existing-agent-example.md](./chunk-3-existing-agent-example.md)
+   Define the existing-agent compatibility example without adapter code or
+   runtime ownership.
+4. [chunk-4-public-conformance-checklist.md](./chunk-4-public-conformance-checklist.md)
+   Publish the readable conformance checklist from the Week 3 fixtures and
+   rejection gates.
+5. [chunk-5-protocol-record-examples.md](./chunk-5-protocol-record-examples.md)
+   Add concrete protocol record examples for the core collaboration loop.
+6. [chunk-6-public-story-simulation.md](./chunk-6-public-story-simulation.md)
+   Tighten public README language, public story, and simulation proof path.
+7. [chunk-7-closeout.md](./chunk-7-closeout.md)
+   Close Week 4 after checks, review, CodeRabbit, and public readiness pass.
+
+## Done State
+
+Week 4 is complete when:
+
+- at least two host shapes map to equivalent Jarvis records
+- one existing-agent example preserves native execution
+- public conformance checklist links to fixture rejection gates
+- protocol examples show WorkSession, Request, Review, Takeover, Contribution,
+  EvidenceManifest, LearningRecord, MemoryProposal, SkillProposal, and
+  OutcomeReport
+- README explains Jarvis as protocol only
+- simulation shows the OpenAPI proof path
+- SDK language stays limited to protocol implementation helpers
+- local checks pass
+- automated and human review have no actionable comments
+
+## Boundary
+
+Jarvis owns protocol records, examples, conformance expectations, and public
+protocol explanation.
+
+Hosts own execution, storage, identity, UI, runtime behavior, model calls, tool
+execution, billing, monitoring, workflow, adapters, wrappers, and deployment.
+
+Week 4 strengthens Jarvis only when a change improves public protocol clarity,
+compatibility proof, conformance readability, portable evidence, governed
+learning, existing-agent adoption, or SDK boundary discipline.

--- a/docs/planning/week-4/chunk-1-execution-spec.md
+++ b/docs/planning/week-4/chunk-1-execution-spec.md
@@ -1,0 +1,108 @@
+# Chunk 1: Week 4 Execution Spec
+
+Chunk 1 locks the Week 4 working method before compatibility examples and
+public docs start.
+
+## Scope
+
+This chunk defines:
+
+- Week 4 goal
+- Week 4 chunk sequence
+- artifact ownership
+- review lanes
+- done gates
+- local validation
+- CodeRabbit gate
+
+This chunk does not create compatibility examples, public checklist content,
+record examples, README edits, simulation edits, adapter code, SDK code, or
+runtime behavior.
+
+## Required Artifacts
+
+Chunk 1 creates:
+
+```txt
+docs/planning/week-4/README.md
+docs/planning/week-4/chunk-1-execution-spec.md
+docs/planning/week-4/chunk-2-compatible-host-mapping.md
+docs/planning/week-4/chunk-3-existing-agent-example.md
+docs/planning/week-4/chunk-4-public-conformance-checklist.md
+docs/planning/week-4/chunk-5-protocol-record-examples.md
+docs/planning/week-4/chunk-6-public-story-simulation.md
+docs/planning/week-4/chunk-7-closeout.md
+```
+
+## Review Lanes
+
+Every Week 4 implementation chunk requires these review lanes before PR ready:
+
+```txt
+protocol-boundary review
+zero-trust security review
+conformance and fixture review
+existing-agent compatibility review
+public-readability review
+wording review
+```
+
+The protocol-boundary review verifies that Jarvis stays protocol-only.
+
+The zero-trust security review verifies required headers, Actor authority,
+WorkSession revision, previous event hash, forbidden export fields, and
+host-private exclusion.
+
+The conformance and fixture review verifies that examples match the OpenAPI
+contract and the Week 3 fixture gates.
+
+The existing-agent compatibility review verifies that examples preserve native
+agent execution and never require a Jarvis-owned agent.
+
+The public-readability review verifies that the public story explains Jarvis
+without product-specific or host-specific assumptions.
+
+The wording review verifies direct protocol language.
+
+## Required Checks
+
+Every Week 4 PR runs:
+
+```txt
+python3 scripts/check_conformance_fixtures.py
+python3 scripts/check_openapi_skeleton.py
+python3 scripts/check_markdown_links.py
+python3 scripts/check_week1_wording.py
+git diff --check
+```
+
+Fixture or OpenAPI changes also require the relevant targeted validation from
+the changed area.
+
+## Week 4 Chunk Order
+
+Week 4 work proceeds in this order:
+
+```txt
+1. execution spec
+2. compatible host mapping
+3. existing-agent example
+4. public conformance checklist
+5. protocol record examples
+6. public story and simulation
+7. closeout
+```
+
+Later chunks use earlier chunks as inputs. A chunk does not reopen previous
+protocol locks unless a concrete contradiction blocks compatibility proof.
+
+## Acceptance Gate
+
+Chunk 1 is complete when:
+
+- Week 4 directory exists
+- all Week 4 chunk files exist
+- each chunk has scope, output, boundary, review, and done criteria
+- local checks pass
+- internal reviewer lanes have no valid unresolved findings
+- CodeRabbit has no valid unresolved findings

--- a/docs/planning/week-4/chunk-2-compatible-host-mapping.md
+++ b/docs/planning/week-4/chunk-2-compatible-host-mapping.md
@@ -1,0 +1,112 @@
+# Chunk 2: Compatible Host Mapping Example
+
+Chunk 2 creates the first public-compatible host mapping example.
+
+## Scope
+
+This chunk maps one native human-agent workflow into Jarvis records.
+
+The example starts from the Week 3 proof plan and includes `host_shape_ref`
+as descriptive metadata only. `host_shape_ref` names the host boundary shape; it
+MUST NOT select behavior, change required records, change conformance results,
+or imply a Jarvis-owned host adapter or runtime.
+
+Allowed `host_shape_ref` values for this example are:
+
+```txt
+command_line_host_boundary
+local_execution_host_boundary
+```
+
+This chunk does not build a host, adapter, wrapper, runtime, UI, model
+integration, tool integration, storage backend, auth backend, SDK package, or
+deployment path.
+
+## Required Output
+
+Chunk 2 creates or updates:
+
+```txt
+docs/examples/compatible-host-mapping.md
+```
+
+The mapping example records:
+
+```txt
+native human participant -> HumanWorker + Actor
+native agent participant -> AgentWorker + Actor
+native work objective -> WorkSession.objective
+native policy boundary -> Policy
+native agent action -> PolicyDecision + JarvisEvent
+blocked native action -> Request
+human judgment -> Review or Takeover
+approved or narrowed authority -> ApprovalScope
+performed work -> Contribution
+source events and artifacts -> EvidenceManifest evidence refs
+confirmed improvement -> LearningRecord
+durable memory update -> MemoryProposal
+reusable procedure update -> SkillProposal
+post-session feedback -> OutcomeReport
+```
+
+## Required Invariants
+
+The example preserves:
+
+- WorkSession-scoped mutation headers: `Jarvis-Protocol-Version`,
+  `Jarvis-Actor-Id`, `Jarvis-Idempotency-Key`,
+  `Jarvis-Request-Timestamp`, `Jarvis-Expected-WorkSession-Revision`, and
+  `Jarvis-Previous-Event-Hash`
+- non-WorkSession protocol mutation headers: `Jarvis-Protocol-Version`,
+  `Jarvis-Actor-Id`, `Jarvis-Idempotency-Key`, and
+  `Jarvis-Request-Timestamp` only
+- Actor authority verification before accepted protocol state
+- WorkSession revision check for every WorkSession-scoped mutation
+- previous event hash linkage for every WorkSession-scoped mutation
+- PolicyDecision before accepted AgentWorker state
+- Request for denied, blocked, or review-required scope
+- Review or Takeover as the only human resolution path
+- ApprovalScope bounds for approve or narrow Review decisions
+- Takeover lock epoch and reconciliation refs
+- attributable Contribution records
+- EvidenceManifest source event refs
+- forbidden host-private export exclusion
+- governed LearningRecord, MemoryProposal, and SkillProposal records
+- OutcomeReport as post-session feedback without sealed-record mutation
+
+## Public Explanation
+
+The example must answer:
+
+```txt
+What happened?
+Who acted?
+What did policy allow or block?
+Where did the agent request human help?
+What did the human review or take over?
+What evidence proves the work?
+What learning carries forward?
+What stays host-owned?
+```
+
+## Review Focus
+
+Review verifies:
+
+- mapping uses protocol objects only
+- host-owned execution stays outside records
+- example fields exist in the OpenAPI contract
+- example references Week 3 conformance gates
+- wording stays direct and public-readable
+
+## Done Criteria
+
+Chunk 2 is complete when:
+
+- compatible host mapping doc exists
+- both host shapes map to equivalent Jarvis records
+- no adapter or runtime behavior enters Jarvis
+- all required invariants are represented
+- local checks pass
+- internal reviewer lanes have no valid unresolved findings
+- CodeRabbit has no valid unresolved findings

--- a/docs/planning/week-4/chunk-3-existing-agent-example.md
+++ b/docs/planning/week-4/chunk-3-existing-agent-example.md
@@ -1,0 +1,111 @@
+# Chunk 3: Existing-Agent Compatibility Example
+
+Chunk 3 proves that an existing agent participates in Jarvis without becoming a
+Jarvis-owned agent.
+
+## Scope
+
+This chunk defines a public example for an existing native agent boundary.
+When the example mentions a Jarvis SDK, the SDK appears only as a protocol
+implementation helper around that native agent.
+
+The native agent keeps its own runtime, model calls, tool calls, memory,
+skills, tracing, session handling, and execution flow. Jarvis records the
+human-agent collaboration loop around that native work.
+
+This chunk does not build adapter code, wrapper code, SDK code, integration
+code, runtime behavior, host workflow, UI, model routing, tool execution,
+storage, auth, billing, scoring, payment, or deployment behavior.
+
+## Required Output
+
+Chunk 3 creates or updates:
+
+```txt
+docs/examples/existing-agent-compatibility.md
+```
+
+The example records:
+
+```txt
+WorkSession-scoped mutation headers -> Jarvis-Protocol-Version, Jarvis-Actor-Id, Jarvis-Idempotency-Key, Jarvis-Request-Timestamp, Jarvis-Expected-WorkSession-Revision, Jarvis-Previous-Event-Hash
+non-WorkSession protocol mutation headers -> Jarvis-Protocol-Version, Jarvis-Actor-Id, Jarvis-Idempotency-Key, Jarvis-Request-Timestamp only
+Actor authority verification -> before accepted protocol state
+WorkSession revision check -> every WorkSession-scoped mutation
+previous event hash linkage -> every WorkSession-scoped mutation
+existing agent identity -> AgentWorker + Actor
+human operator -> HumanWorker + Actor
+task intent -> WorkSession
+agent action affecting protocol state -> PolicyDecision
+blocked action -> Request
+human resolution -> Review or Takeover
+agent continuation -> JarvisEvent inside approved scope
+work performed -> Contribution
+evidence captured during work -> EvidenceManifest
+confirmed learning -> LearningRecord
+future behavior change -> MemoryProposal or SkillProposal
+external result -> OutcomeReport
+```
+
+## Non-Rewrite Rule
+
+The example rejects compatibility claims that require:
+
+- rewriting the existing agent as a Jarvis agent
+- moving native runtime behavior into Jarvis
+- moving model orchestration into Jarvis
+- moving tool execution into Jarvis
+- moving native memory into Jarvis
+- making Jarvis own host storage, auth, UI, or deployment
+
+## SDK Boundary
+
+The example treats a Jarvis SDK as a protocol implementation kit only.
+
+Allowed SDK use:
+
+```txt
+create protocol records
+validate records
+attach required headers
+preserve event hash chain
+export EvidenceManifest
+run conformance checks
+map example records
+```
+
+Rejected SDK use:
+
+```txt
+run agent
+plan task
+route model
+execute tool
+own memory
+own host adapter
+own UI
+own auth
+own storage
+```
+
+## Review Focus
+
+Review verifies:
+
+- existing agent remains native
+- Jarvis records collaboration only
+- compatibility proof references Week 3 gates
+- SDK boundary stays protocol-only
+- public wording explains why existing agents still need Jarvis records
+
+## Done Criteria
+
+Chunk 3 is complete when:
+
+- existing-agent compatibility doc exists
+- the example preserves native execution
+- the example maps the full collaboration loop into protocol records
+- SDK language stays limited to protocol implementation helpers
+- local checks pass
+- internal reviewer lanes have no valid unresolved findings
+- CodeRabbit has no valid unresolved findings

--- a/docs/planning/week-4/chunk-4-public-conformance-checklist.md
+++ b/docs/planning/week-4/chunk-4-public-conformance-checklist.md
@@ -1,0 +1,128 @@
+# Chunk 4: Public Conformance Checklist
+
+Chunk 4 turns Week 3 fixtures and rejection gates into a readable public
+conformance checklist.
+
+## Scope
+
+This chunk publishes the compatibility rules a developer uses to understand
+whether an implementation follows Jarvis.
+
+This chunk does not add new protocol objects, new OpenAPI paths, new fixture
+classes, runtime behavior, adapter code, SDK code, host behavior, UI, storage,
+auth, billing, scoring, payment, or deployment behavior.
+
+## Required Output
+
+Chunk 4 creates or updates:
+
+```txt
+docs/conformance/checklist.md
+```
+
+The checklist covers:
+
+```txt
+participant records
+WorkSession source of truth
+PolicyDecision before accepted AgentWorker state
+Request for blocked scope
+Review and Takeover resolution
+ApprovalScope bounds
+Takeover stale-continuation rejection
+Contribution attribution
+EvidenceManifest source refs
+forbidden host-private export fields
+governed LearningRecord
+MemoryProposal review state
+SkillProposal review state
+OutcomeReport feedback hook
+mutation headers
+event hash chain
+protocol error envelope
+unsupported capability behavior
+```
+
+## Required Rejection Coverage
+
+The checklist covers these Week 3 rejection classes and links fixture-backed
+classes to the current valid and invalid fixtures:
+
+```txt
+missing protocol version
+missing Actor
+unauthorized Actor
+missing idempotency key
+missing request timestamp
+stale request timestamp
+missing expected WorkSession revision
+stale WorkSession revision
+missing previous event hash
+invalid previous event hash
+missing policy
+missing PolicyDecision
+unresolved Request
+missing Review resolution
+missing Takeover resolution
+invalid ApprovalScope
+stale Takeover epoch
+missing reconciliation refs
+invalid EvidenceManifest export state
+sealed WorkSession mutation
+sealed EvidenceManifest mutation
+missing Contribution actor
+invalid contributor refs
+shared Contribution without individual refs
+evidence after the fact
+missing evidence event refs
+forbidden host-private field
+silent memory mutation
+silent skill activation
+OutcomeReport without LearningRecord
+```
+
+The checklist names additional `ProtocolErrorId` values separately as
+non-fixture-backed rejection ids. It MUST NOT describe those ids as fixture
+links unless fixtures are added.
+
+```txt
+unsupported protocol version
+duplicate idempotency mismatch
+invalid event hash
+missing objective
+duplicate contributor ref
+duplicate evidence item ref
+unsupported capability
+```
+
+## Public Format
+
+The checklist uses direct conformance language:
+
+```txt
+Compatible implementations MUST...
+The protocol rejects...
+The export excludes...
+The record preserves...
+```
+
+## Review Focus
+
+Review verifies:
+
+- checklist matches current fixtures
+- rejection ids match OpenAPI error ids
+- no host behavior becomes protocol behavior
+- checklist is readable by public implementers
+- wording remains direct
+
+## Done Criteria
+
+Chunk 4 is complete when:
+
+- public checklist exists
+- checklist references valid and invalid fixtures
+- every Week 3 rejection class appears
+- local checks pass
+- internal reviewer lanes have no valid unresolved findings
+- CodeRabbit has no valid unresolved findings

--- a/docs/planning/week-4/chunk-5-protocol-record-examples.md
+++ b/docs/planning/week-4/chunk-5-protocol-record-examples.md
@@ -1,0 +1,96 @@
+# Chunk 5: Protocol Record Examples
+
+Chunk 5 adds concrete protocol record examples for the core collaboration
+loop.
+
+## Scope
+
+This chunk creates public examples for the protocol records developers need to
+understand first.
+
+This chunk does not create a runtime, host, adapter, SDK package, UI, model
+integration, tool integration, database, auth system, billing system, scoring
+system, payment system, or deployment path.
+
+## Required Output
+
+Chunk 5 creates or updates:
+
+```txt
+docs/examples/protocol-records.md
+```
+
+The examples cover:
+
+```txt
+Worker
+Actor
+HumanWorker
+AgentWorker
+WorkSession
+JarvisEvent
+Policy
+PolicyDecision
+Request
+Review
+Takeover
+ApprovalScope
+Contribution
+EvidenceManifest
+LearningRecord
+MemoryProposal
+SkillProposal
+OutcomeReport
+```
+
+## Example Requirements
+
+Every example record:
+
+- uses fields from the OpenAPI contract
+- avoids host-private fields
+- uses stable ids and refs
+- preserves event ordering where relevant
+- includes required mutation headers when the example describes a mutation
+- links to the conformance gate it demonstrates
+- stays small enough for public readers
+
+## Required Narrative Flow
+
+The examples follow one loop:
+
+```txt
+1. HumanWorker and AgentWorker exist.
+2. WorkSession starts under Policy.
+3. AgentWorker action records PolicyDecision before accepted protocol state.
+4. Blocked action creates Request.
+5. HumanWorker resolves Request through Review or Takeover.
+6. Review approve or narrow creates bounded ApprovalScope.
+7. Takeover records lock epoch and resumed Takeover requires reconciliation refs.
+8. Work creates Contribution.
+9. EvidenceManifest exports proof.
+10. LearningRecord captures pair learning.
+11. MemoryProposal or SkillProposal stays governed.
+12. OutcomeReport carries post-session feedback.
+```
+
+## Review Focus
+
+Review verifies:
+
+- examples match OpenAPI field names
+- references are coherent
+- required gates remain visible
+- examples do not invent host behavior
+- examples teach protocol records without becoming implementation docs
+
+## Done Criteria
+
+Chunk 5 is complete when:
+
+- protocol record examples exist
+- examples cover the required records
+- examples link to conformance expectations
+- local checks pass
+- internal reviewer lanes have no valid unresolved findings
+- CodeRabbit has no valid unresolved findings

--- a/docs/planning/week-4/chunk-6-public-story-simulation.md
+++ b/docs/planning/week-4/chunk-6-public-story-simulation.md
@@ -1,0 +1,95 @@
+# Chunk 6: Public Story And Simulation Proof Path
+
+Chunk 6 tightens the public story and updates the simulation to show the
+OpenAPI proof path.
+
+## Scope
+
+This chunk updates public-facing explanation and the existing GitHub Pages
+simulation.
+
+This chunk does not build product UI, host UI, runtime behavior, adapter code,
+SDK code, model orchestration, tool execution, storage, auth, billing, scoring,
+payment, or deployment behavior.
+
+## Required Output
+
+Chunk 6 updates:
+
+```txt
+README.md
+demo/index.html
+demo/assets/*
+```
+
+Only simulation assets that already belong to the public demo are in scope.
+
+## Public Story
+
+The public story states:
+
+```txt
+MCP connects agents to tools.
+A2A connects agents to agents.
+AG-UI connects agents to UI.
+Jarvis records how humans and agents collaborate, produce evidence, and learn.
+```
+
+The README explains:
+
+```txt
+what Jarvis is
+why Jarvis exists
+what Jarvis does not replace
+how existing agents participate
+what compatible implementations prove
+what SDK helpers are allowed to do
+```
+
+## Simulation Proof Path
+
+The simulation shows:
+
+```txt
+WorkSession-scoped mutation carries required headers
+Actor authority verified
+WorkSession revision checked
+previous event hash linked
+WorkSession created
+Policy attached
+AgentWorker action checked
+PolicyDecision recorded before accepted action
+Request created for blocked or review-required scope
+Review or Takeover resolves Request
+ApprovalScope bounds Review-approved continuation
+Takeover lock epoch and reconciliation refs bound Takeover continuation
+Contribution recorded
+EvidenceManifest exported without host-private fields
+LearningRecord created
+MemoryProposal or SkillProposal remains governed
+OutcomeReport enters post-session feedback without sealed-record mutation
+```
+
+The simulation must not present Jarvis as a workspace product, runtime,
+personal agent, agent framework, scheduler, router, or host UI.
+
+## Review Focus
+
+Review verifies:
+
+- public wording stays protocol-only
+- simulation matches protocol objects and OpenAPI proof path
+- visual copy avoids product-specific claims
+- no new host behavior enters the repo
+- README and simulation tell the same story
+
+## Done Criteria
+
+Chunk 6 is complete when:
+
+- README public story is tighter
+- simulation shows the OpenAPI proof path
+- demo assets render locally or as static files
+- local checks pass
+- internal reviewer lanes have no valid unresolved findings
+- CodeRabbit has no valid unresolved findings

--- a/docs/planning/week-4/chunk-7-closeout.md
+++ b/docs/planning/week-4/chunk-7-closeout.md
@@ -1,0 +1,71 @@
+# Chunk 7: Week 4 Closeout
+
+Chunk 7 closes Week 4 after compatibility examples, public conformance
+checklist, protocol record examples, README updates, and simulation updates are
+complete.
+
+## Scope
+
+This chunk records the Week 4 result.
+
+It does not start SDK implementation, adapter implementation, host
+implementation, runtime work, model orchestration, tool execution, UI work,
+storage work, auth work, billing work, scoring work, payment work, or
+deployment work.
+
+## Required Closeout
+
+Chunk 7 records:
+
+- completed compatible host mapping example
+- completed existing-agent compatibility example
+- completed public conformance checklist
+- completed protocol record examples
+- completed public README tightening
+- completed simulation proof-path update
+- local validation output
+- internal reviewer lane results
+- CodeRabbit result
+- remaining public-readiness gaps
+- v0.1 acceptance status
+
+## Required Output
+
+Chunk 7 creates:
+
+```txt
+docs/planning/week-4/closeout.md
+```
+
+## v0.1 Readiness Gate
+
+Week 4 closeout verifies:
+
+- Jarvis remains protocol-only
+- compatible examples preserve host-owned execution
+- existing agents remain first-class
+- SDK language stays limited to protocol implementation helpers
+- required mutation headers remain visible by operation class
+- accepted WorkSession-scoped state changes verify Actor authority
+- WorkSession-scoped mutations check expected revision and previous event hash
+- AgentWorker actions record PolicyDecision before accepted protocol state
+- Requests resolve only through Review or Takeover
+- Takeover resume requires reconciliation refs
+- EvidenceManifest export excludes forbidden host-private fields
+- public conformance checklist matches fixtures
+- examples match OpenAPI field names
+- README explains Jarvis without product-specific dependency
+- simulation shows protocol proof path
+- local checks pass
+- automated and human review have no valid unresolved findings
+
+## Done Criteria
+
+Chunk 7 is complete when:
+
+- Week 4 outputs are linked from the closeout
+- v0.1 readiness gaps are explicit
+- local checks pass
+- internal reviewer lanes have no valid unresolved findings
+- CodeRabbit has no valid unresolved findings
+- roadmap status is ready for the next phase only after review approves it


### PR DESCRIPTION
## Summary
- Add the Week 4 planning directory with the Week 4 README and seven chunk specs.
- Lock Week 4 as compatible examples and public story work, not runtime, adapter, SDK implementation, host UI, model/tool execution, storage, auth, scoring, payment, or deployment work.
- Define chunks for compatible host mapping, existing-agent example, public conformance checklist, protocol record examples, public README/simulation updates, and Week 4 closeout.
- Add explicit zero-trust, Request/Review/Takeover, fixture-backed rejection, SDK-boundary, and existing-agent compatibility gates before each future Week 4 implementation chunk.

## Internal reviewer lanes
- protocol-boundary review: clean
- zero-trust security and conformance review: findings fixed
- existing-agent compatibility review: findings fixed
- public-readability and wording review: finding fixed

## Validation
- python3 scripts/check_conformance_fixtures.py
- python3 scripts/check_openapi_skeleton.py
- python3 scripts/check_markdown_links.py
- python3 scripts/check_week1_wording.py
- git diff --cached --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Week 4 planning documentation with defined scope, deliverables, and completion criteria.
  * Added detailed execution specifications for protocol examples, compatibility validation, and conformance requirements.
  * Established review requirements and quality gates to ensure deliverable consistency and completeness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->