### PR TITLE
[codex] Add v0.1 Gate 2 OpenAPI binding audit

### DIFF
--- a/docs/openapi/jarvis-openapi.yaml
+++ b/docs/openapi/jarvis-openapi.yaml
@@ -35,6 +35,15 @@ paths:
   /workers/{worker_id}:
     put:
       operationId: registerWorker
+      summary: Register Worker protocol reference.
+      description: |
+        Records a Worker protocol reference. Hosts own account creation,
+        authentication, identity storage, and credentials. Compatible
+        implementations MUST verify Actor authority, HostAuth,
+        Jarvis-Protocol-Version, Jarvis-Actor-Id, Jarvis-Idempotency-Key, and
+        Jarvis-Request-Timestamp. This non-WorkSession mutation does not
+        require WorkSession revision or previous event hash.
+      x-jarvis-operation-class: non_worksession_mutation
       tags:
         - Workers
       security:
@@ -55,6 +64,15 @@ paths:
   /actors/{actor_id}:
     put:
       operationId: registerActor
+      summary: Register Actor protocol authority reference.
+      description: |
+        Records an Actor protocol authority reference for an existing Worker.
+        Hosts own identity proof, credentials, sessions, and account storage.
+        Compatible implementations MUST verify Actor authority, HostAuth,
+        Jarvis-Protocol-Version, Jarvis-Actor-Id, Jarvis-Idempotency-Key, and
+        Jarvis-Request-Timestamp. This non-WorkSession mutation does not
+        require WorkSession revision or previous event hash.
+      x-jarvis-operation-class: non_worksession_mutation
       tags:
         - Workers
       security:
@@ -75,6 +93,15 @@ paths:
   /work-sessions:
     post:
       operationId: createWorkSession
+      summary: Create WorkSession genesis record.
+      description: |
+        Creates the genesis WorkSession protocol record for one governed
+        HumanWorker and AgentWorker collaboration loop. Compatible
+        implementations MUST verify Actor authority, HostAuth, all six Jarvis
+        mutation headers, expected revision `0`, and
+        `Jarvis-Previous-Event-Hash` equal to `hash:protocol-genesis` before
+        accepting the WorkSession creation state.
+      x-jarvis-operation-class: worksession_genesis_mutation
       tags:
         - WorkSessions
       security:
@@ -96,6 +123,13 @@ paths:
   /work-sessions/{work_session_id}:
     get:
       operationId: getWorkSession
+      summary: Read WorkSession protocol record.
+      description: |
+        Returns a WorkSession protocol record. Compatible implementations MUST
+        verify HostAuth, Jarvis-Protocol-Version, Jarvis-Actor-Id, and Actor
+        read authority. Read operations MUST NOT require mutation-only
+        idempotency, expected revision, or previous event hash headers.
+      x-jarvis-operation-class: worksession_scoped_read
       tags:
         - WorkSessions
       security:
@@ -112,6 +146,13 @@ paths:
   /work-sessions/{work_session_id}/events:
     post:
       operationId: appendJarvisEvent
+      summary: Append JarvisEvent to WorkSession.
+      description: |
+        Appends an attributable JarvisEvent to the WorkSession event chain.
+        Compatible implementations MUST verify Actor authority, HostAuth, all
+        six Jarvis mutation headers, current WorkSession revision, and previous
+        event hash before accepting protocol state.
+      x-jarvis-operation-class: worksession_scoped_mutation
       tags:
         - WorkSessions
       security:
@@ -134,6 +175,13 @@ paths:
   /work-sessions/{work_session_id}/policy-decisions:
     post:
       operationId: recordPolicyDecision
+      summary: Record PolicyDecision before accepted AgentWorker action.
+      description: |
+        Records a PolicyDecision for an AgentWorker action before that action
+        becomes accepted protocol state. Compatible implementations MUST verify
+        Actor authority, HostAuth, all six Jarvis mutation headers, current
+        WorkSession revision, and previous event hash.
+      x-jarvis-operation-class: worksession_scoped_mutation
       tags:
         - ControlPlane
       security:
@@ -156,6 +204,14 @@ paths:
   /work-sessions/{work_session_id}/requests:
     post:
       operationId: createRequest
