### PR TITLE
[codex] Add v0.1 Gate 3 conformance surface audit

### DIFF
--- a/docs/conformance/fixtures/README.md
+++ b/docs/conformance/fixtures/README.md
@@ -107,8 +107,9 @@ a JarvisEvent request body.
 `assertions` record the protocol gates that a compatible implementation proves
 or rejects.
 
-Assertion classes come from
-`docs/planning/week-3/chunk-1-fixture-architecture.md`.
+Assertion classes come from the public conformance gates in
+`docs/conformance/checklist.md` and the allowed validator set in
+`scripts/check_conformance_fixtures.py`.
 
 ## Validator
 
@@ -120,8 +121,10 @@ python3 scripts/check_conformance_fixtures.py
 
 Conformance fixture records MUST satisfy fixture envelope fields, operation
 binding, required headers, assertion refs, source_contract_refs, OpenAPI
-component refs, required invalid-fixture coverage, host-private export
-boundaries, and expected protocol outcomes.
+component refs, required invalid-fixture coverage, global assertion-class
+coverage, golden-path semantic coverage, invalid rejection semantics,
+WorkSession revision and previous-hash binding, host-private export boundaries,
+and expected protocol outcomes.
 
 The validator MUST NOT execute host behavior. It validates Jarvis protocol
 fixture records only.

