### PR TITLE
[codex] Add v0.1 acceptance review spec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,6 +237,11 @@ Work on:
 - additional conformance evidence only when it preserves the protocol boundary
 - next-phase specification after acceptance review
 
+The v0.1 acceptance review starts from
+[docs/planning/v0.1-acceptance-review/README.md](./docs/planning/v0.1-acceptance-review/README.md)
+and
+[docs/planning/v0.1-acceptance-review/acceptance-spec.md](./docs/planning/v0.1-acceptance-review/acceptance-spec.md).
+
 Do not build host implementations in this repo.
 Do not build runtime features in this repo.
 Do not add or own adapters, wrappers, host behavior, or integration code in this
@@ -263,7 +268,7 @@ Soft protocol wording is a defect.
 
 Do not write protocol rules with soft modal verbs, speculative phrases,
 advisory phrases, or generic implementation-concern phrasing. The wording
-guard in [scripts/check_week1_wording.py](./scripts/check_week1_wording.py)
+guard in [scripts/check_protocol_wording.py](./scripts/check_protocol_wording.py)
 rejects the blocked terms.
 
 Use direct ownership and state language instead:
@@ -288,9 +293,9 @@ Every protocol PR MUST run:
 
 ```txt
 python3 scripts/check_conformance_fixtures.py
-python3 scripts/check_openapi_skeleton.py
+python3 scripts/check_openapi_contract.py
 python3 scripts/check_markdown_links.py
-python3 scripts/check_week1_wording.py
+python3 scripts/check_protocol_wording.py
 git diff --check
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ external system that needs to participate in governed human-agent collaboration.
 
 ## Interactive Simulation
 
+The simulation is non-normative public explanation. It is not protocol proof
+and it is not a host UI implementation.
+
 Open the live simulation here:
 
 https://flow-research.github.io/jarvis/
@@ -331,9 +334,9 @@ Every protocol PR MUST run:
 
 ```txt
 python3 scripts/check_conformance_fixtures.py
-python3 scripts/check_openapi_skeleton.py
+python3 scripts/check_openapi_contract.py
 python3 scripts/check_markdown_links.py