+      summary: Create scoped Request for blocked work.
+      description: |
+        Creates a scoped Request when AgentWorker cannot continue a declared
+        work scope safely without HumanWorker permission, context, judgment,
+        review, correction, or Takeover. Compatible implementations MUST verify
+        Actor authority, HostAuth, all six Jarvis mutation headers, current
+        WorkSession revision, and previous event hash.
+      x-jarvis-operation-class: worksession_scoped_mutation
       tags:
         - ControlPlane
       security:
@@ -178,6 +234,14 @@ paths:
   /work-sessions/{work_session_id}/reviews:
     post:
       operationId: recordReview
+      summary: Record HumanWorker Review.
+      description: |
+        Records HumanWorker judgment over a Request or protocol target.
+        Review resolves Request scopes through approve, deny, narrow, correct,
+        takeover, or needs_revision decisions. Compatible implementations MUST
+        verify Actor authority, HostAuth, all six Jarvis mutation headers,
+        current WorkSession revision, and previous event hash.
+      x-jarvis-operation-class: worksession_scoped_mutation
       tags:
         - ControlPlane
       security:
@@ -200,6 +264,14 @@ paths:
   /work-sessions/{work_session_id}/takeovers:
     post:
       operationId: recordTakeover
+      summary: Record Takeover and reconciliation state.
+      description: |
+        Records HumanWorker direct-control state for a declared WorkSession
+        scope and prevents stale AgentWorker continuation. Compatible
+        implementations MUST verify Actor authority, HostAuth, all six Jarvis
+        mutation headers, current WorkSession revision, previous event hash,
+        and Takeover lock epoch rules.
+      x-jarvis-operation-class: worksession_scoped_mutation
       tags:
         - ControlPlane
       security:
@@ -222,6 +294,14 @@ paths:
   /work-sessions/{work_session_id}/contributions:
     post:
       operationId: recordContribution
+      summary: Record attributable Contribution.
+      description: |
+        Records who contributed work, which Actor represented the contributor,
+        and which events or artifacts support the contribution. Compatible
+        implementations MUST verify Actor authority, HostAuth, all six Jarvis
+        mutation headers, current WorkSession revision, and previous event
+        hash.
+      x-jarvis-operation-class: worksession_scoped_mutation
       tags:
         - Attribution
       security:
@@ -244,6 +324,13 @@ paths:
   /work-sessions/{work_session_id}/learning-records:
     post:
       operationId: createLearningRecord
+      summary: Create governed LearningRecord.
+      description: |
+        Creates a governed LearningRecord for human, agent, or pair learning
+        supported by WorkSession source events. Compatible implementations MUST
+        verify Actor authority, HostAuth, all six Jarvis mutation headers,
+        current WorkSession revision, and previous event hash.
+      x-jarvis-operation-class: worksession_scoped_mutation
       tags:
         - Learning
       security:
@@ -266,6 +353,13 @@ paths:
   /work-sessions/{work_session_id}/memory-proposals:
     post:
       operationId: createMemoryProposal
+      summary: Create governed MemoryProposal.
+      description: |
+        Creates a MemoryProposal that remains governed until reviewed.
+        Compatible implementations MUST verify Actor authority, HostAuth, all
+        six Jarvis mutation headers, current WorkSession revision, previous
+        event hash, provenance, and review-required state.
+      x-jarvis-operation-class: worksession_scoped_mutation
       tags:
         - Learning
       security:
@@ -288,6 +382,14 @@ paths:
   /work-sessions/{work_session_id}/skill-proposals:
     post:
       operationId: createSkillProposal
+      summary: Create governed SkillProposal.
+      description: |
+        Creates a SkillProposal that remains governed until reviewed and cannot
+        expand tool access without policy review. Compatible implementations
+        MUST verify Actor authority, HostAuth, all six Jarvis mutation headers,
+        current WorkSession revision, previous event hash, provenance, and
+        review-required state.
+      x-jarvis-operation-class: worksession_scoped_mutation
       tags:
         - Learning
       security:
@@ -310,6 +412,14 @@ paths:
   /work-sessions/{work_session_id}/export:
     get:
       operationId: exportEvidenceManifest
+      summary: Export EvidenceManifest.
+      description: |
+        Exports portable EvidenceManifest proof from a terminal WorkSession
+        state. Compatible implementations MUST verify HostAuth,
+        Jarvis-Protocol-Version, Jarvis-Actor-Id, and Actor read authority.
+        Export reads MUST NOT require mutation-only idempotency, expected
+        revision, or previous event hash headers.
+      x-jarvis-operation-class: export_read
       tags:
         - Evidence
       security:
@@ -326,6 +436,16 @@ paths:
   /outcome-reports:
     post:
       operationId: submitOutcomeReport
+      summary: Submit OutcomeReport post-session feedback.
+      description: |
+        Records attributable post-session feedback after WorkSession export.
+        OutcomeReport references governed LearningRecord records and does not
+        mutate sealed WorkSession, EvidenceManifest, or LearningRecord records.
+        Compatible implementations MUST verify Actor authority, HostAuth,
+        Jarvis-Protocol-Version, Jarvis-Actor-Id, Jarvis-Idempotency-Key, and
+        Jarvis-Request-Timestamp. This non-WorkSession mutation does not
+        require WorkSession revision or previous event hash.
+      x-jarvis-operation-class: non_worksession_mutation
       tags:
         - Feedback
       security:
@@ -1034,6 +1154,8 @@ components:
         - credential
         - raw_auth_token
         - provider_secret
+        - session_cookie
+        - private_key
         - database_primary_key
         - cloud_storage_secret
         - unredacted_secret_value
@@ -1096,6 +1218,8 @@ components:
         - credential
         - raw_auth_token
         - provider_secret
+        - session_cookie
+        - private_key
         - database_primary_key
         - cloud_storage_secret
         - unredacted_secret_value
@@ -2073,6 +2197,8 @@ components:
         - credential
         - raw_auth_token
         - provider_secret
+        - session_cookie
+        - private_key
         - database_primary_key
         - cloud_storage_secret
         - unredacted_secret_value
@@ -2707,8 +2833,8 @@ components:
         agent_worker_id: worker-agent-001
         policy_id: policy-bounded-001
         status: active
-        revision: 0
-        last_event_hash: hash:genesis
+        revision: 1
+        last_event_hash: hash:event-worksession-created
         event_log_ref: event-log:ws-protocol-001
         created_at: "2026-06-12T18:00:00Z"
         updated_at: "2026-06-12T18:00:00Z"