--- a/docs/conformance/fixtures/invalid/forbidden-host-private-export-field.json
+++ b/docs/conformance/fixtures/invalid/forbidden-host-private-export-field.json
@@ -7,8 +7,8 @@
   "source_contract_refs": [
     "docs/conformance/failure-modes.md",
     "docs/conformance/compatibility-mapping.md",
-    "docs/planning/week-3/chunk-1-fixture-architecture.md",
-    "docs/planning/week-3/chunk-4-failure-fixtures.md",
+    "docs/conformance/checklist.md",
+    "docs/protocol/15-openapi-communication-binding.md",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/ProtocolError",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Worker",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Actor",

--- a/docs/conformance/fixtures/invalid/invalid-approval-scope.json
+++ b/docs/conformance/fixtures/invalid/invalid-approval-scope.json
@@ -7,8 +7,8 @@
   "source_contract_refs": [
     "docs/conformance/failure-modes.md",
     "docs/conformance/compatibility-mapping.md",
-    "docs/planning/week-3/chunk-1-fixture-architecture.md",
-    "docs/planning/week-3/chunk-4-failure-fixtures.md",
+    "docs/conformance/checklist.md",
+    "docs/protocol/15-openapi-communication-binding.md",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/ProtocolError",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Worker",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Actor",

--- a/docs/conformance/fixtures/invalid/invalid-evidence-export-state.json
+++ b/docs/conformance/fixtures/invalid/invalid-evidence-export-state.json
@@ -7,8 +7,8 @@
   "source_contract_refs": [
     "docs/conformance/failure-modes.md",
     "docs/conformance/compatibility-mapping.md",
-    "docs/planning/week-3/chunk-1-fixture-architecture.md",
-    "docs/planning/week-3/chunk-4-failure-fixtures.md",
+    "docs/conformance/checklist.md",
+    "docs/protocol/15-openapi-communication-binding.md",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/ProtocolError",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Worker",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Actor",
@@ -251,7 +251,7 @@
       "assertion_id": "assert-invalid-evidence-export-state",
       "class": "evidence_export_gate",
       "target_ref": "records.work_sessions.active",
-      "required_state": "EvidenceManifest final export requires completed, failed, cancelled, or externally_submitted WorkSession state.",
+      "required_state": "EvidenceManifest final export requires completed, failed, cancelled, or closed WorkSession state.",
       "expected_result": "reject",
       "expected_error_id": "invalid_evidence_export_state"
     }

--- a/docs/conformance/fixtures/invalid/invalid-previous-event-hash.json
+++ b/docs/conformance/fixtures/invalid/invalid-previous-event-hash.json
@@ -7,8 +7,8 @@
   "source_contract_refs": [
     "docs/conformance/failure-modes.md",
     "docs/conformance/compatibility-mapping.md",
-    "docs/planning/week-3/chunk-1-fixture-architecture.md",
-    "docs/planning/week-3/chunk-4-failure-fixtures.md",
+    "docs/conformance/checklist.md",
+    "docs/protocol/15-openapi-communication-binding.md",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/ProtocolError",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Worker",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Actor",

--- a/docs/conformance/fixtures/invalid/missing-actor.json
+++ b/docs/conformance/fixtures/invalid/missing-actor.json
@@ -7,8 +7,8 @@
   "source_contract_refs": [
     "docs/conformance/failure-modes.md",
     "docs/conformance/compatibility-mapping.md",
-    "docs/planning/week-3/chunk-1-fixture-architecture.md",
-    "docs/planning/week-3/chunk-4-failure-fixtures.md",
+    "docs/conformance/checklist.md",
+    "docs/protocol/15-openapi-communication-binding.md",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/ProtocolError",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Worker",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Actor",

--- a/docs/conformance/fixtures/invalid/missing-expected-work-session-revision.json
+++ b/docs/conformance/fixtures/invalid/missing-expected-work-session-revision.json
@@ -7,8 +7,8 @@
   "source_contract_refs": [
     "docs/conformance/failure-modes.md",
     "docs/conformance/compatibility-mapping.md",
-    "docs/planning/week-3/chunk-1-fixture-architecture.md",
-    "docs/planning/week-3/chunk-4-failure-fixtures.md",
+    "docs/conformance/checklist.md",
+    "docs/protocol/15-openapi-communication-binding.md",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/ProtocolError",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Worker",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Actor",

--- a/docs/conformance/fixtures/invalid/missing-idempotency-key.json
+++ b/docs/conformance/fixtures/invalid/missing-idempotency-key.json
@@ -7,8 +7,8 @@
   "source_contract_refs": [
     "docs/conformance/failure-modes.md",
     "docs/conformance/compatibility-mapping.md",
-    "docs/planning/week-3/chunk-1-fixture-architecture.md",
-    "docs/planning/week-3/chunk-4-failure-fixtures.md",
+    "docs/conformance/checklist.md",
+    "docs/protocol/15-openapi-communication-binding.md",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/ProtocolError",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Worker",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Actor",

--- a/docs/conformance/fixtures/invalid/missing-policy-decision.json
+++ b/docs/conformance/fixtures/invalid/missing-policy-decision.json
@@ -7,8 +7,8 @@
   "source_contract_refs": [
     "docs/conformance/failure-modes.md",
     "docs/conformance/compatibility-mapping.md",
-    "docs/planning/week-3/chunk-1-fixture-architecture.md",
-    "docs/planning/week-3/chunk-4-failure-fixtures.md",
+    "docs/conformance/checklist.md",
+    "docs/protocol/15-openapi-communication-binding.md",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/ProtocolError",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Worker",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Actor",

--- a/docs/conformance/fixtures/invalid/missing-policy.json
+++ b/docs/conformance/fixtures/invalid/missing-policy.json
@@ -7,8 +7,8 @@
   "source_contract_refs": [
     "docs/conformance/failure-modes.md",
     "docs/conformance/compatibility-mapping.md",
-    "docs/planning/week-3/chunk-1-fixture-architecture.md",
-    "docs/planning/week-3/chunk-4-failure-fixtures.md",
+    "docs/conformance/checklist.md",
+    "docs/protocol/15-openapi-communication-binding.md",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/ProtocolError",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Worker",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Actor",

--- a/docs/conformance/fixtures/invalid/missing-previous-event-hash.json
+++ b/docs/conformance/fixtures/invalid/missing-previous-event-hash.json
@@ -7,8 +7,8 @@
   "source_contract_refs": [
     "docs/conformance/failure-modes.md",
     "docs/conformance/compatibility-mapping.md",
-    "docs/planning/week-3/chunk-1-fixture-architecture.md",
-    "docs/planning/week-3/chunk-4-failure-fixtures.md",
+    "docs/conformance/checklist.md",
+    "docs/protocol/15-openapi-communication-binding.md",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/ProtocolError",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Worker",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Actor",

--- a/docs/conformance/fixtures/invalid/missing-protocol-version.json
+++ b/docs/conformance/fixtures/invalid/missing-protocol-version.json
@@ -7,8 +7,8 @@
   "source_contract_refs": [
     "docs/conformance/failure-modes.md",
     "docs/conformance/compatibility-mapping.md",
-    "docs/planning/week-3/chunk-1-fixture-architecture.md",
-    "docs/planning/week-3/chunk-4-failure-fixtures.md",
+    "docs/conformance/checklist.md",
+    "docs/protocol/15-openapi-communication-binding.md",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/ProtocolError",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Worker",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Actor",

--- a/docs/conformance/fixtures/invalid/missing-request-timestamp.json
+++ b/docs/conformance/fixtures/invalid/missing-request-timestamp.json
@@ -7,8 +7,8 @@
   "source_contract_refs": [
     "docs/conformance/failure-modes.md",
     "docs/conformance/compatibility-mapping.md",
-    "docs/planning/week-3/chunk-1-fixture-architecture.md",
-    "docs/planning/week-3/chunk-4-failure-fixtures.md",
+    "docs/conformance/checklist.md",
+    "docs/protocol/15-openapi-communication-binding.md",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/ProtocolError",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Worker",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Actor",

--- a/docs/conformance/fixtures/invalid/missing-review-resolution.json
+++ b/docs/conformance/fixtures/invalid/missing-review-resolution.json
@@ -7,8 +7,8 @@
   "source_contract_refs": [
     "docs/conformance/failure-modes.md",
     "docs/conformance/compatibility-mapping.md",
-    "docs/planning/week-3/chunk-1-fixture-architecture.md",
-    "docs/planning/week-3/chunk-4-failure-fixtures.md",
+    "docs/conformance/checklist.md",
+    "docs/protocol/15-openapi-communication-binding.md",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/ProtocolError",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Worker",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Actor",

--- a/docs/conformance/fixtures/invalid/missing-takeover-resolution.json
+++ b/docs/conformance/fixtures/invalid/missing-takeover-resolution.json
@@ -7,8 +7,8 @@
   "source_contract_refs": [
     "docs/conformance/failure-modes.md",
     "docs/conformance/compatibility-mapping.md",
-    "docs/planning/week-3/chunk-1-fixture-architecture.md",
-    "docs/planning/week-3/chunk-4-failure-fixtures.md",
+    "docs/conformance/checklist.md",
+    "docs/protocol/15-openapi-communication-binding.md",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/ProtocolError",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Worker",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Actor",

--- a/docs/conformance/fixtures/invalid/outcome-report-without-learning-record.json
+++ b/docs/conformance/fixtures/invalid/outcome-report-without-learning-record.json
@@ -7,8 +7,8 @@
   "source_contract_refs": [
     "docs/conformance/failure-modes.md",
     "docs/conformance/compatibility-mapping.md",
-    "docs/planning/week-3/chunk-1-fixture-architecture.md",
-    "docs/planning/week-3/chunk-4-failure-fixtures.md",
+    "docs/conformance/checklist.md",
+    "docs/protocol/15-openapi-communication-binding.md",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/ProtocolError",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Worker",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Actor",

--- a/docs/conformance/fixtures/invalid/sealed-evidence-mutation.json
+++ b/docs/conformance/fixtures/invalid/sealed-evidence-mutation.json
@@ -7,8 +7,8 @@
   "source_contract_refs": [
     "docs/conformance/failure-modes.md",
     "docs/conformance/compatibility-mapping.md",
-    "docs/planning/week-3/chunk-1-fixture-architecture.md",
-    "docs/planning/week-3/chunk-4-failure-fixtures.md",
+    "docs/conformance/checklist.md",
+    "docs/protocol/15-openapi-communication-binding.md",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/ProtocolError",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Worker",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Actor",

--- a/docs/conformance/fixtures/invalid/sealed-work-session-mutation.json
+++ b/docs/conformance/fixtures/invalid/sealed-work-session-mutation.json
@@ -7,8 +7,8 @@
   "source_contract_refs": [
     "docs/conformance/failure-modes.md",
     "docs/conformance/compatibility-mapping.md",
-    "docs/planning/week-3/chunk-1-fixture-architecture.md",
-    "docs/planning/week-3/chunk-4-failure-fixtures.md",
+    "docs/conformance/checklist.md",
+    "docs/protocol/15-openapi-communication-binding.md",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/ProtocolError",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Worker",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Actor",

--- a/docs/conformance/fixtures/invalid/silent-memory-mutation.json
+++ b/docs/conformance/fixtures/invalid/silent-memory-mutation.json
@@ -7,8 +7,8 @@
   "source_contract_refs": [
     "docs/conformance/failure-modes.md",
     "docs/conformance/compatibility-mapping.md",
-    "docs/planning/week-3/chunk-1-fixture-architecture.md",
-    "docs/planning/week-3/chunk-4-failure-fixtures.md",
+    "docs/conformance/checklist.md",
+    "docs/protocol/15-openapi-communication-binding.md",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/ProtocolError",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Worker",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Actor",

--- a/docs/conformance/fixtures/invalid/silent-skill-activation.json
+++ b/docs/conformance/fixtures/invalid/silent-skill-activation.json
@@ -7,8 +7,8 @@
   "source_contract_refs": [
     "docs/conformance/failure-modes.md",
     "docs/conformance/compatibility-mapping.md",
-    "docs/planning/week-3/chunk-1-fixture-architecture.md",
-    "docs/planning/week-3/chunk-4-failure-fixtures.md",
+    "docs/conformance/checklist.md",
+    "docs/protocol/15-openapi-communication-binding.md",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/ProtocolError",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Worker",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Actor",

--- a/docs/conformance/fixtures/invalid/stale-request-timestamp.json
+++ b/docs/conformance/fixtures/invalid/stale-request-timestamp.json
@@ -7,8 +7,8 @@
   "source_contract_refs": [
     "docs/conformance/failure-modes.md",
     "docs/conformance/compatibility-mapping.md",
-    "docs/planning/week-3/chunk-1-fixture-architecture.md",
-    "docs/planning/week-3/chunk-4-failure-fixtures.md",
+    "docs/conformance/checklist.md",
+    "docs/protocol/15-openapi-communication-binding.md",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/ProtocolError",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Worker",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Actor",

--- a/docs/conformance/fixtures/invalid/stale-takeover-continuation.json
+++ b/docs/conformance/fixtures/invalid/stale-takeover-continuation.json
@@ -7,8 +7,8 @@
   "source_contract_refs": [
     "docs/conformance/failure-modes.md",
     "docs/conformance/compatibility-mapping.md",
-    "docs/planning/week-3/chunk-1-fixture-architecture.md",
-    "docs/planning/week-3/chunk-4-failure-fixtures.md",
+    "docs/conformance/checklist.md",
+    "docs/protocol/15-openapi-communication-binding.md",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/ProtocolError",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Worker",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Actor",
@@ -285,6 +285,7 @@
       "expected_status": 400,
       "expected_error_id": "stale_takeover_epoch",
       "expected_error_field": "records.takeovers.active.lock_epoch",
+      "attempted_takeover_lock_epoch": 1,
       "work_session_id": "ws-invalid-001",
       "body_ref": "records.jarvis_events.stale_agent_continuation"
     }

--- a/docs/conformance/fixtures/invalid/stale-work-session-revision.json
+++ b/docs/conformance/fixtures/invalid/stale-work-session-revision.json
@@ -7,8 +7,8 @@
   "source_contract_refs": [
     "docs/conformance/failure-modes.md",
     "docs/conformance/compatibility-mapping.md",
-    "docs/planning/week-3/chunk-1-fixture-architecture.md",
-    "docs/planning/week-3/chunk-4-failure-fixtures.md",
+    "docs/conformance/checklist.md",
+    "docs/protocol/15-openapi-communication-binding.md",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/ProtocolError",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Worker",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Actor",

--- a/docs/conformance/fixtures/invalid/unauthorized-actor.json
+++ b/docs/conformance/fixtures/invalid/unauthorized-actor.json
@@ -7,8 +7,8 @@
   "source_contract_refs": [
     "docs/conformance/failure-modes.md",
     "docs/conformance/compatibility-mapping.md",
-    "docs/planning/week-3/chunk-1-fixture-architecture.md",
-    "docs/planning/week-3/chunk-4-failure-fixtures.md",
+    "docs/conformance/checklist.md",
+    "docs/protocol/15-openapi-communication-binding.md",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/ProtocolError",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Worker",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Actor",

--- a/docs/conformance/fixtures/invalid/unresolved-request.json
+++ b/docs/conformance/fixtures/invalid/unresolved-request.json
@@ -7,8 +7,8 @@
   "source_contract_refs": [
     "docs/conformance/failure-modes.md",
     "docs/conformance/compatibility-mapping.md",
-    "docs/planning/week-3/chunk-1-fixture-architecture.md",
-    "docs/planning/week-3/chunk-4-failure-fixtures.md",
+    "docs/conformance/checklist.md",
+    "docs/protocol/15-openapi-communication-binding.md",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/ProtocolError",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Worker",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Actor",

--- a/docs/conformance/fixtures/valid/golden-path.json
+++ b/docs/conformance/fixtures/valid/golden-path.json
@@ -7,7 +7,7 @@
   "source_contract_refs": [
     "docs/conformance/golden-path.md",
     "docs/conformance/compatibility-mapping.md",
-    "docs/planning/week-3/chunk-1-fixture-architecture.md",
+    "docs/conformance/checklist.md",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Worker",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Actor",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/HumanWorker",

--- a/docs/planning/v0.1-acceptance-review/gate-3-conformance-surface-audit.md
+++ b/docs/planning/v0.1-acceptance-review/gate-3-conformance-surface-audit.md
@@ -1,0 +1,250 @@
+# Gate 3 Conformance Surface Audit
+
+Status: pass.
+
+Review date: 2026-06-30.
+
+Branch: `codex/v0.1-gate-3-conformance-surface-audit`.
+
+Base commit audited: `b093337`.
+
+Working-tree audit state: Gate 3 diff on top of `b093337`.
+
+Decision: Gate 3 passes. Every required proof row passes and no blocker
+remains.
+
+## Scope
+
+Audited sources:
+
+- [../../conformance/checklist.md](../../conformance/checklist.md)
+- [../../conformance/golden-path.md](../../conformance/golden-path.md)
+- [../../conformance/failure-modes.md](../../conformance/failure-modes.md)
+- [../../conformance/fixtures/README.md](../../conformance/fixtures/README.md)
+- [../../conformance/fixtures/valid/golden-path.json](../../conformance/fixtures/valid/golden-path.json)
+- [../../conformance/fixtures/invalid/](../../conformance/fixtures/invalid/)
+- [../../../scripts/check_conformance_fixtures.py](../../../scripts/check_conformance_fixtures.py)
+- [../../openapi/jarvis-openapi.yaml](../../openapi/jarvis-openapi.yaml)
+
+Out of scope:
+
+```txt
+SDK implementation
+adapter implementation
+wrapper implementation
+host runtime behavior
+host UI behavior
+model orchestration
+tool execution
+storage behavior
+auth behavior
+billing behavior
+scoring behavior
+payment behavior
+deployment behavior
+```
+
+## Source Coverage
+
+| Source group | Covered paths | Gate 3 check | Result |
+| --- | --- | --- | --- |
+| Public checklist | `docs/conformance/checklist.md` | Golden path, required headers, compatibility gates, fixture-backed rejection ids, non-fixture-backed error ids, error envelope, public compatibility claim | pass |
+| Fixture entry | `docs/conformance/fixtures/README.md` | Fixture layout, envelope, operations, assertions, validator contract, host boundary | pass |
+| Fixture records | `docs/conformance/fixtures/valid/golden-path.json`, `docs/conformance/fixtures/invalid/*.json` | Golden path and 24 invalid rejection fixtures | pass |
+| Validator | `scripts/check_conformance_fixtures.py` | Required fixture set, OpenAPI operation binding, headers, revision/hash binding, forbidden export fields, event chain, golden-path semantics, invalid rejection semantics, assertion coverage | pass |
+| OpenAPI source | `docs/openapi/jarvis-openapi.yaml` | Operation ids, protocol error ids, schema refs used by fixtures | pass |
+| Acceptance audit artifact | `docs/planning/v0.1-acceptance-review/gate-3-conformance-surface-audit.md` | Gate proof matrix, blocker ledger, command evidence, changed-file coverage | pass |
+
+Every changed file belongs to a coverage row:
+
+| Changed file | Coverage row |
+| --- | --- |
+| `docs/conformance/fixtures/README.md` | Fixture entry |
+| `docs/conformance/fixtures/valid/golden-path.json` | Fixture records |
+| `docs/conformance/fixtures/invalid/*.json` | Fixture records |
+| `scripts/check_conformance_fixtures.py` | Validator |
+| `docs/planning/v0.1-acceptance-review/gate-3-conformance-surface-audit.md` | Acceptance audit artifact |
+
+## Required Proof Matrix
+
+| ID | Required proof | Evidence | Result |
+| --- | --- | --- | --- |
+| G3-01 | golden-path fixture validates | `docs/conformance/fixtures/valid/golden-path.json`, `scripts/check_conformance_fixtures.py:1034`, `scripts/check_conformance_fixtures.py:1639` | pass |
+| G3-02 | invalid fixtures validate | `docs/conformance/fixtures/invalid/`, `scripts/check_conformance_fixtures.py:99`, `scripts/check_conformance_fixtures.py:1643` | pass |
+| G3-03 | fixture-backed rejection ids match checklist | `docs/conformance/checklist.md:387`, `scripts/check_conformance_fixtures.py:99`, `scripts/check_conformance_fixtures.py:1651` | pass |
+| G3-04 | unsupported non-fixture rejection ids remain documented without claiming fixture coverage | `docs/conformance/checklist.md:418`, `docs/conformance/checklist.md:423` | pass |
+| G3-05 | validator checks required headers | `scripts/check_conformance_fixtures.py:130`, `scripts/check_conformance_fixtures.py:140`, `scripts/check_conformance_fixtures.py:148`, `scripts/check_conformance_fixtures.py:765` | pass |
+| G3-06 | validator checks expected revision and previous event hash | `scripts/check_conformance_fixtures.py:424`, `scripts/check_conformance_fixtures.py:915`, `scripts/check_conformance_fixtures.py:1007` | pass |
+| G3-07 | validator checks Actor authority fixture semantics | `scripts/check_conformance_fixtures.py:369`, `scripts/check_conformance_fixtures.py:1481` | pass |
+| G3-08 | validator checks PolicyDecision ordering semantics | `scripts/check_conformance_fixtures.py:1080`, `scripts/check_conformance_fixtures.py:1249` | pass |
+| G3-09 | validator checks Request resolution semantics | `scripts/check_conformance_fixtures.py:1088`, `scripts/check_conformance_fixtures.py:1266`, `scripts/check_conformance_fixtures.py:1290` | pass |
+| G3-10 | validator checks Takeover epoch semantics | `scripts/check_conformance_fixtures.py:1377`, `scripts/check_conformance_fixtures.py:1394`, `docs/conformance/checklist.md:230` | pass |
+| G3-11 | validator checks forbidden host-private export fields | `scripts/check_conformance_fixtures.py:172`, `scripts/check_conformance_fixtures.py:549`, `docs/conformance/checklist.md:44` | pass |
+| G3-12 | validator checks sealed WorkSession and sealed EvidenceManifest mutation | `scripts/check_conformance_fixtures.py:1434`, `scripts/check_conformance_fixtures.py:1447`, `docs/conformance/checklist.md:157`, `docs/conformance/checklist.md:291` | pass |
+| G3-13 | public checklist covers ApprovalScope bounds | `docs/conformance/checklist.md:212`, `docs/conformance/checklist.md:219` | pass |
+| G3-14 | public checklist covers Contribution attribution | `docs/conformance/checklist.md:248`, `docs/conformance/checklist.md:252` | pass |
+| G3-15 | public checklist covers EvidenceManifest completeness and capture timing | `docs/conformance/checklist.md:268`, `docs/conformance/checklist.md:272`, `docs/conformance/checklist.md:275` | pass |
+| G3-16 | public checklist covers MemoryProposal and SkillProposal governance | `docs/conformance/checklist.md:317`, `docs/conformance/checklist.md:334` | pass |
+| G3-17 | public checklist covers OutcomeReport learning hook | `docs/conformance/checklist.md:349`, `docs/conformance/checklist.md:358` | pass |
+| G3-18 | public checklist covers protocol error envelope | `docs/conformance/checklist.md:463`, `docs/conformance/checklist.md:465` | pass |
+| G3-19 | public checklist covers capability negotiation and extension rejection | `docs/conformance/checklist.md:370`, `docs/conformance/checklist.md:374`, `docs/conformance/checklist.md:381` | pass |
+| G3-20 | validator checks global assertion-class coverage | `scripts/check_conformance_fixtures.py:90`, `scripts/check_conformance_fixtures.py:1526`, `scripts/check_conformance_fixtures.py:1691` | pass |
+
+## Source Findings
+
+| Finding ID | Blocker ID | Severity | Source | Gate proof affected | Finding | Resolution | Status |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| G3-F1 | G3-B1 | blocker | `scripts/check_conformance_fixtures.py` | G3-07, G3-08, G3-09, G3-10, G3-12, G3-20 | The validator checked fixture envelopes, operation binding, header classes, event hash shape, and assertion labels, but it did not prove several semantic rejection shapes. A fixture label alone did not prove invalid Request, PolicyDecision, Takeover, sealed mutation, or learning-governance rejection state. | Added golden-path semantic checks, invalid rejection semantic checks, and global assertion-class coverage checks. The validator now rejects fake semantic fixtures for Actor authority, missing Policy, missing PolicyDecision, Request resolution, ApprovalScope, Takeover epoch, evidence export state, sealed WorkSession mutation, sealed EvidenceManifest mutation, silent memory mutation, silent skill activation, OutcomeReport learning refs, and golden-path proof. | resolved |
+| G3-F2 | G3-B2 | blocker | `docs/conformance/fixtures/README.md` | G3-03, G3-20 | The fixture README described envelope, operation, header, and host-private validation but did not state the full semantic validator contract. | Updated the fixture README to name global assertion-class coverage, golden-path semantic coverage, invalid rejection semantics, WorkSession revision and previous-hash binding, and host-private export boundaries. | resolved |
+| G3-F3 | G3-B3 | blocker | `scripts/check_conformance_fixtures.py` | G3-01, G3-09, G3-13, G3-15, G3-17 | Golden-path checks proved object presence but did not bind `PolicyDecision -> Request -> Review -> ApprovalScope -> EvidenceManifest -> LearningRecord -> OutcomeReport` by protocol ids. | Added cross-object golden-path binding for PolicyDecision, Request, Review, ApprovalScope, Contribution, EvidenceManifest, LearningRecord, MemoryProposal, SkillProposal, and OutcomeReport. | resolved |
+| G3-F4 | G3-B4 | blocker | `scripts/check_conformance_fixtures.py` | G3-09, G3-10, G3-12 | Several invalid fixture checks accepted unrelated records instead of the rejecting operation body, Actor, WorkSession, and scope. | Bound `request_unresolved`, `stale_takeover_epoch`, `invalid_evidence_export_state`, `sealed_work_session_mutation`, and `sealed_evidence_mutation` to the rejecting operation and target WorkSession. | resolved |
+| G3-F5 | G3-B5 | blocker | `scripts/check_conformance_fixtures.py` | G3-05 | `stale_request_timestamp` checked timestamp format but did not prove stale time. | Added timestamp comparison between `Jarvis-Request-Timestamp` and the submitted protocol body timestamp. | resolved |
+| G3-F6 | G3-B6 | blocker | `scripts/check_conformance_fixtures.py` | G3-09 | Request review-resolution status coverage omitted `needs_revision`. | Added `needs_revision` to review-resolved Request status validation. | resolved |
+| G3-F7 | G3-B7 | blocker | `docs/conformance/fixtures/README.md`, `docs/conformance/fixtures/**/*.json` | G3-03, G3-15 | Public fixture docs and fixture source refs contained week-planning references, and the invalid EvidenceManifest fixture used stale `externally_submitted` wording. | Replaced planning references with stable conformance, protocol, and validator sources, and changed final export wording to `completed`, `failed`, `cancelled`, or `closed`. | resolved |
+
+## Blocker List
+
+No blocker remains.
+
+| Blocker ID | Source | Gate proof failed | Resolution evidence | Status |
+| --- | --- | --- | --- | --- |
+| G3-B1 | Conformance validator semantic coverage | G3-07, G3-08, G3-09, G3-10, G3-12, G3-20 | `scripts/check_conformance_fixtures.py:1034`, `scripts/check_conformance_fixtures.py:1227`, `scripts/check_conformance_fixtures.py:1526`, `scripts/check_conformance_fixtures.py:1639` | resolved |
+| G3-B2 | Fixture README validator contract | G3-03, G3-20 | `docs/conformance/fixtures/README.md:121` | resolved |
+| G3-B3 | Golden-path cross-object binding | G3-01, G3-09, G3-13, G3-15, G3-17 | `scripts/check_conformance_fixtures.py:1080`, `scripts/check_conformance_fixtures.py:1088`, `scripts/check_conformance_fixtures.py:1104`, `scripts/check_conformance_fixtures.py:1175`, `scripts/check_conformance_fixtures.py:1210` | resolved |
+| G3-B4 | Invalid fixture rejecting-operation binding | G3-09, G3-10, G3-12 | `scripts/check_conformance_fixtures.py:1301`, `scripts/check_conformance_fixtures.py:1377`, `scripts/check_conformance_fixtures.py:1417`, `scripts/check_conformance_fixtures.py:1434`, `scripts/check_conformance_fixtures.py:1447` | resolved |
+| G3-B5 | Stale request timestamp proof | G3-05 | `scripts/check_conformance_fixtures.py:97`, `scripts/check_conformance_fixtures.py:1236` | resolved |
+| G3-B6 | Request `needs_revision` resolution coverage | G3-09 | `scripts/check_conformance_fixtures.py:89`, `scripts/check_conformance_fixtures.py:1277` | resolved |
+| G3-B7 | Public fixture source wording | G3-03, G3-15 | `docs/conformance/fixtures/README.md:110`, `docs/conformance/fixtures/valid/golden-path.json:10`, `docs/conformance/fixtures/invalid/invalid-evidence-export-state.json:254` | resolved |
+
+## Command Evidence
+
+Commands run after Gate 3 fixes:
+
+| Command | Exit status | Output summary |
+| --- | --- | --- |
+| `python3 scripts/check_conformance_fixtures.py` | 0 | `conformance fixtures ok` |
+| `python3 scripts/check_protocol_wording.py` | 0 | `protocol wording ok` |
+| `python3 scripts/check_markdown_links.py` | 0 | `markdown links ok` |
+| `python3 scripts/check_openapi_contract.py` | 0 | `openapi contract ok` |
+| `git diff --check` | 0 | no output |
+| `node --check demo/assets/app.js` | 0 | no output |
+
+Pre-stage working-tree state at audit time:
+
+```txt
+ M docs/conformance/fixtures/README.md
+ M docs/conformance/fixtures/invalid/forbidden-host-private-export-field.json
+ M docs/conformance/fixtures/invalid/invalid-approval-scope.json
+ M docs/conformance/fixtures/invalid/invalid-evidence-export-state.json
+ M docs/conformance/fixtures/invalid/invalid-previous-event-hash.json
+ M docs/conformance/fixtures/invalid/missing-actor.json
+ M docs/conformance/fixtures/invalid/missing-expected-work-session-revision.json
+ M docs/conformance/fixtures/invalid/missing-idempotency-key.json
+ M docs/conformance/fixtures/invalid/missing-policy-decision.json
+ M docs/conformance/fixtures/invalid/missing-policy.json
+ M docs/conformance/fixtures/invalid/missing-previous-event-hash.json
+ M docs/conformance/fixtures/invalid/missing-protocol-version.json
+ M docs/conformance/fixtures/invalid/missing-request-timestamp.json
+ M docs/conformance/fixtures/invalid/missing-review-resolution.json
+ M docs/conformance/fixtures/invalid/missing-takeover-resolution.json
+ M docs/conformance/fixtures/invalid/outcome-report-without-learning-record.json
+ M docs/conformance/fixtures/invalid/sealed-evidence-mutation.json
+ M docs/conformance/fixtures/invalid/sealed-work-session-mutation.json
+ M docs/conformance/fixtures/invalid/silent-memory-mutation.json
+ M docs/conformance/fixtures/invalid/silent-skill-activation.json
+ M docs/conformance/fixtures/invalid/stale-request-timestamp.json
+ M docs/conformance/fixtures/invalid/stale-takeover-continuation.json
+ M docs/conformance/fixtures/invalid/stale-work-session-revision.json
+ M docs/conformance/fixtures/invalid/unauthorized-actor.json
+ M docs/conformance/fixtures/invalid/unresolved-request.json
+ M docs/conformance/fixtures/valid/golden-path.json
+ M scripts/check_conformance_fixtures.py
+?? docs/planning/v0.1-acceptance-review/gate-3-conformance-surface-audit.md
+```
+
+Tracked diff stat before staging:
+
+```txt
+ docs/conformance/fixtures/README.md                |  11 +-
+ .../forbidden-host-private-export-field.json       |   4 +-
+ .../fixtures/invalid/invalid-approval-scope.json   |   4 +-
+ .../invalid/invalid-evidence-export-state.json     |   6 +-
+ .../invalid/invalid-previous-event-hash.json       |   4 +-
+ .../fixtures/invalid/missing-actor.json            |   4 +-
+ .../missing-expected-work-session-revision.json    |   4 +-
+ .../fixtures/invalid/missing-idempotency-key.json  |   4 +-
+ .../fixtures/invalid/missing-policy-decision.json  |   4 +-
+ .../fixtures/invalid/missing-policy.json           |   4 +-
+ .../invalid/missing-previous-event-hash.json       |   4 +-
+ .../fixtures/invalid/missing-protocol-version.json |   4 +-
+ .../invalid/missing-request-timestamp.json         |   4 +-
+ .../invalid/missing-review-resolution.json         |   4 +-
+ .../invalid/missing-takeover-resolution.json       |   4 +-
+ .../outcome-report-without-learning-record.json    |   4 +-
+ .../fixtures/invalid/sealed-evidence-mutation.json |   4 +-
+ .../invalid/sealed-work-session-mutation.json      |   4 +-
+ .../fixtures/invalid/silent-memory-mutation.json   |   4 +-
+ .../fixtures/invalid/silent-skill-activation.json  |   4 +-
+ .../fixtures/invalid/stale-request-timestamp.json  |   4 +-
+ .../invalid/stale-takeover-continuation.json       |   5 +-
+ .../invalid/stale-work-session-revision.json       |   4 +-
+ .../fixtures/invalid/unauthorized-actor.json       |   4 +-
+ .../fixtures/invalid/unresolved-request.json       |   4 +-
+ docs/conformance/fixtures/valid/golden-path.json   |   2 +-
+ scripts/check_conformance_fixtures.py              | 721 ++++++++++++++++++++-
+ 27 files changed, 775 insertions(+), 58 deletions(-)
+```
+
+Tracked diff name-only before staging:
+
+```txt
+docs/conformance/fixtures/README.md
+docs/conformance/fixtures/invalid/forbidden-host-private-export-field.json
+docs/conformance/fixtures/invalid/invalid-approval-scope.json
+docs/conformance/fixtures/invalid/invalid-evidence-export-state.json
+docs/conformance/fixtures/invalid/invalid-previous-event-hash.json
+docs/conformance/fixtures/invalid/missing-actor.json
+docs/conformance/fixtures/invalid/missing-expected-work-session-revision.json
+docs/conformance/fixtures/invalid/missing-idempotency-key.json
+docs/conformance/fixtures/invalid/missing-policy-decision.json
+docs/conformance/fixtures/invalid/missing-policy.json
+docs/conformance/fixtures/invalid/missing-previous-event-hash.json
+docs/conformance/fixtures/invalid/missing-protocol-version.json
+docs/conformance/fixtures/invalid/missing-request-timestamp.json
+docs/conformance/fixtures/invalid/missing-review-resolution.json
+docs/conformance/fixtures/invalid/missing-takeover-resolution.json
+docs/conformance/fixtures/invalid/outcome-report-without-learning-record.json
+docs/conformance/fixtures/invalid/sealed-evidence-mutation.json
+docs/conformance/fixtures/invalid/sealed-work-session-mutation.json
+docs/conformance/fixtures/invalid/silent-memory-mutation.json
+docs/conformance/fixtures/invalid/silent-skill-activation.json
+docs/conformance/fixtures/invalid/stale-request-timestamp.json
+docs/conformance/fixtures/invalid/stale-takeover-continuation.json
+docs/conformance/fixtures/invalid/stale-work-session-revision.json
+docs/conformance/fixtures/invalid/unauthorized-actor.json
+docs/conformance/fixtures/invalid/unresolved-request.json
+docs/conformance/fixtures/valid/golden-path.json
+scripts/check_conformance_fixtures.py
+```
+
+## Gate 3 Decision
+
+Gate 3 status: pass.
+
+Accepted proof rows: G3-01 through G3-20.
+
+Resolved blockers: G3-B1, G3-B2, G3-B3, G3-B4, G3-B5, G3-B6, G3-B7.
+
+Remaining blockers: none.
+
+Decision rationale:
+
+```txt
+Jarvis v0.1 conformance now has public checklist coverage, fixture-backed
+golden-path and invalid rejection proof, OpenAPI-bound operation validation,
+zero-trust header checks, revision and previous-hash checks, cross-object
+protocol id binding, rejecting-operation semantic checks, host-private export
+rejection, sealed-record mutation rejection, stale timestamp rejection,
+learning-governance checks, and global assertion-class coverage without
+executing host-owned runtime behavior.
+```

--- a/scripts/check_conformance_fixtures.py
+++ b/scripts/check_conformance_fixtures.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from pathlib import Path
 import json
 import re
@@ -43,6 +44,57 @@ ASSERTION_CLASSES = {
     "learning_governance_gate",
     "host_private_boundary_gate",
 }
+
+GOLDEN_PATH_REQUIRED_RECORD_GROUPS = {
+    "actors",
+    "agent_workers",
+    "contributions",
+    "evidence_manifests",
+    "human_workers",
+    "jarvis_events",
+    "learning_records",
+    "memory_proposals",
+    "outcome_reports",
+    "policies",
+    "policy_decisions",
+    "requests",
+    "reviews",
+    "skill_proposals",
+    "work_sessions",
+    "workers",
+}
+
+GOLDEN_PATH_REQUIRED_ASSERTION_CLASSES = {
+    "header_gate",
+    "actor_authority_gate",
+    "event_chain_gate",
+    "policy_decision_gate",
+    "request_resolution_gate",
+    "approval_scope_gate",
+    "contribution_attribution_gate",
+    "evidence_export_gate",
+    "learning_governance_gate",
+    "host_private_boundary_gate",
+}
+
+GLOBAL_REQUIRED_ASSERTION_CLASSES = ASSERTION_CLASSES
+
+TERMINAL_WORK_SESSION_STATES = {
+    "completed",
+    "failed",
+    "cancelled",
+    "closed",
+}
+
+REVIEW_RESOLVED_REQUEST_STATUSES = {
+    "approved",
+    "denied",
+    "narrowed",
+    "answered",
+    "needs_revision",
+}
+
+STALE_TIMESTAMP_MIN_SECONDS = 300
 
 REQUIRED_INVALID_FIXTURES = {
     "forbidden-host-private-export-field.json": "forbidden_host_private_field",
@@ -260,6 +312,152 @@ def get_ref(data: dict[str, Any], ref: str) -> Any:
     return current
 
 
+def all_records(records: dict[str, Any], group_name: str) -> list[dict[str, Any]]:
+    group = records.get(group_name, {})
+    if not isinstance(group, dict):
+        return []
+    return [value for value in group.values() if isinstance(value, dict)]
+
+
+def ids_for(records: dict[str, Any], group_name: str) -> set[str]:
+    return {
+        record["id"]
+        for record in all_records(records, group_name)
+        if isinstance(record.get("id"), str)
+    }
+
+
+def record_by_id(
+    records: dict[str, Any], group_name: str, record_id: str | None
+) -> dict[str, Any] | None:
+    if record_id is None:
+        return None
+    for record in all_records(records, group_name):
+        if record.get("id") == record_id:
+            return record
+    return None
+
+
+def rejecting_operation(operation: dict[str, Any]) -> bool:
+    status = operation.get("expected_status")
+    return is_int(status) and status >= 400
+
+
+def first_rejecting_operation(fixture: dict[str, Any]) -> dict[str, Any]:
+    expected_error_id = fixture.get("expected_error_id")
+    for operation in fixture.get("operations", []):
+        if (
+            isinstance(operation, dict)
+            and rejecting_operation(operation)
+            and operation.get("expected_error_id") == expected_error_id
+        ):
+            return operation
+    return {}
+
+
+def operation_body(fixture: dict[str, Any], operation: dict[str, Any]) -> Any:
+    body_ref = operation.get("body_ref")
+    if isinstance(body_ref, str):
+        return get_ref(fixture, body_ref)
+    return None
+
+
+def actor_by_id(records: dict[str, Any], actor_id: str | None) -> dict[str, Any] | None:
+    return record_by_id(records, "actors", actor_id)
+
+
+def worker_for_actor(
+    records: dict[str, Any], actor: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    if actor is None:
+        return None
+    worker_id = actor.get("worker_id")
+    if not isinstance(worker_id, str):
+        return None
+    return record_by_id(records, "workers", worker_id)
+
+
+def worker_grants(worker: dict[str, Any] | None) -> set[str]:
+    if worker is None:
+        return set()
+    authority_scope = worker.get("authority_scope", {})
+    if not isinstance(authority_scope, dict):
+        return set()
+    grants = authority_scope.get("grants", [])
+    if not isinstance(grants, list):
+        return set()
+    return {grant for grant in grants if isinstance(grant, str)}
+
+
+def parse_utc_timestamp(value: Any) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
+    except ValueError:
+        return None
+    return parsed.replace(tzinfo=timezone.utc)
+
+
+def timestamp_field(value: dict[str, Any]) -> datetime | None:
+    for field_name in ("created_at", "updated_at", "timestamp", "received_at"):
+        parsed = parse_utc_timestamp(value.get(field_name))
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def request_id_from_target_ref(target_ref: Any) -> str | None:
+    if isinstance(target_ref, str) and target_ref.startswith("request:"):
+        return target_ref.removeprefix("request:")
+    return None
+
+
+def target_work_session_id(operation: dict[str, Any], body: Any) -> str | None:
+    if isinstance(operation.get("work_session_id"), str):
+        return operation["work_session_id"]
+    if isinstance(body, dict) and isinstance(body.get("work_session_id"), str):
+        return body["work_session_id"]
+    return None
+
+
+def work_session_snapshot_for_operation(
+    records: dict[str, Any], operation: dict[str, Any], body: Any
+) -> dict[str, Any] | None:
+    work_session_id = target_work_session_id(operation, body)
+    if work_session_id is None:
+        return None
+    revision = operation.get("headers", {}).get("Jarvis-Expected-WorkSession-Revision")
+    previous_hash = operation.get("headers", {}).get("Jarvis-Previous-Event-Hash")
+    for snapshot in all_records(records, "work_sessions"):
+        if snapshot.get("id") != work_session_id:
+            continue
+        if is_int(revision) and previous_hash is not None:
+            if (
+                snapshot.get("revision") == revision
+                and snapshot.get("last_event_hash") == previous_hash
+            ):
+                return snapshot
+    return None
+
+
+def resolved_state_ref(path: Path, fixture: dict[str, Any], state_ref: str) -> Any:
+    value = get_ref(fixture, state_ref)
+    if value is None:
+        raise FixtureError(f"{rel(path)}: expected_error_field does not resolve")
+    return value
+
+
+def records_with_status(
+    records: dict[str, Any], group_name: str, statuses: set[str]
+) -> list[dict[str, Any]]:
+    return [
+        record
+        for record in all_records(records, group_name)
+        if record.get("status") in statuses
+    ]
+
+
 def ref_targets_protocol_state(ref: str) -> bool:
     return ref == "host_shape_ref" or ref == "operations" or ref.startswith(
         "records."
@@ -444,7 +642,7 @@ def validate_fixture_envelope(path: Path, fixture: dict[str, Any], expected_kind
             operation
             for operation in fixture["operations"]
             if isinstance(operation, dict)
-            and operation.get("expected_status", 0) >= 400
+            and rejecting_operation(operation)
             and operation.get("expected_error_id") == fixture.get("expected_error_id")
         ]
         if not rejected_operations:
@@ -533,6 +731,8 @@ def validate_operation(
         raise FixtureError(f"{rel(path)}: unknown operation_id {operation_id}")
     operation_info = operations[operation_id]
 
+    if not is_int(operation.get("expected_status")):
+        raise FixtureError(f"{rel(path)}: {operation_id} expected_status MUST be integer")
     if operation.get("method") != operation_info["method"]:
         raise FixtureError(f"{rel(path)}: {operation_id} method does not match OpenAPI")
     path_values = path_param_values(operation_info["path_template"], operation.get("path", ""))
@@ -631,7 +831,7 @@ def validate_operation(
         if "work_session_id" not in operation:
             raise FixtureError(f"{rel(path)}: {operation_id} requires work_session_id")
 
-    if operation.get("expected_status", 0) >= 400:
+    if rejecting_operation(operation):
         if operation.get("expected_error_id") != expected_error_id:
             raise FixtureError(
                 f"{rel(path)}: {operation_id} expected_error_id must match fixture"
@@ -831,6 +1031,513 @@ def validate_assertion(path: Path, fixture: dict[str, Any], assertion: dict[str,
         raise FixtureError(f"{rel(path)}: passing assertion has expected_error_id")
 
 
+def validate_golden_path_semantics(path: Path, fixture: dict[str, Any]) -> None:
+    if path.name != "golden-path.json":
+        return
+
+    records = fixture.get("records", {})
+    missing_record_groups = sorted(GOLDEN_PATH_REQUIRED_RECORD_GROUPS - set(records))
+    if missing_record_groups:
+        raise FixtureError(
+            f"{rel(path)}: golden path missing record groups: "
+            + ", ".join(missing_record_groups)
+        )
+
+    assertion_classes = {
+        assertion.get("class")
+        for assertion in fixture.get("assertions", [])
+        if isinstance(assertion, dict)
+    }
+    missing_assertion_classes = sorted(
+        GOLDEN_PATH_REQUIRED_ASSERTION_CLASSES - assertion_classes
+    )
+    if missing_assertion_classes:
+        raise FixtureError(
+            f"{rel(path)}: golden path missing assertion classes: "
+            + ", ".join(missing_assertion_classes)
+        )
+
+    request = get_ref(fixture, "records.requests.approved")
+    review = get_ref(fixture, "records.reviews.approve_source")
+    policy_decision = get_ref(
+        fixture, "records.policy_decisions.external_source_denied"
+    )
+    evidence_manifest = get_ref(fixture, "records.evidence_manifests.portable_export")
+    learning_record = get_ref(fixture, "records.learning_records.pair")
+    outcome_report = get_ref(fixture, "records.outcome_reports.post_session")
+    memory_proposal = get_ref(fixture, "records.memory_proposals.source_policy_pattern")
+    skill_proposal = get_ref(fixture, "records.skill_proposals.bounded_source_collection")
+    contribution = get_ref(fixture, "records.contributions.shared_answer")
+
+    if (
+        not isinstance(policy_decision, dict)
+        or not isinstance(request, dict)
+        or policy_decision.get("request_id") != request.get("id")
+        or request.get("policy_decision_id") != policy_decision.get("id")
+        or policy_decision.get("work_session_id") != request.get("work_session_id")
+        or policy_decision.get("actor_id") != request.get("requester_actor_id")
+    ):
+        raise FixtureError(f"{rel(path)}: golden PolicyDecision MUST create Request")
+
+    if (
+        not isinstance(review, dict)
+        or request.get("resolved_by_review_id") != review.get("id")
+        or review.get("target_ref") != f"request:{request.get('id')}"
+        or review.get("work_session_id") != request.get("work_session_id")
+    ):
+        raise FixtureError(f"{rel(path)}: golden Request MUST resolve by Review")
+
+    approval_scope = review.get("approval_scope") if isinstance(review, dict) else None
+    if (
+        not isinstance(approval_scope, dict)
+        or approval_scope.get("request_id") != request.get("id")
+        or approval_scope.get("review_id") != review.get("id")
+        or approval_scope.get("policy_decision_id") != policy_decision.get("id")
+        or approval_scope.get("applies_to_work_session_id") != request.get("work_session_id")
+        or approval_scope.get("applies_to_actor_id") != request.get("requester_actor_id")
+        or approval_scope.get("approved_action") != request.get("requested_action")
+        or not is_int(approval_scope.get("max_uses"))
+        or approval_scope.get("max_uses") <= 0
+        or not parse_utc_timestamp(approval_scope.get("expires_at"))
+        or parse_utc_timestamp(approval_scope.get("expires_at"))
+        <= timestamp_field(review)
+        or not isinstance(approval_scope.get("normalized_action_hash"), str)
+        or not approval_scope["normalized_action_hash"].startswith("hash:")
+    ):
+        raise FixtureError(f"{rel(path)}: golden Review MUST create ApprovalScope")
+
+    worker_ids = ids_for(records, "workers")
+    actor_ids = ids_for(records, "actors")
+    if (
+        not isinstance(contribution, dict)
+        or contribution.get("contributor_type") != "shared"
+        or not isinstance(contribution.get("contributor_refs"), list)
+        or len(contribution["contributor_refs"]) < 2
+    ):
+        raise FixtureError(f"{rel(path)}: golden Contribution MUST be attributable")
+    contributor_roles = {
+        contributor.get("contribution_role")
+        for contributor in contribution["contributor_refs"]
+        if isinstance(contributor, dict)
+    }
+    if not {"human", "agent"} <= contributor_roles:
+        raise FixtureError(f"{rel(path)}: golden Contribution MUST include human and agent")
+    if contribution.get("work_session_id") != request.get("work_session_id"):
+        raise FixtureError(f"{rel(path)}: golden Contribution MUST bind WorkSession")
+    for contributor in contribution["contributor_refs"]:
+        if not isinstance(contributor, dict):
+            raise FixtureError(
+                f"{rel(path)}: golden Contribution contributor refs MUST resolve"
+            )
+        contributor_worker = record_by_id(records, "workers", contributor.get("worker_id"))
+        contributor_actor = record_by_id(records, "actors", contributor.get("actor_id"))
+        if (
+            contributor.get("contribution_role") not in {"human", "agent"}
+            or contributor.get("worker_id") not in worker_ids
+            or contributor.get("actor_id") not in actor_ids
+            or not isinstance(contributor_worker, dict)
+            or not isinstance(contributor_actor, dict)
+            or contributor_worker.get("type") != contributor.get("contribution_role")
+            or contributor_actor.get("type") != contributor.get("contribution_role")
+            or contributor_actor.get("worker_id") != contributor_worker.get("id")
+        ):
+            raise FixtureError(
+                f"{rel(path)}: golden Contribution contributor refs MUST resolve"
+            )
+
+    event_ids = ids_for(records, "jarvis_events")
+    policy_decision_ids = ids_for(records, "policy_decisions")
+    request_ids = ids_for(records, "requests")
+    review_ids = ids_for(records, "reviews")
+    contribution_ids = ids_for(records, "contributions")
+    takeover_ids = ids_for(records, "takeovers")
+    terminal_snapshots = [
+        snapshot
+        for snapshot in all_records(records, "work_sessions")
+        if snapshot.get("id") == evidence_manifest.get("work_session_id")
+        and snapshot.get("status") in TERMINAL_WORK_SESSION_STATES
+    ] if isinstance(evidence_manifest, dict) else []
+
+    if (
+        not isinstance(evidence_manifest, dict)
+        or evidence_manifest.get("generated_by_actor_id") not in actor_ids
+        or evidence_manifest.get("work_session_id") != contribution.get("work_session_id")
+        or not terminal_snapshots
+        or evidence_manifest.get("event_chain_root")
+        not in {snapshot.get("last_event_hash") for snapshot in terminal_snapshots}
+        or not isinstance(evidence_manifest.get("evidence_item_refs"), list)
+        or not evidence_manifest["evidence_item_refs"]
+        or not isinstance(evidence_manifest.get("export_profile"), dict)
+        or not evidence_manifest.get("artifact_refs")
+        or not evidence_manifest.get("limitation_refs")
+        or contribution.get("id") not in evidence_manifest.get("contribution_refs", [])
+    ):
+        raise FixtureError(f"{rel(path)}: golden EvidenceManifest MUST export evidence")
+    for evidence_item in evidence_manifest["evidence_item_refs"]:
+        if (
+            not isinstance(evidence_item, dict)
+            or evidence_item.get("work_session_id") != evidence_manifest.get("work_session_id")
+            or evidence_item.get("captured_by_actor_id") not in actor_ids
+            or not set(evidence_item.get("source_event_refs", [])) <= event_ids
+        ):
+            raise FixtureError(
+                f"{rel(path)}: golden EvidenceManifest evidence items MUST bind events"
+            )
+    reference_sets = {
+        "policy_decision_refs": policy_decision_ids,
+        "request_refs": request_ids,
+        "review_refs": review_ids,
+        "takeover_refs": takeover_ids,
+        "contribution_refs": contribution_ids,
+    }
+    for field_name, allowed_ids in reference_sets.items():
+        refs = evidence_manifest.get(field_name, [])
+        if not isinstance(refs, list) or not set(refs) <= allowed_ids:
+            raise FixtureError(
+                f"{rel(path)}: golden EvidenceManifest {field_name} MUST resolve"
+            )
+
+    if not isinstance(learning_record, dict) or learning_record.get("subject_type") not in {
+        "human",
+        "agent",
+        "pair",
+    }:
+        raise FixtureError(f"{rel(path)}: golden LearningRecord subject_type is invalid")
+    learning_id = learning_record.get("id")
+    if (
+        not set(learning_record.get("source_event_refs", [])) <= event_ids
+        or not isinstance(memory_proposal, dict)
+        or not isinstance(skill_proposal, dict)
+        or learning_id not in memory_proposal.get("learning_record_refs", [])
+        or learning_id not in skill_proposal.get("learning_record_refs", [])
+        or not set(memory_proposal.get("source_event_refs", [])) <= event_ids
+        or not set(skill_proposal.get("source_event_refs", [])) <= event_ids
+    ):
+        raise FixtureError(f"{rel(path)}: golden LearningRecord refs MUST resolve")
+
+    if (
+        not isinstance(outcome_report, dict)
+        or learning_id not in outcome_report.get("learning_record_refs", [])
+        or outcome_report.get("work_session_id") != learning_record.get("work_session_id")
+        or outcome_report.get("accepted_by_actor_id") not in actor_ids
+    ):
+        raise FixtureError(f"{rel(path)}: golden OutcomeReport MUST reference learning")
+
+
+def validate_invalid_fixture_semantics(path: Path, fixture: dict[str, Any]) -> None:
+    expected_error_id = fixture.get("expected_error_id")
+    if not expected_error_id:
+        return
+
+    records = fixture.get("records", {})
+    operation = first_rejecting_operation(fixture)
+    body = operation_body(fixture, operation)
+
+    if expected_error_id == "stale_request_timestamp":
+        header_timestamp = parse_utc_timestamp(
+            operation.get("headers", {}).get("Jarvis-Request-Timestamp")
+        )
+        body_timestamp = timestamp_field(body) if isinstance(body, dict) else None
+        if (
+            header_timestamp is None
+            or body_timestamp is None
+            or (body_timestamp - header_timestamp).total_seconds()
+            < STALE_TIMESTAMP_MIN_SECONDS
+        ):
+            raise FixtureError(
+                f"{rel(path)}: stale_request_timestamp fixture MUST use stale timestamp"
+            )
+
+    elif expected_error_id == "missing_policy":
+        if not isinstance(body, dict):
+            raise FixtureError(f"{rel(path)}: missing_policy fixture MUST submit WorkSession")
+        policy_id = body.get("policy_id")
+        if not isinstance(policy_id, str) or policy_id in ids_for(records, "policies"):
+            raise FixtureError(
+                f"{rel(path)}: missing_policy fixture MUST reference absent Policy"
+            )
+
+    elif expected_error_id == "missing_policy_decision":
+        if not isinstance(body, dict):
+            raise FixtureError(
+                f"{rel(path)}: missing_policy_decision fixture MUST submit JarvisEvent"
+            )
+        actor = actor_by_id(records, body.get("actor_id"))
+        payload = body.get("payload", {})
+        has_policy_decision_ref = any(
+            key in body or (isinstance(payload, dict) and key in payload)
+            for key in ("policy_decision_id", "policy_decision_ref", "policy_decision_refs")
+        )
+        if actor is None or actor.get("type") != "agent" or has_policy_decision_ref:
+            raise FixtureError(
+                f"{rel(path)}: missing_policy_decision fixture MUST be AgentWorker "
+                "state without PolicyDecision"
+            )
+
+    elif expected_error_id == "missing_review_resolution":
+        if not isinstance(body, dict):
+            raise FixtureError(
+                f"{rel(path)}: missing_review_resolution fixture MUST submit Request"
+            )
+        if body.get("status") not in REVIEW_RESOLVED_REQUEST_STATUSES:
+            raise FixtureError(
+                f"{rel(path)}: missing_review_resolution fixture MUST use review-resolved status"
+            )
+        if body.get("resolved_by_review_id"):
+            raise FixtureError(
+                f"{rel(path)}: missing_review_resolution fixture MUST omit Review resolution"
+            )
+
+    elif expected_error_id == "missing_takeover_resolution":
+        if not isinstance(body, dict):
+            raise FixtureError(
+                f"{rel(path)}: missing_takeover_resolution fixture MUST submit Request"
+            )
+        if body.get("status") != "takeover" or body.get("resolved_by_takeover_id"):
+            raise FixtureError(
+                f"{rel(path)}: missing_takeover_resolution fixture MUST omit Takeover resolution"
+            )
+
+    elif expected_error_id == "request_unresolved":
+        work_session_id = target_work_session_id(operation, body)
+        pending_requests = [
+            request
+            for request in records_with_status(records, "requests", {"pending"})
+            if request.get("work_session_id") == work_session_id
+        ]
+        if not pending_requests or not isinstance(body, dict):
+            raise FixtureError(
+                f"{rel(path)}: request_unresolved fixture MUST keep Request pending"
+            )
+        if (
+            body.get("type") != "work_session.completed"
+            or body.get("work_session_id") != work_session_id
+        ):
+            raise FixtureError(
+                f"{rel(path)}: request_unresolved fixture MUST attempt terminal completion"
+            )
+
+    elif expected_error_id == "invalid_approval_scope":
+        if not isinstance(body, dict) or body.get("decision") not in {"approve", "narrow"}:
+            raise FixtureError(
+                f"{rel(path)}: invalid_approval_scope fixture MUST submit approve or narrow Review"
+            )
+        approval_scope = body.get("approval_scope")
+        request_id = request_id_from_target_ref(body.get("target_ref"))
+        request = record_by_id(records, "requests", request_id)
+        if (
+            not isinstance(request, dict)
+            or request.get("work_session_id") != body.get("work_session_id")
+        ):
+            raise FixtureError(
+                f"{rel(path)}: invalid_approval_scope fixture MUST target Request"
+            )
+        required = {
+            "request_id",
+            "review_id",
+            "policy_decision_id",
+            "normalized_action_hash",
+            "approved_action",
+            "allowed_scope",
+            "denied_scope",
+            "expires_at",
+            "max_uses",
+            "applies_to_work_session_id",
+            "applies_to_actor_id",
+        }
+        if not isinstance(approval_scope, dict):
+            return
+        if not required <= set(approval_scope):
+            return
+        approval_scope_valid = (
+            isinstance(request, dict)
+            and approval_scope.get("request_id") == request.get("id")
+            and approval_scope.get("review_id") == body.get("id")
+            and approval_scope.get("policy_decision_id") == request.get("policy_decision_id")
+            and approval_scope.get("applies_to_work_session_id")
+            == body.get("work_session_id")
+            and approval_scope.get("applies_to_actor_id") == request.get("requester_actor_id")
+            and approval_scope.get("approved_action") == request.get("requested_action")
+            and is_int(approval_scope.get("max_uses"))
+            and approval_scope.get("max_uses") > 0
+            and parse_utc_timestamp(approval_scope.get("expires_at")) is not None
+            and timestamp_field(body) is not None
+            and parse_utc_timestamp(approval_scope.get("expires_at")) > timestamp_field(body)
+            and isinstance(approval_scope.get("normalized_action_hash"), str)
+            and approval_scope["normalized_action_hash"].startswith("hash:")
+            and isinstance(approval_scope.get("approved_action"), dict)
+            and isinstance(approval_scope.get("allowed_scope"), dict)
+            and isinstance(approval_scope.get("denied_scope"), dict)
+        )
+        if approval_scope_valid:
+            raise FixtureError(
+                f"{rel(path)}: invalid_approval_scope fixture MUST have invalid bounds"
+            )
+
+    elif expected_error_id == "stale_takeover_epoch":
+        active_takeovers = [
+            takeover
+            for takeover in all_records(records, "takeovers")
+            if takeover.get("state") == "active"
+        ]
+        actor = actor_by_id(records, operation.get("actor_id"))
+        work_session_id = target_work_session_id(operation, body)
+        active_takeover = next(
+            (
+                takeover
+                for takeover in active_takeovers
+                if takeover.get("work_session_id") == work_session_id
+            ),
+            None,
+        )
+        operation_snapshot = work_session_snapshot_for_operation(records, operation, body)
+        attempted_lock_epoch = operation.get("attempted_takeover_lock_epoch")
+        stale_epoch = (
+            isinstance(body, dict)
+            and active_takeover is not None
+            and body.get("work_session_id") == active_takeover.get("work_session_id")
+            and body.get("actor_id") == operation.get("actor_id")
+            and is_int(attempted_lock_epoch)
+            and attempted_lock_epoch != active_takeover.get("lock_epoch")
+        )
+        if (
+            active_takeover is None
+            or actor is None
+            or actor.get("type") != "agent"
+            or operation_snapshot is None
+            or operation_snapshot.get("last_event_hash")
+            != operation.get("headers", {}).get("Jarvis-Previous-Event-Hash")
+            or not stale_epoch
+        ):
+            raise FixtureError(
+                f"{rel(path)}: stale_takeover_epoch fixture MUST show AgentWorker "
+                "continuing during active Takeover"
+            )
+
+    elif expected_error_id == "invalid_evidence_export_state":
+        error_field = fixture.get("expected_error_field")
+        if not isinstance(error_field, str) or not error_field.endswith(".status"):
+            raise FixtureError(
+                f"{rel(path)}: invalid_evidence_export_state fixture MUST target status"
+            )
+        target_ref = error_field.removesuffix(".status")
+        work_session = resolved_state_ref(path, fixture, target_ref)
+        if (
+            not isinstance(work_session, dict)
+            or work_session.get("id") != operation.get("work_session_id")
+            or work_session.get("status") in TERMINAL_WORK_SESSION_STATES
+        ):
+            raise FixtureError(
+                f"{rel(path)}: invalid_evidence_export_state fixture MUST use non-terminal state"
+            )
+
+    elif expected_error_id == "sealed_work_session_mutation":
+        operation_snapshot = work_session_snapshot_for_operation(records, operation, body)
+        if (
+            operation_snapshot is None
+            or operation_snapshot.get("status") not in TERMINAL_WORK_SESSION_STATES
+            or operation.get("method") == "GET"
+            or not isinstance(body, dict)
+            or body.get("work_session_id") != operation_snapshot.get("id")
+        ):
+            raise FixtureError(
+                f"{rel(path)}: sealed_work_session_mutation fixture MUST mutate sealed WorkSession"
+            )
+
+    elif expected_error_id == "sealed_evidence_mutation":
+        if not isinstance(body, dict) or body.get("type") != "evidence_manifest.mutated":
+            raise FixtureError(
+                f"{rel(path)}: sealed_evidence_mutation fixture MUST submit evidence mutation event"
+            )
+        if not all_records(records, "evidence_manifests"):
+            raise FixtureError(
+                f"{rel(path)}: sealed_evidence_mutation fixture MUST include EvidenceManifest"
+            )
+        evidence_manifest = next(iter(all_records(records, "evidence_manifests")), {})
+        if evidence_manifest.get("work_session_id") != body.get("work_session_id"):
+            raise FixtureError(
+                f"{rel(path)}: sealed_evidence_mutation fixture MUST target sealed EvidenceManifest"
+            )
+
+    elif expected_error_id == "silent_memory_mutation":
+        if not isinstance(body, dict):
+            raise FixtureError(
+                f"{rel(path)}: silent_memory_mutation fixture MUST submit MemoryProposal"
+            )
+        if body.get("review_required") is not False or body.get("status") != "accepted":
+            raise FixtureError(
+                f"{rel(path)}: silent_memory_mutation fixture MUST silently accept memory"
+            )
+
+    elif expected_error_id == "silent_skill_activation":
+        if not isinstance(body, dict):
+            raise FixtureError(
+                f"{rel(path)}: silent_skill_activation fixture MUST submit SkillProposal"
+            )
+        if body.get("status") != "active" or body.get("review_refs"):
+            raise FixtureError(
+                f"{rel(path)}: silent_skill_activation fixture MUST activate without review"
+            )
+
+    elif expected_error_id == "outcome_report_without_learning_record":
+        if not isinstance(body, dict):
+            raise FixtureError(
+                f"{rel(path)}: outcome_report_without_learning_record fixture MUST submit OutcomeReport"
+            )
+        if body.get("learning_record_refs"):
+            raise FixtureError(
+                f"{rel(path)}: outcome_report_without_learning_record fixture MUST omit learning refs"
+            )
+
+    elif expected_error_id == "unauthorized_actor":
+        if not isinstance(body, dict):
+            raise FixtureError(
+                f"{rel(path)}: unauthorized_actor fixture MUST submit protocol body"
+            )
+        actor_id = operation.get("actor_id")
+        actor = actor_by_id(records, actor_id)
+        worker = worker_for_actor(records, actor)
+        grants = worker_grants(worker)
+        if actor is None:
+            raise FixtureError(
+                f"{rel(path)}: unauthorized_actor fixture MUST use represented Actor"
+            )
+        if operation.get("operation_id") == "createWorkSession":
+            if (
+                actor_id == body.get("created_by_actor_id")
+                and "policy:own" in grants
+            ):
+                raise FixtureError(
+                    f"{rel(path)}: unauthorized_actor fixture MUST use Actor outside authority"
+                )
+        else:
+            required_grants_by_operation = {
+                "recordReview": "review:approve",
+                "startTakeover": "takeover:start",
+                "appendJarvisEvent": "action:execute_after_policy",
+            }
+            required_grant = required_grants_by_operation.get(operation.get("operation_id"))
+            if required_grant is not None and required_grant in grants:
+                raise FixtureError(
+                    f"{rel(path)}: unauthorized_actor fixture MUST use Actor outside authority"
+                )
+
+
+def validate_assertion_coverage(fixtures: list[dict[str, Any]]) -> None:
+    covered = {
+        assertion.get("class")
+        for fixture in fixtures
+        for assertion in fixture.get("assertions", [])
+        if isinstance(assertion, dict)
+    }
+    missing = sorted(GLOBAL_REQUIRED_ASSERTION_CLASSES - covered)
+    if missing:
+        raise FixtureError(
+            "docs/conformance/fixtures: missing assertion class coverage: "
+            + ", ".join(missing)
+        )
+
+
 def represented_hash_set(fixture: dict[str, Any]) -> set[str]:
     hashes = {PROTOCOL_GENESIS_HASH}
     for event in fixture.get("records", {}).get("jarvis_events", {}).values():
@@ -917,7 +1624,7 @@ def validate_fixture(
     openapi: dict[str, Any],
     operations: dict[str, dict[str, Any]],
     protocol_error_ids: set[str],
-) -> None:
+) -> dict[str, Any]:
     fixture = load_json(path)
     validate_fixture_envelope(path, fixture, expected_kind)
 
@@ -929,6 +1636,8 @@ def validate_fixture(
     validate_host_shape(path, fixture)
     validate_forbidden_export_fields(path, fixture)
     validate_event_chain(path, fixture)
+    validate_golden_path_semantics(path, fixture)
+    validate_invalid_fixture_semantics(path, fixture)
 
     for operation in fixture["operations"]:
         if not isinstance(operation, dict):
@@ -939,6 +1648,7 @@ def validate_fixture(
         if not isinstance(assertion, dict):
             raise FixtureError(f"{rel(path)}: assertion entries MUST be objects")
         validate_assertion(path, fixture, assertion)
+    return fixture
 
 
 def validate_required_fixture_set() -> None:
@@ -968,14 +1678,17 @@ def main() -> int:
         operations = openapi_operations(openapi)
         protocol_error_ids = schema_enum(openapi, "ProtocolErrorId")
 
+        loaded_fixtures: list[dict[str, Any]] = []
         for path, expected_kind in fixture_files():
-            validate_fixture(
+            fixture = validate_fixture(
                 path,
                 expected_kind,
                 openapi,
                 operations,
                 protocol_error_ids,
             )
+            loaded_fixtures.append(fixture)
+        validate_assertion_coverage(loaded_fixtures)
     except FixtureError as exc:
         return fail(str(exc))
 


### PR DESCRIPTION
## Summary
- Adds the Gate 3 v0.1 conformance surface audit artifact.
- Strengthens `check_conformance_fixtures.py` with semantic validation for golden-path object binding, invalid rejection semantics, required assertion-class coverage, stale timestamp proof, explicit stale Takeover epoch proof, sealed mutation checks, and Actor authority fixture checks.
- Replaces week-planning fixture source refs with stable conformance/protocol refs across the fixture set.

## Reviewer-agent coverage
- Validator semantics reviewer: fixed cross-object binding, rejecting-operation binding, stale timestamp, expected status robustness, and attributable Contribution proof.
- Protocol/security reviewer: fixed Actor authority proof, EvidenceManifest target-state binding, explicit stale Takeover epoch proof, and sealed mutation semantics.
- Documentation alignment reviewer: fixed stale audit anchors and public fixture source refs.
- Public acceptance reviewer: confirmed no product/runtime drift after fixes.

## Validation
- `python3 scripts/check_conformance_fixtures.py`
- `python3 scripts/check_protocol_wording.py`
- `python3 scripts/check_markdown_links.py`
- `python3 scripts/check_openapi_contract.py`
- `git diff --check HEAD~1 HEAD`
- `node --check demo/assets/app.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new conformance audit document with coverage status, proof matrix, findings, and evidence summary.

* **Bug Fixes**
  * Strengthened conformance checks to catch more invalid fixture cases and enforce stricter validation for timestamps, approvals, revisions, and rejection behavior.
  * Improved consistency checks across golden-path fixtures for required coverage and reference integrity.

* **Documentation**
  * Updated conformance fixture references to use the latest checklist and protocol documentation.
  * Expanded fixture guidance to include additional required binding and validation expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->