-python3 scripts/check_week1_wording.py
+python3 scripts/check_protocol_wording.py
 git diff --check
 ```
 

--- a/docs/planning/12-30-day-roadmap.md
+++ b/docs/planning/12-30-day-roadmap.md
@@ -190,7 +190,7 @@ Deliverables:
   SkillProposal, and OutcomeReport
 - public README tightened around protocol positioning
 - Jarvis SDK boundary note: protocol implementation kit, not agent framework
-- GitHub Pages simulation updated to show the OpenAPI proof path
+- GitHub Pages simulation kept as non-normative public explanation
 - short public narrative: why Jarvis exists and what it does not replace
 
 Completed Compatibility Targets:
@@ -242,6 +242,18 @@ Daily checks:
 - Contributions remain attributable.
 - Memory and skills do not silently mutate.
 - Compatibility matters more than owning the runtime.
+
+## v0.1 Acceptance Review
+
+The 30-day proof now enters
+[v0.1 acceptance review](./v0.1-acceptance-review/README.md).
+
+Acceptance review audits the full protocol contract, OpenAPI binding,
+conformance surface, public examples, README, and non-normative simulation
+boundary before v0.1 is called Protocol Alpha.
+
+The acceptance gates are defined in
+[acceptance-spec.md](./v0.1-acceptance-review/acceptance-spec.md).
 
 ## First 72 Hours
 

--- a/docs/planning/ROADMAP.md
+++ b/docs/planning/ROADMAP.md
@@ -17,7 +17,8 @@ For the OpenAPI entry gate, see
 
 Week 1 protocol lock is complete.
 
-Current active work: v0.1 acceptance review after Week 4 closeout.
+Current active work: [v0.1 acceptance review](./v0.1-acceptance-review/README.md)
+after Week 4 closeout.
 
 Week 2 completed the OpenAPI 3.1 component syntax, path syntax, security scheme
 encoding, protocol examples, and conformance entry rules from the locked Week 1
@@ -148,7 +149,7 @@ MemoryProposal and SkillProposal remain governed
 - one real existing-agent compatibility proof
 - valid and invalid conformance fixtures
 - version and capability negotiation
-- one protocol simulation that visualizes the proof path
+- non-normative public simulation boundary
 - compatible implementation guide
 - protocol implementation helper boundary
 
@@ -344,13 +345,13 @@ Output:
 - compatible implementation guide
 - EvidenceManifest consumption rules
 - compatible host boundary note
-- interactive simulation
+- non-normative public simulation boundary
 
 Done when:
 
 - a team understands Jarvis without knowing any specific host
 - a host implements Jarvis without inheriting execution assumptions
-- the public simulation matches the protocol definition
+- the public simulation, when present, stays non-normative and protocol-aligned
 
 ## v0.1 Acceptance
 
@@ -361,7 +362,7 @@ v0.1 is accepted when:
 - no protocol contract names a cloud, database, sandbox, or deployment
   platform
 - public docs describe Jarvis as protocol only
-- live simulation describes Jarvis as protocol only
+- live simulation, when present, describes Jarvis as protocol only
 - any Jarvis SDK surface is limited to protocol implementation helpers
 
 ## v0.2 Evidence And Learning Beta
@@ -476,7 +477,7 @@ and example record mappers.
 3. Use `11-core-protocol-objects.md`, `jarvis-openapi.yaml`, and
    `docs/conformance/` as the source of truth for v0.1 acceptance review.
 4. Review Week 4 closeout against the OpenAPI contract, conformance fixtures,
-   public examples, README, and simulation.
+   public examples, README, and non-normative simulation boundary.
 5. Record public-readiness gaps before starting next-phase specification.
 6. Keep adapter code, wrappers, host behavior, and integration code outside
    Jarvis.

--- a/docs/planning/v0.1-acceptance-review/README.md
+++ b/docs/planning/v0.1-acceptance-review/README.md
@@ -1,0 +1,109 @@
+# v0.1 Acceptance Review
+
+Status: active.
+
+This review decides whether Jarvis v0.1 is ready to be called Protocol Alpha.
+
+The review starts after Week 4 closeout. It audits the full protocol contract,
+OpenAPI binding, conformance surface, public examples, README, and
+non-normative simulation boundary before any v0.1 acceptance decision.
+
+Jarvis records protocol proof. Hosts own native execution.
+
+## Goal
+
+Prove that Jarvis v0.1 is internally consistent, implementable by compatible
+hosts, safe under zero-trust mutation rules, clear to public readers, and still
+strictly protocol-only.
+
+## Non-Goals
+
+This review does not create:
+
+```txt
+SDK implementation
+adapter implementation
+wrapper implementation
+host runtime behavior
+host UI behavior
+model orchestration
+tool execution
+storage behavior
+auth behavior
+billing behavior
+scoring behavior
+payment behavior
+deployment behavior
+```
+
+## Required Inputs
+
+The acceptance review starts from:
+
+- [../../protocol/00-principles.md](../../protocol/00-principles.md)
+- [../../protocol/01-architecture.md](../../protocol/01-architecture.md)
+- [../../protocol/11-core-protocol-objects.md](../../protocol/11-core-protocol-objects.md)
+- [../../protocol/12-request-protocol.md](../../protocol/12-request-protocol.md)
+- [../../protocol/13-contribution-evidence-learning.md](../../protocol/13-contribution-evidence-learning.md)
+- [../../protocol/14-protocol-lock.md](../../protocol/14-protocol-lock.md)
+- [../../protocol/15-openapi-communication-binding.md](../../protocol/15-openapi-communication-binding.md)
+- [../../protocol/16-positioning-adoption-lock.md](../../protocol/16-positioning-adoption-lock.md)
+- [../../openapi/jarvis-openapi.yaml](../../openapi/jarvis-openapi.yaml)
+- [../../conformance/checklist.md](../../conformance/checklist.md)
+- [../../conformance/fixtures/README.md](../../conformance/fixtures/README.md)
+- [../../conformance/fixtures/valid/golden-path.json](../../conformance/fixtures/valid/golden-path.json)
+- [../../conformance/fixtures/invalid/](../../conformance/fixtures/invalid/)
+- [../../examples/compatible-host-mapping.md](../../examples/compatible-host-mapping.md)
+- [../../examples/existing-agent-compatibility.md](../../examples/existing-agent-compatibility.md)
+- [../../examples/protocol-records.md](../../examples/protocol-records.md)
+- [../../../README.md](../../../README.md)
+- [../../../demo/index.html](../../../demo/index.html)
+- [../../../demo/assets/app.js](../../../demo/assets/app.js)
+- [../../../demo/assets/styles.css](../../../demo/assets/styles.css)
+- [../week-4/closeout.md](../week-4/closeout.md)
+
+The demo files are non-normative public explanation. They are not protocol
+proof and they do not block v0.1 unless they misrepresent Jarvis as a product,
+runtime, framework, host UI, or host implementation.
+
+## Review Units
+
+The v0.1 acceptance review has eight units:
+
+```txt
+1. protocol contract audit
+2. OpenAPI binding audit
+3. conformance surface audit
+4. public examples audit
+5. README and non-normative simulation boundary audit
+6. boundary and wording audit
+7. local validation audit
+8. acceptance decision record
+```
+
+Each unit records findings, blockers, decisions, and required fixes before the
+acceptance decision.
+
+## Acceptance Rule
+
+v0.1 is accepted only when every acceptance gate in
+[acceptance-spec.md](./acceptance-spec.md) passes.
+
+The acceptance decision MUST be a separate record. This README starts the
+review. It does not accept v0.1.
+
+## Review Output
+
+The review produces:
+
+```txt
+acceptance findings
+blocker list
+resolved-finding log
+acceptance decision record
+next-phase entry notes
+```
+
+The review rejects any attempt to turn Jarvis into an agent framework, runtime,
+host product, adapter layer, tool executor, UI surface, auth system, storage
+system, billing system, scoring system, or deployment stack.

--- a/docs/planning/v0.1-acceptance-review/acceptance-spec.md
+++ b/docs/planning/v0.1-acceptance-review/acceptance-spec.md
@@ -1,0 +1,219 @@
+# v0.1 Acceptance Review Spec
+
+This spec defines the gates for accepting Jarvis v0.1 as Protocol Alpha.
+
+The review accepts v0.1 only after every gate passes. A failed gate creates a
+blocker. Blockers require a fix and linked evidence before acceptance.
+Deferrals apply only to non-blocking future work outside the v0.1 acceptance
+gates.
+
+Jarvis remains protocol-only throughout the review.
+
+## Gate 1: Protocol Contract
+
+The protocol contract passes when:
+
+```txt
+README, AGENTS.md, protocol docs, planning docs, and examples all define
+Jarvis as the human-agent collaboration and learning-loop protocol.
+```
+
+Required proof:
+
+- core object names match across all public docs
+- `WorkSession` remains the central record
+- `HumanWorker` and `AgentWorker` remain first-class workers and actors
+- `PolicyDecision` exists before accepted AgentWorker protocol state
+- `Request` remains scoped deferral, not chat, notification, or authority
+- `Review` and `Takeover` remain the only human-resolution paths for Request
+- `Contribution` records who did what
+- `EvidenceManifest` exports portable proof without host-private fields
+- `LearningRecord`, `MemoryProposal`, and `SkillProposal` preserve governed
+  learning
+- `OutcomeReport` carries post-session feedback without sealed-record mutation
+- protocol event envelope remains append-only and attributable
+- portable export format excludes forbidden host-private fields
+- version negotiation and capability negotiation remain protocol-owned
+- extension rules require namespaced extensions and reject core-field override
+- protocol error ids and error envelope remain public and portable
+- conformance expectations remain protocol-owned and host-implementation neutral
+
+The gate fails when any protocol source assigns host implementation ownership
+to Jarvis.
+
+## Gate 2: OpenAPI Binding
+
+The OpenAPI binding passes when:
+
+```txt
+docs/openapi/jarvis-openapi.yaml encodes the v0.1 protocol objects,
+operations, security headers, error envelope, and examples without
+host-private fields.
+```
+
+Required proof:
+
+- all core schemas exist
+- required fields match `11-core-protocol-objects.md`
+- core operations exist for WorkSession, event, PolicyDecision, Request,
+  Review, Takeover, Contribution, LearningRecord, MemoryProposal,
+  SkillProposal, EvidenceManifest export, Worker, Actor, and OutcomeReport
+- mutating operations require OpenAPI security through host authentication
+- WorkSession-scoped mutations require the six Jarvis mutation headers
+- non-WorkSession mutations require the four Jarvis mutation headers
+- Worker registration, Actor registration, and OutcomeReport submission do not
+  require fake WorkSession revision or previous event hash values
+- WorkSession-scoped reads and export reads require host authentication,
+  `Jarvis-Protocol-Version`, and `Jarvis-Actor-Id`
+- WorkSession-scoped reads and export reads verify Actor read authority
+- protocol errors expose public error fields only
+
+The gate fails when OpenAPI allows unauthenticated mutation, unauthorized read,
+or portable protocol records that require runtime ids, database ids, UI state,
+credentials, deployment details, billing data, private scores, or provider
+secrets.
+
+## Gate 3: Conformance Surface
+
+The conformance surface passes when:
+
+```txt
+docs/conformance/checklist.md, fixtures, and validator checks prove the golden
+path and required rejection gates.
+```
+
+Required proof:
+
+- golden-path fixture validates
+- invalid fixtures validate
+- fixture-backed rejection ids match the checklist
+- unsupported non-fixture rejection ids remain documented without claiming
+  fixture coverage
+- validator checks required headers, expected revision, previous event hash,
+  Actor authority, PolicyDecision ordering, Request resolution, Takeover epoch,
+  forbidden host-private fields, and sealed-record mutation
+- public checklist covers ApprovalScope bounds
+- public checklist covers Contribution attribution
+- public checklist covers EvidenceManifest export completeness and capture
+  timing
+- public checklist covers MemoryProposal and SkillProposal governance
+- public checklist covers OutcomeReport learning hook
+- public checklist covers protocol error envelope
+- public checklist covers capability negotiation and extension rejection
+
+The gate fails when a fake implementation skips policy, review, evidence,
+learning, or mutation-header enforcement and still appears compatible.
+
+## Gate 4: Compatibility Examples
+
+Compatibility examples pass when:
+
+```txt
+examples show existing human-agent work mapping into Jarvis records without
+rewriting the agent or moving host behavior into Jarvis.
+```
+
+Required proof:
+
+- compatible host mapping includes at least two host shapes
+- existing-agent compatibility preserves native execution
+- examples map permissions into Policy, PolicyDecision, Request, Review,
+  ApprovalScope, and Takeover
+- examples map connectors and tools into host-owned execution with
+  protocol-visible evidence refs
+- examples map completed work into Contribution, EvidenceManifest,
+  LearningRecord, MemoryProposal, SkillProposal, and OutcomeReport
+- examples do not define adapters, wrappers, host runtime behavior, host UI
+  behavior, model calls, tool execution, storage, auth, billing, scoring,
+  payment, or deployment
+
+The gate fails when an example makes Jarvis own Garden-like product behavior,
+native agent runtime behavior, external task-system behavior, or connector
+execution.
+
+## Gate 5: Public README And Non-Normative Simulation
+
+Public docs pass when:
+
+```txt
+README explains Jarvis as protocol-only. The non-normative simulation, when
+present, stays aligned with the protocol boundary and does not become protocol
+proof.
+```
+
+Required proof:
+
+- README one-line definition matches protocol docs
+- README positions Jarvis beside MCP, A2A, and AG-UI without replacing them
+- README states that hosts own UI, storage, auth, execution, models, tools,
+  memory engines, deployment, monitoring, and workflow
+- simulation is treated as public explanation only
+- simulation remains static explanation, not host UI implementation
+- simulation does not define additional protocol objects, operations, or
+  conformance rules
+
+The gate fails when public docs make Jarvis sound like a personal agent,
+runtime, product workspace, model provider, cloud stack, UI framework, or
+agent framework.
+
+## Gate 6: Boundary And Wording
+
+Boundary and wording pass when:
+
+```txt
+all changed markdown uses direct protocol language and passes the wording
+guard.
+```
+
+Required proof:
+
+- protocol statements use direct ownership language
+- host-owned responsibilities stay outside Jarvis
+- SDK language stays limited to protocol implementation helpers
+- docs do not use soft wording for locked protocol rules
+- `python3 scripts/check_protocol_wording.py` passes
+
+The gate fails when a document weakens locked decisions or describes Jarvis as
+guidance, product strategy, host implementation, or third-party review.
+
+## Gate 7: Local Validation
+
+Local validation passes when this command set passes:
+
+```txt
+python3 scripts/check_markdown_links.py
+python3 scripts/check_protocol_wording.py
+python3 scripts/check_openapi_contract.py
+python3 scripts/check_conformance_fixtures.py
+git diff --check
+```
+
+The gate fails when any required protocol local check fails.
+
+The non-normative demo has a separate public-readiness check while the demo
+files remain in the repo:
+
+```txt
+node --check demo/assets/app.js
+```
+
+Demo syntax failure creates a public-readiness finding. It does not fail the
+protocol acceptance gate unless the demo misrepresents Jarvis as a product,
+runtime, framework, host UI, or host implementation.
+
+## Decision Rule
+
+The v0.1 acceptance decision MUST record:
+
+```txt
+accepted gates
+resolved blockers
+future-work deferrals outside acceptance gates
+remaining risks
+release notes required before tag
+next-phase entry scope
+```
+
+The decision MUST NOT mark v0.1 accepted until all gates pass, all blockers are
+resolved, and the decision record links the evidence for each accepted gate.
+Future-work deferrals MUST stay outside the v0.1 acceptance gates.

--- a/docs/planning/week-1/README.md
+++ b/docs/planning/week-1/README.md
@@ -104,7 +104,7 @@ Every chunk runs:
 ```txt
 git diff --check
 python3 scripts/check_markdown_links.py