--- a/docs/planning/v0.1-acceptance-review/gate-2-openapi-binding-audit.md
+++ b/docs/planning/v0.1-acceptance-review/gate-2-openapi-binding-audit.md
@@ -1,0 +1,155 @@
+# Gate 2 OpenAPI Binding Audit
+
+Status: pass.
+
+Review date: 2026-06-30.
+
+Branch: `codex/v0.1-gate-2-openapi-binding-audit`.
+
+Base commit audited: `35fd13f`.
+
+Working-tree audit state: Gate 2 diff on top of `35fd13f`.
+
+Decision: Gate 2 passes. Every required proof row passes and no blocker
+remains.
+
+## Scope
+
+Audited sources:
+
+- [../../openapi/jarvis-openapi.yaml](../../openapi/jarvis-openapi.yaml)
+- [../../../scripts/check_openapi_contract.py](../../../scripts/check_openapi_contract.py)
+- [../../protocol/11-core-protocol-objects.md](../../protocol/11-core-protocol-objects.md)
+- [../../protocol/15-openapi-communication-binding.md](../../protocol/15-openapi-communication-binding.md)
+- [../../conformance/checklist.md](../../conformance/checklist.md)
+- [../../conformance/golden-path.md](../../conformance/golden-path.md)
+- [../../conformance/failure-modes.md](../../conformance/failure-modes.md)
+- [../../examples/protocol-records.md](../../examples/protocol-records.md)
+
+Out of scope:
+
+```txt
+SDK implementation
+adapter implementation
+wrapper implementation
+host runtime behavior
+host UI behavior
+model orchestration
+tool execution
+storage behavior
+auth behavior
+billing behavior
+scoring behavior
+payment behavior
+deployment behavior
+```
+
+## Source Coverage
+
+| Source group | Covered paths | Gate 2 check | Result |
+| --- | --- | --- | --- |
+| Machine contract | `docs/openapi/jarvis-openapi.yaml` | OpenAPI 3.1 version, metadata, paths, schemas, parameters, request bodies, responses, security scheme, examples, operation descriptions, operation classes | pass |
+| Validator | `scripts/check_openapi_contract.py` | Required schemas, required fields, enum values, forbidden fields, invariants, operation header classes, request bodies, success responses, error responses, examples, conformance entry refs | pass |
+| Protocol source | `docs/protocol/11-core-protocol-objects.md`, `docs/protocol/15-openapi-communication-binding.md` | Object field lock, operation list, header matrix, security model, error model, forbidden export fields | pass |
+| Conformance source | `docs/conformance/checklist.md`, `docs/conformance/golden-path.md`, `docs/conformance/failure-modes.md` | OpenAPI-backed rejection ids, mutation headers, read authority, evidence export, learning governance | pass |
+| Example source | `docs/examples/protocol-records.md` | Example object shape alignment, OutcomeReport learning refs, EvidenceManifest export refs | pass |
+| Acceptance audit artifact | `docs/planning/v0.1-acceptance-review/gate-2-openapi-binding-audit.md` | Gate proof matrix, blocker ledger, command evidence, changed-file coverage | pass |
+
+Every changed file belongs to a coverage row:
+
+| Changed file | Coverage row |
+| --- | --- |
+| `docs/openapi/jarvis-openapi.yaml` | Machine contract |
+| `scripts/check_openapi_contract.py` | Validator |
+| `docs/planning/v0.1-acceptance-review/gate-2-openapi-binding-audit.md` | Acceptance audit artifact |
+
+## Required Proof Matrix
+
+| ID | Required proof | Evidence | Result |
+| --- | --- | --- | --- |
+| G2-01 | all core schemas exist | `scripts/check_openapi_contract.py:46`, `docs/openapi/jarvis-openapi.yaml:1232`, `docs/openapi/jarvis-openapi.yaml:2467` | pass |
+| G2-02 | required fields match core object field locks | `scripts/check_openapi_contract.py:453`, `scripts/check_openapi_contract.py:1862` | pass |
+| G2-03 | core operations exist for Worker, Actor, WorkSession, event, PolicyDecision, Request, Review, Takeover, Contribution, LearningRecord, MemoryProposal, SkillProposal, EvidenceManifest export, and OutcomeReport | `scripts/check_openapi_contract.py:300`, `docs/openapi/jarvis-openapi.yaml:37`, `docs/openapi/jarvis-openapi.yaml:438` | pass |
+| G2-04 | every mutating operation requires HostAuth | `scripts/check_openapi_contract.py:2323`, `docs/openapi/jarvis-openapi.yaml:50`, `docs/openapi/jarvis-openapi.yaml:452` | pass |
+| G2-05 | WorkSession-scoped mutations require six Jarvis mutation headers | `scripts/check_openapi_contract.py:279`, `scripts/check_openapi_contract.py:2325`, `docs/openapi/jarvis-openapi.yaml:162` | pass |
+| G2-06 | non-WorkSession mutations require four Jarvis mutation headers and do not require fake WorkSession revision or previous hash | `scripts/check_openapi_contract.py:288`, `scripts/check_openapi_contract.py:2304`, `docs/openapi/jarvis-openapi.yaml:46`, `docs/openapi/jarvis-openapi.yaml:448` | pass |
+| G2-07 | WorkSession-scoped reads and export reads require HostAuth, protocol version, Actor, and Actor read authority | `scripts/check_openapi_contract.py:295`, `scripts/check_openapi_contract.py:2296`, `docs/openapi/jarvis-openapi.yaml:128`, `docs/openapi/jarvis-openapi.yaml:130`, `docs/openapi/jarvis-openapi.yaml:132`, `docs/openapi/jarvis-openapi.yaml:418`, `docs/openapi/jarvis-openapi.yaml:419`, `docs/openapi/jarvis-openapi.yaml:422` | pass |
+| G2-08 | Worker registration, Actor registration, and OutcomeReport submission stay non-WorkSession mutations | `docs/openapi/jarvis-openapi.yaml:46`, `docs/openapi/jarvis-openapi.yaml:75`, `docs/openapi/jarvis-openapi.yaml:448`, `scripts/check_openapi_contract.py:303`, `scripts/check_openapi_contract.py:313`, `scripts/check_openapi_contract.py:443` | pass |
+| G2-09 | protocol errors expose public error fields only | `docs/openapi/jarvis-openapi.yaml:2528`, `docs/openapi/jarvis-openapi.yaml:2559`, `scripts/check_openapi_contract.py:693`, `scripts/check_openapi_contract.py:1271` | pass |
+| G2-10 | portable protocol records reject host-private fields | `scripts/check_openapi_contract.py:1185`, `scripts/check_openapi_contract.py:1881`, `scripts/check_openapi_contract.py:1888`, `docs/openapi/jarvis-openapi.yaml:1153`, `docs/openapi/jarvis-openapi.yaml:2196` | pass |
+| G2-11 | examples exist and avoid host-private fields | `scripts/check_openapi_contract.py:1771`, `scripts/check_openapi_contract.py:1789`, `scripts/check_openapi_contract.py:1796`, `docs/openapi/jarvis-openapi.yaml:2828` | pass |
+| G2-12 | operation descriptions make the spec implementable without guessing authority or header class | `docs/openapi/jarvis-openapi.yaml:39`, `docs/openapi/jarvis-openapi.yaml:46`, `docs/openapi/jarvis-openapi.yaml:127`, `docs/openapi/jarvis-openapi.yaml:132`, `docs/openapi/jarvis-openapi.yaml:440`, `docs/openapi/jarvis-openapi.yaml:448`, `scripts/check_openapi_contract.py:2279`, `scripts/check_openapi_contract.py:2287` | pass |
+
+## Source Findings
+
+| Finding ID | Blocker ID | Severity | Source | Gate proof affected | Finding | Resolution | Status |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| G2-F1 | G2-B1 | blocker | `docs/openapi/jarvis-openapi.yaml`, `scripts/check_openapi_contract.py` | G2-03, G2-05, G2-06, G2-07, G2-12 | OpenAPI operations had correct parameters and responses, but no summaries, descriptions, or operation-class metadata. A developer reading the OpenAPI had to infer authority semantics and mutation/read class from parameter lists. | Added operation summaries, direct descriptions, and `x-jarvis-operation-class` to every operation. Updated `check_openapi_contract.py` to require operation summaries, descriptions, operation class, read-authority wording, non-WorkSession mutation exclusions, and genesis revision wording. | resolved |
+| G2-F2 | G2-B2 | blocker | `docs/openapi/jarvis-openapi.yaml`, `scripts/check_openapi_contract.py` | G2-05, G2-11 | `WorkSessionCreateExample` represented an accepted WorkSession response with revision `0` and `last_event_hash: hash:genesis`, which conflicted with the WorkSession hash-chain rule. | Changed the accepted example to revision `1` and `last_event_hash: hash:event-worksession-created`. Updated `check_openapi_contract.py` to require those accepted response values and require the create operation description to name `hash:protocol-genesis` for the genesis request header. | resolved |
+| G2-F3 | G2-B3 | blocker | `docs/openapi/jarvis-openapi.yaml`, `scripts/check_openapi_contract.py` | G2-10 | Export-related forbidden-field metadata omitted `session_cookie` and `private_key` even though the locked OpenAPI binding forbids session cookies and private keys in exports. | Added `session_cookie` and `private_key` to `ExportProfile`, `EvidenceItemRef`, and `EvidenceManifest` forbidden-field metadata and to validator-required forbidden metadata. | resolved |
+
+## Blocker List
+
+No blocker remains.
+
+| Blocker ID | Source | Gate proof failed | Resolution evidence | Status |
+| --- | --- | --- | --- | --- |
+| G2-B1 | OpenAPI operation semantics | G2-03, G2-05, G2-06, G2-07, G2-12 | `docs/openapi/jarvis-openapi.yaml:39`, `docs/openapi/jarvis-openapi.yaml:46`, `docs/openapi/jarvis-openapi.yaml:127`, `docs/openapi/jarvis-openapi.yaml:132`, `docs/openapi/jarvis-openapi.yaml:440`, `docs/openapi/jarvis-openapi.yaml:448`, `scripts/check_openapi_contract.py:2279`, `scripts/check_openapi_contract.py:2287` | resolved |
+| G2-B2 | WorkSession creation example | G2-05, G2-11 | `docs/openapi/jarvis-openapi.yaml:102`, `docs/openapi/jarvis-openapi.yaml:2836`, `docs/openapi/jarvis-openapi.yaml:2837`, `scripts/check_openapi_contract.py:256`, `scripts/check_openapi_contract.py:257`, `scripts/check_openapi_contract.py:2317` | resolved |
+| G2-B3 | Export forbidden-field metadata | G2-10 | `docs/openapi/jarvis-openapi.yaml:1157`, `docs/openapi/jarvis-openapi.yaml:1221`, `docs/openapi/jarvis-openapi.yaml:2200`, `scripts/check_openapi_contract.py:1185` | resolved |
+
+## Command Evidence
+
+Commands run after Gate 2 fixes:
+
+| Command | Exit status | Output summary |
+| --- | --- | --- |
+| `python3 scripts/check_openapi_contract.py` | 0 | `openapi contract ok` |
+| `python3 scripts/check_protocol_wording.py` | 0 | `protocol wording ok` |
+| `python3 scripts/check_markdown_links.py` | 0 | `markdown links ok` |
+| `python3 scripts/check_conformance_fixtures.py` | 0 | `conformance fixtures ok` |
+| `git diff --check` | 0 | no output |
+| `node --check demo/assets/app.js` | 0 | no output |
+
+Pre-stage working-tree state at audit time:
+
+```txt
+ M docs/openapi/jarvis-openapi.yaml
+ M scripts/check_openapi_contract.py
+?? docs/planning/v0.1-acceptance-review/gate-2-openapi-binding-audit.md
+```
+
+Tracked diff stat before staging:
+
+```txt
+ docs/openapi/jarvis-openapi.yaml  | 130 +++++++++++++++++++++++++++++++++++++-
+ scripts/check_openapi_contract.py |  67 ++++++++++++++++++++
+ 2 files changed, 195 insertions(+), 2 deletions(-)
+```
+
+Tracked diff name-only before staging:
+
+```txt
+docs/openapi/jarvis-openapi.yaml
+scripts/check_openapi_contract.py
+```
+
+## Gate 2 Decision
+
+Gate 2 status: pass.
+
+Accepted proof rows: G2-01 through G2-12.
+
+Resolved blockers: G2-B1, G2-B2, G2-B3.
+
+Remaining blockers: none.
+
+Decision rationale:
+
+```txt
+Jarvis v0.1 OpenAPI now carries the machine-readable schema contract, operation
+contract, security header contract, error contract, forbidden-field boundary,
+examples, operation class metadata, and operation descriptions required for a
+compatible implementation to implement protocol record exchange without
+guessing Jarvis-owned semantics or adopting host-owned runtime behavior.
+```