-python3 scripts/check_week1_wording.py
+python3 scripts/check_protocol_wording.py
 ```
 
 If those scripts do not exist in the branch, the chunk adds them before the PR.

--- a/docs/planning/week-2/chunk-1-openapi-skeleton.md
+++ b/docs/planning/week-2/chunk-1-openapi-skeleton.md
@@ -33,7 +33,7 @@ This chunk does not define:
 
 - [../../openapi/jarvis-openapi.yaml](../../openapi/jarvis-openapi.yaml)
 - [../../openapi/README.md](../../openapi/README.md)
-- [../../../scripts/check_openapi_skeleton.py](../../../scripts/check_openapi_skeleton.py)
+- [../../../scripts/check_openapi_contract.py](../../../scripts/check_openapi_contract.py)
 
 ## Acceptance
 

--- a/docs/planning/week-2/chunk-2-participant-schemas.md
+++ b/docs/planning/week-2/chunk-2-participant-schemas.md
@@ -38,7 +38,7 @@ This chunk does not define:
 
 - [../../openapi/jarvis-openapi.yaml](../../openapi/jarvis-openapi.yaml)
 - [../../openapi/README.md](../../openapi/README.md)
-- [../../../scripts/check_openapi_skeleton.py](../../../scripts/check_openapi_skeleton.py)
+- [../../../scripts/check_openapi_contract.py](../../../scripts/check_openapi_contract.py)
 
 ## Acceptance
 

--- a/docs/planning/week-2/chunk-3-worksession-policy-schemas.md
+++ b/docs/planning/week-2/chunk-3-worksession-policy-schemas.md
@@ -41,7 +41,7 @@ This chunk does not define:
 
 - [../../openapi/jarvis-openapi.yaml](../../openapi/jarvis-openapi.yaml)
 - [../../openapi/README.md](../../openapi/README.md)
-- [../../../scripts/check_openapi_skeleton.py](../../../scripts/check_openapi_skeleton.py)
+- [../../../scripts/check_openapi_contract.py](../../../scripts/check_openapi_contract.py)
 
 ## Acceptance
 

--- a/docs/planning/week-2/chunk-4-control-plane-schemas.md
+++ b/docs/planning/week-2/chunk-4-control-plane-schemas.md
@@ -42,7 +42,7 @@ This chunk does not define:
 
 - [../../openapi/jarvis-openapi.yaml](../../openapi/jarvis-openapi.yaml)
 - [../../openapi/README.md](../../openapi/README.md)
-- [../../../scripts/check_openapi_skeleton.py](../../../scripts/check_openapi_skeleton.py)
+- [../../../scripts/check_openapi_contract.py](../../../scripts/check_openapi_contract.py)
 
 ## Acceptance
 

--- a/docs/planning/week-2/chunk-5-evidence-learning-schemas.md
+++ b/docs/planning/week-2/chunk-5-evidence-learning-schemas.md
@@ -48,7 +48,7 @@ This chunk does not define:
 
 - [../../openapi/jarvis-openapi.yaml](../../openapi/jarvis-openapi.yaml)
 - [../../openapi/README.md](../../openapi/README.md)
-- [../../../scripts/check_openapi_skeleton.py](../../../scripts/check_openapi_skeleton.py)
+- [../../../scripts/check_openapi_contract.py](../../../scripts/check_openapi_contract.py)
 
 ## Acceptance
 

--- a/docs/planning/week-2/chunk-6-path-security-binding.md
+++ b/docs/planning/week-2/chunk-6-path-security-binding.md
@@ -97,7 +97,7 @@ Reads do not require `Jarvis-Idempotency-Key`,
 
 - [../../openapi/jarvis-openapi.yaml](../../openapi/jarvis-openapi.yaml)
 - [../../openapi/README.md](../../openapi/README.md)
-- [../../../scripts/check_openapi_skeleton.py](../../../scripts/check_openapi_skeleton.py)
+- [../../../scripts/check_openapi_contract.py](../../../scripts/check_openapi_contract.py)
 
 ## Acceptance
 

--- a/docs/planning/week-3/chunk-5-fixture-validator.md
+++ b/docs/planning/week-3/chunk-5-fixture-validator.md
@@ -69,9 +69,9 @@ Every conformance-fixture change MUST run:
 
 ```txt
 python3 scripts/check_conformance_fixtures.py
-python3 scripts/check_openapi_skeleton.py
+python3 scripts/check_openapi_contract.py
 python3 scripts/check_markdown_links.py
-python3 scripts/check_week1_wording.py
+python3 scripts/check_protocol_wording.py
 git diff --check
 ```
 

--- a/docs/planning/week-3/chunk-6-existing-agent-proof-plan.md
+++ b/docs/planning/week-3/chunk-6-existing-agent-proof-plan.md
@@ -95,8 +95,8 @@ Every Chunk 6 change MUST run:
 
 ```txt
 python3 scripts/check_conformance_fixtures.py
-python3 scripts/check_openapi_skeleton.py
+python3 scripts/check_openapi_contract.py
 python3 scripts/check_markdown_links.py
-python3 scripts/check_week1_wording.py
+python3 scripts/check_protocol_wording.py
 git diff --check
 ```

--- a/docs/planning/week-3/closeout.md
+++ b/docs/planning/week-3/closeout.md
@@ -174,9 +174,9 @@ Week 3 closeout requires this local check sequence:
 
 ```txt
 python3 scripts/check_conformance_fixtures.py
-python3 scripts/check_openapi_skeleton.py
+python3 scripts/check_openapi_contract.py
 python3 scripts/check_markdown_links.py
-python3 scripts/check_week1_wording.py
+python3 scripts/check_protocol_wording.py
 git diff --check
 ```
 
@@ -184,9 +184,9 @@ This closeout ran the sequence and passed:
 
 ```txt
 conformance fixtures ok