--- a/scripts/check_openapi_contract.py
+++ b/scripts/check_openapi_contract.py
@@ -253,6 +253,8 @@ REQUIRED_EXAMPLES = {
 }
 
 EXAMPLE_REQUIRED_VALUES = {
+    ("WorkSessionCreateExample", "revision"): 1,
+    ("WorkSessionCreateExample", "last_event_hash"): "hash:event-worksession-created",
     ("PolicyDecisionDeniedExample", "result"): "deny",
     ("RequestBlockedActionExample", "status"): "pending",
     ("ReviewApproveRequestExample", "decision"): "approve",
@@ -298,6 +300,7 @@ READ_HEADERS = {
 REQUIRED_OPERATIONS = {
     ("put", "/workers/{worker_id}"): {
         "operation_id": "registerWorker",
+        "operation_class": "non_worksession_mutation",
         "tag": "Workers",
         "headers": NON_WORKSESSION_MUTATION_HEADERS,
         "path_parameters": {"WorkerIdPath"},
@@ -307,6 +310,7 @@ REQUIRED_OPERATIONS = {
     },
     ("put", "/actors/{actor_id}"): {
         "operation_id": "registerActor",
+        "operation_class": "non_worksession_mutation",
         "tag": "Workers",
         "headers": NON_WORKSESSION_MUTATION_HEADERS,
         "path_parameters": {"ActorIdPath"},
@@ -316,6 +320,7 @@ REQUIRED_OPERATIONS = {
     },
     ("post", "/work-sessions"): {
         "operation_id": "createWorkSession",
+        "operation_class": "worksession_genesis_mutation",
         "tag": "WorkSessions",
         "headers": WORKSESSION_MUTATION_HEADERS,
         "path_parameters": set(),
@@ -325,6 +330,7 @@ REQUIRED_OPERATIONS = {
     },
     ("get", "/work-sessions/{work_session_id}"): {
         "operation_id": "getWorkSession",
+        "operation_class": "worksession_scoped_read",
         "tag": "WorkSessions",
         "headers": READ_HEADERS,
         "path_parameters": {"WorkSessionIdPath"},
@@ -334,6 +340,7 @@ REQUIRED_OPERATIONS = {
     },
     ("post", "/work-sessions/{work_session_id}/events"): {
         "operation_id": "appendJarvisEvent",
+        "operation_class": "worksession_scoped_mutation",
         "tag": "WorkSessions",
         "headers": WORKSESSION_MUTATION_HEADERS,
         "path_parameters": {"WorkSessionIdPath"},
@@ -343,6 +350,7 @@ REQUIRED_OPERATIONS = {
     },
     ("post", "/work-sessions/{work_session_id}/policy-decisions"): {
         "operation_id": "recordPolicyDecision",
+        "operation_class": "worksession_scoped_mutation",
         "tag": "ControlPlane",
         "headers": WORKSESSION_MUTATION_HEADERS,
         "path_parameters": {"WorkSessionIdPath"},
@@ -352,6 +360,7 @@ REQUIRED_OPERATIONS = {
     },
     ("post", "/work-sessions/{work_session_id}/requests"): {
         "operation_id": "createRequest",
+        "operation_class": "worksession_scoped_mutation",
         "tag": "ControlPlane",
         "headers": WORKSESSION_MUTATION_HEADERS,
         "path_parameters": {"WorkSessionIdPath"},
@@ -361,6 +370,7 @@ REQUIRED_OPERATIONS = {
     },
     ("post", "/work-sessions/{work_session_id}/reviews"): {
         "operation_id": "recordReview",
+        "operation_class": "worksession_scoped_mutation",
         "tag": "ControlPlane",
         "headers": WORKSESSION_MUTATION_HEADERS,
         "path_parameters": {"WorkSessionIdPath"},
@@ -370,6 +380,7 @@ REQUIRED_OPERATIONS = {
     },
     ("post", "/work-sessions/{work_session_id}/takeovers"): {
         "operation_id": "recordTakeover",
+        "operation_class": "worksession_scoped_mutation",
         "tag": "ControlPlane",
         "headers": WORKSESSION_MUTATION_HEADERS,
         "path_parameters": {"WorkSessionIdPath"},
@@ -379,6 +390,7 @@ REQUIRED_OPERATIONS = {
     },
     ("post", "/work-sessions/{work_session_id}/contributions"): {
         "operation_id": "recordContribution",
+        "operation_class": "worksession_scoped_mutation",
         "tag": "Attribution",
         "headers": WORKSESSION_MUTATION_HEADERS,
         "path_parameters": {"WorkSessionIdPath"},
@@ -388,6 +400,7 @@ REQUIRED_OPERATIONS = {
     },
     ("post", "/work-sessions/{work_session_id}/learning-records"): {
         "operation_id": "createLearningRecord",
+        "operation_class": "worksession_scoped_mutation",
         "tag": "Learning",
         "headers": WORKSESSION_MUTATION_HEADERS,
         "path_parameters": {"WorkSessionIdPath"},
@@ -397,6 +410,7 @@ REQUIRED_OPERATIONS = {
     },
     ("post", "/work-sessions/{work_session_id}/memory-proposals"): {
         "operation_id": "createMemoryProposal",
+        "operation_class": "worksession_scoped_mutation",
         "tag": "Learning",
         "headers": WORKSESSION_MUTATION_HEADERS,
         "path_parameters": {"WorkSessionIdPath"},
@@ -406,6 +420,7 @@ REQUIRED_OPERATIONS = {
     },
     ("post", "/work-sessions/{work_session_id}/skill-proposals"): {
         "operation_id": "createSkillProposal",
+        "operation_class": "worksession_scoped_mutation",
         "tag": "Learning",
         "headers": WORKSESSION_MUTATION_HEADERS,
         "path_parameters": {"WorkSessionIdPath"},
@@ -415,6 +430,7 @@ REQUIRED_OPERATIONS = {
     },
     ("get", "/work-sessions/{work_session_id}/export"): {
         "operation_id": "exportEvidenceManifest",
+        "operation_class": "export_read",
         "tag": "Evidence",
         "headers": READ_HEADERS,
         "path_parameters": {"WorkSessionIdPath"},
@@ -424,6 +440,7 @@ REQUIRED_OPERATIONS = {
     },
     ("post", "/outcome-reports"): {
         "operation_id": "submitOutcomeReport",
+        "operation_class": "non_worksession_mutation",
         "tag": "Feedback",
         "headers": NON_WORKSESSION_MUTATION_HEADERS,
         "path_parameters": set(),
@@ -1169,6 +1186,8 @@ REQUIRED_FORBIDDEN_METADATA = {
         "credential",
         "raw_auth_token",
         "provider_secret",
+        "session_cookie",
+        "private_key",
         "database_primary_key",
         "cloud_storage_secret",
         "unredacted_secret_value",
@@ -1183,6 +1202,8 @@ REQUIRED_FORBIDDEN_METADATA = {
         "credential",
         "raw_auth_token",
         "provider_secret",
+        "session_cookie",
+        "private_key",
         "database_primary_key",
         "cloud_storage_secret",
         "unredacted_secret_value",
@@ -1204,6 +1225,8 @@ REQUIRED_FORBIDDEN_METADATA = {
         "credential",
         "raw_auth_token",
         "provider_secret",
+        "session_cookie",
+        "private_key",
         "database_primary_key",
         "cloud_storage_secret",
         "unredacted_secret_value",
@@ -2251,6 +2274,50 @@ def main() -> int:
                 f"{method.upper()} {path} operationId must be "
                 + expected["operation_id"]
             )
+        if not operation.get("summary"):
+            return fail(f"{method.upper()} {path} must define summary")
+        description = operation.get("description")
+        if not isinstance(description, str) or not description.strip():
+            return fail(f"{method.upper()} {path} must define description")
+        normalized_description = " ".join(description.split())
+        if "Compatible implementations MUST verify" not in normalized_description:
+            return fail(
+                f"{method.upper()} {path} description must define verification duty"
+            )
+        if operation.get("x-jarvis-operation-class") != expected["operation_class"]:
+            return fail(
+                f"{method.upper()} {path} x-jarvis-operation-class must be "
+                + expected["operation_class"]
+            )
+        if expected["operation_class"] in {
+            "worksession_scoped_read",
+            "export_read",
+        }:
+            if "Actor read authority" not in normalized_description:
+                return fail(
+                    f"{method.upper()} {path} description must require Actor read authority"
+                )
+            if "MUST NOT require mutation-only" not in normalized_description:
+                return fail(
+                    f"{method.upper()} {path} description must exclude mutation-only headers"
+                )
+        if expected["operation_class"] == "non_worksession_mutation":
+            if (
+                "does not require WorkSession revision or previous event hash"
+                not in normalized_description
+            ):
+                return fail(
+                    f"{method.upper()} {path} description must exclude WorkSession revision and previous hash"
+                )
+        if expected["operation_class"] == "worksession_genesis_mutation":
+            if "expected revision `0`" not in normalized_description:
+                return fail(
+                    f"{method.upper()} {path} description must require genesis revision"
+                )
+            if "`hash:protocol-genesis`" not in normalized_description:
+                return fail(
+                    f"{method.upper()} {path} description must require protocol genesis hash"
+                )
         if operation.get("tags") != [expected["tag"]]:
             return fail(f"{method.upper()} {path} tag must be {expected['tag']}")
         if operation.get("security") != [{"HostAuth": []}]:


### PR DESCRIPTION
## Summary
- add Gate 2 OpenAPI binding acceptance audit artifact
- add OpenAPI operation summaries, descriptions, and x-jarvis-operation-class metadata
- strengthen the OpenAPI checker for operation classes, read authority, non-WorkSession mutation carveouts, genesis hash, accepted WorkSession example state, and export forbidden-field metadata

## Reviewer-agent coverage
- OpenAPI semantics reviewer: no findings
- wording and protocol-boundary reviewer: no findings
- security reviewer: found genesis example and forbidden export metadata issues; fixed and re-reviewed clean
- audit-evidence reviewer: found weak/stale anchors; fixed and re-reviewed to final anchor cleanup

## Validation
- python3 scripts/check_openapi_contract.py
- python3 scripts/check_protocol_wording.py
- python3 scripts/check_markdown_links.py
- python3 scripts/check_conformance_fixtures.py
- git diff --check
- node --check demo/assets/app.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer operation summaries and descriptions across protocol endpoints, making the API easier to understand and use.
  * Introduced explicit operation classifications for endpoints to better distinguish reads, writes, and export actions.

* **Bug Fixes**
  * Tightened validation for example work-session data and required metadata.
  * Updated forbidden-field checks to better protect sensitive host-private values.

* **Documentation**
  * Added a new audit report documenting the OpenAPI binding review and its passing result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->