-openapi skeleton ok
+openapi contract ok
 markdown links ok
-week1 wording ok
+protocol wording ok
 git diff --check produced no output
 ```
 

--- a/docs/planning/week-4/chunk-1-execution-spec.md
+++ b/docs/planning/week-4/chunk-1-execution-spec.md
@@ -70,9 +70,9 @@ Every Week 4 PR runs:
 
 ```txt
 python3 scripts/check_conformance_fixtures.py
-python3 scripts/check_openapi_skeleton.py
+python3 scripts/check_openapi_contract.py
 python3 scripts/check_markdown_links.py
-python3 scripts/check_week1_wording.py
+python3 scripts/check_protocol_wording.py
 git diff --check
 ```
 

--- a/docs/planning/week-4/closeout.md
+++ b/docs/planning/week-4/closeout.md
@@ -109,8 +109,8 @@ Week 4 closeout requires this local check sequence:
 
 ```txt
 python3 scripts/check_markdown_links.py
-python3 scripts/check_week1_wording.py
-python3 scripts/check_openapi_skeleton.py
+python3 scripts/check_protocol_wording.py
+python3 scripts/check_openapi_contract.py
 python3 scripts/check_conformance_fixtures.py
 node --check demo/assets/app.js
 git diff --check
@@ -120,8 +120,8 @@ This closeout ran the sequence and passed:
 
 ```txt
 markdown links ok
-week1 wording ok
-openapi skeleton ok
+protocol wording ok
+openapi contract ok
 conformance fixtures ok
 node --check demo/assets/app.js produced no output
 git diff --check produced no output

--- a/scripts/check_openapi_contract.py
+++ b/scripts/check_openapi_contract.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate the Jarvis v0.1 OpenAPI skeleton."""
+"""Validate the Jarvis v0.1 OpenAPI contract."""
 
 from pathlib import Path
 import sys
@@ -1441,7 +1441,7 @@ PORTABLE_PROPERTY_PATTERN = (
 
 
 def fail(message: str) -> int:
-    print(f"openapi skeleton check failed: {message}")
+    print(f"openapi contract check failed: {message}")
     return 1
 
 
@@ -2298,7 +2298,7 @@ def main() -> int:
     if "Jarvis does not operate this server" not in description:
         return fail("server description must state that Jarvis does not operate it")
 
-    print("openapi skeleton ok")
+    print("openapi contract ok")
     return 0
 
 

--- a/scripts/check_protocol_wording.py
+++ b/scripts/check_protocol_wording.py
@@ -62,8 +62,6 @@ def main() -> int:
                 continue
             if in_code_block:
                 continue
-            if path.name == "check_protocol_wording.py":
-                continue
             line_to_check = NORMATIVE_TERM_PATTERN.sub("", line)
             for pattern in [*compiled, *lowercase_compiled]:
                 if pattern.search(line_to_check):

--- a/scripts/check_protocol_wording.py
+++ b/scripts/check_protocol_wording.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Reject wording that drifts away from the Jarvis protocol boundary."""
+"""Validate wording against the Jarvis protocol boundary."""
 
 from pathlib import Path
 import re
@@ -62,7 +62,7 @@ def main() -> int:
                 continue
             if in_code_block:
                 continue
-            if path.name == "check_week1_wording.py":
+            if path.name == "check_protocol_wording.py":
                 continue
             line_to_check = NORMATIVE_TERM_PATTERN.sub("", line)
             for pattern in [*compiled, *lowercase_compiled]:
@@ -75,7 +75,7 @@ def main() -> int:
             print(f"{path}:{line_number}: rejected wording: {line}")
         return 1
 
-    print("week1 wording ok")
+    print("protocol wording ok")
     return 0
 
 


### PR DESCRIPTION
## Summary
- add v0.1 acceptance review plan and acceptance gates
- make failed acceptance gates hard blockers
- mark the demo as non-normative public explanation, not protocol proof
- rename stale validation scripts to protocol-wide names
- update docs and local check references to the current validation surface

## Validation
- python3 scripts/check_markdown_links.py
- python3 scripts/check_protocol_wording.py
- python3 scripts/check_openapi_contract.py
- python3 scripts/check_conformance_fixtures.py
- node --check demo/assets/app.js
- git diff --check

## Internal Review
- protocol boundary review found demo acceptance-blocker issue and README demo ambiguity; fixed
- gate completeness review found blocker-deferral, HostAuth/read-authority, non-object contract, and conformance coverage gaps; fixed
- validation naming review found no stale command names after script rename
- final focused review found blocker-deferral wording still present; fixed

## Boundary
Jarvis remains protocol-only. Hosts own execution, UI, auth, storage, runtime behavior, model calls, tool execution, billing, scoring, payment, deployment, adapters, wrappers, and workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a v0.1 acceptance review guide and acceptance criteria, with clear review gates and required inputs.
  * Expanded planning docs to better describe the non-normative public simulation boundary and protocol-aligned examples.

* **Bug Fixes**
  * Updated validation steps and status messages to use the new OpenAPI contract and protocol wording checks.
  * Clarified README guidance so the interactive simulation is presented as informational only, not protocol proof.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->