### PR TITLE
[codex] Add v0.1 Gate 4 compatibility examples audit

### DIFF
--- a/docs/conformance/compatibility-mapping.md
+++ b/docs/conformance/compatibility-mapping.md
@@ -21,7 +21,7 @@ provider secrets, session cookies, or private keys.
 
 ## Host Shape Reference
 
-Every Week 3 fixture includes `host_shape_ref`.
+Every compatibility fixture includes `host_shape_ref`.
 
 Allowed v0.1 fixture shape refs:
 
@@ -209,7 +209,7 @@ Contribution, EvidenceManifest, or LearningRecord requirements.
 
 ## Compatibility Assertions
 
-Week 3 fixtures MUST assert:
+Compatibility fixtures MUST assert:
 
 ```txt
 host_shape_ref is present
@@ -281,13 +281,13 @@ unsupported_capability
 
 The fixture uses one primary rejection id per invalid case.
 
-## Done State
+## Compatibility Conditions
 
-Compatibility mapping is complete for v0.1 when:
+Compatibility mapping requires:
 
 - every required native surface has a Jarvis protocol target
 - every unsupported native concept records `limitations` or rejects as
   `unsupported_capability`
 - host-owned execution remains outside portable protocol records
 - fixture `host_shape_ref` values stay host-private-free
-- Week 3 valid and invalid fixtures use this mapping as their source
+- valid and invalid compatibility fixtures use this mapping as their source

--- a/docs/conformance/existing-agent-proof-plan.md
+++ b/docs/conformance/existing-agent-proof-plan.md
@@ -93,7 +93,7 @@ Host-owned runtime details are outside compatibility comparison.
 
 ## Proof Pair
 
-Chunk 6 locks this v0.1 proof pair:
+The compatibility proof locks this v0.1 proof pair:
 
 ```txt
 command_line_host_boundary
@@ -400,9 +400,9 @@ Unsupported native concepts MUST record `limitations` or reject as
 Request, Review, Takeover, Contribution, EvidenceManifest, or LearningRecord
 gates.
 
-## Week 4 Entry Gate
+## Compatible Examples Entry Gate
 
-Week 4 compatible examples MUST start from this proof plan and the Week 3
+Compatible examples MUST start from this proof plan and the conformance
 fixtures.
 
 Compatible examples MUST NOT start from adapter behavior, host runtime behavior,
@@ -426,9 +426,9 @@ forbidden host-private fields
 required rejection gates
 ```
 
-## Done State
+## Compatibility Conditions
 
-Existing-agent compatibility proof is complete for v0.1 when:
+Existing-agent compatibility proof requires:
 
 - two allowed host shapes map the same collaboration loop into equivalent
   Jarvis records

--- a/docs/conformance/fixtures/valid/golden-path.json
+++ b/docs/conformance/fixtures/valid/golden-path.json
@@ -8,6 +8,7 @@
     "docs/conformance/golden-path.md",
     "docs/conformance/compatibility-mapping.md",
     "docs/conformance/checklist.md",
+    "docs/protocol/15-openapi-communication-binding.md",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Worker",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Actor",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/HumanWorker",

--- a/docs/examples/compatible-host-mapping.md
+++ b/docs/examples/compatible-host-mapping.md
@@ -123,6 +123,7 @@ the Actor.
 | local context read | terminal output stays host-owned | local file/process trace stays host-owned | `JarvisEvent` with portable evidence refs only |
 | allowed agent action | allowed command step | allowed local step | `PolicyDecision.result = allow` before accepted event |
 | external source blocked | CLI step pauses | local process branch pauses | `PolicyDecision.result = review_required` and scoped `Request` |
+| connector-backed source result | CLI host owns connector execution | local host owns connector execution | `Review` grants bounded scope and `EvidenceItemRef` records source event refs, artifact ref, content hash, trust label, and limitations |
 | human narrowed approval | CLI response narrows scope | local workspace response narrows scope | `Review.decision = narrow` and bounded `ApprovalScope` |
 | high-risk branch | human pauses CLI branch | human locks local branch | `Takeover` with `lock_epoch` and `reconciliation_refs` |
 | performed work | command transcript summary | local trace summary | `Contribution` with contributor refs |
@@ -248,9 +249,9 @@ EvidenceManifest.export_profile.profile = portable-v0.1
 ```
 
 Evidence item refs point to source JarvisEvents. They do not expose raw
-terminal state, local process state, credentials, raw auth tokens,
-provider secrets, host-only database ids, billing data, private scores, UI
-state, deployment details, private keys, or raw runtime state.
+terminal state, local process state, raw connector responses, credentials, raw
+auth tokens, provider secrets, host-only database ids, billing data, private
+scores, UI state, deployment details, private keys, or raw runtime state.
 
 Learning records preserve the human-agent learning loop:
 
@@ -358,11 +359,10 @@ This example is governed by:
 - [Existing-agent compatibility proof plan](../conformance/existing-agent-proof-plan.md)
 - [Golden-path conformance entry](../conformance/golden-path.md)
 - [Fixture documentation](../conformance/fixtures/README.md)
-- [Week 4 Chunk 2 spec](../planning/week-4/chunk-2-compatible-host-mapping.md)
 
-## Done State
+## Compatibility Conditions
 
-This mapping satisfies Chunk 2 when:
+This mapping is compatible only when:
 
 - both host shapes produce equivalent Jarvis records
 - `host_shape_ref` stays metadata only
@@ -372,6 +372,8 @@ This mapping satisfies Chunk 2 when:
 - Request resolves only through Review or Takeover
 - Takeover resume requires reconciliation refs
 - Contribution remains attributable
+- connector execution stays host-owned and EvidenceManifest records only
+  protocol-visible evidence refs
 - EvidenceManifest excludes forbidden host-private fields
 - LearningRecord, MemoryProposal, and SkillProposal stay governed
 - OutcomeReport remains post-session feedback without sealed-record mutation

--- a/docs/examples/existing-agent-compatibility.md
+++ b/docs/examples/existing-agent-compatibility.md
@@ -165,6 +165,7 @@ portable protocol state.
 | native policy settings | host owns policy UI and storage | `Policy` record |
 | native tool step allowed by policy | host owns tool execution | `PolicyDecision.result = allow` before accepted state |
 | native tool step requiring human judgment | host pauses affected branch | `PolicyDecision.result = review_required` + `Request` |
+| connector-backed source result | host owns connector execution and raw connector response | `Review` grants bounded scope and `EvidenceItemRef` records source event refs, artifact ref, content hash, trust label, and limitations |
 | human narrows action | host owns UI or command surface | `Review.decision = narrow` + `ApprovalScope` |
 | human takes over final submission | host owns direct control surface | `Takeover` with `lock_epoch` and `reconciliation_refs` |
 | native agent output | host owns raw traces and formatting | `Contribution` + evidence refs |
@@ -173,9 +174,9 @@ portable protocol state.
 | future procedure change | host owns skill storage or prompt library | `SkillProposal` |
 | external result | external system owns evaluation source | `OutcomeReport` |
 
-Native memory, traces, prompts, tool logs, and scratchpads never enter portable
-records unless they are converted into permitted evidence refs without
-host-private fields.
+Native memory, traces, prompts, tool logs, connector responses, and scratchpads
+never enter portable records unless they are converted into permitted evidence
+refs without host-private fields.
 
 ## Review Resolution Branch
 
@@ -535,11 +536,10 @@ being rewritten as a Jarvis agent.
 - [Compatible host mapping example](./compatible-host-mapping.md)
 - [Golden-path conformance entry](../conformance/golden-path.md)
 - [Fixture documentation](../conformance/fixtures/README.md)
-- [Week 4 Chunk 3 spec](../planning/week-4/chunk-3-existing-agent-example.md)
 
-## Done State
+## Compatibility Conditions
 
-This example satisfies Chunk 3 when:
+This example is compatible only when:
 
 - the existing native agent remains native
 - Jarvis records collaboration only
@@ -552,6 +552,8 @@ This example satisfies Chunk 3 when:
 - ApprovalScope bounds narrowed authority
 - Takeover resume requires reconciliation refs
 - Contribution remains attributable
+- connector execution stays host-owned and EvidenceManifest records only
+  protocol-visible evidence refs
 - EvidenceManifest excludes forbidden host-private fields
 - LearningRecord, MemoryProposal, and SkillProposal stay governed
 - OutcomeReport remains post-session feedback without sealed-record mutation

--- a/docs/examples/protocol-records.md
+++ b/docs/examples/protocol-records.md
@@ -244,15 +244,20 @@ Conformance gate:
       "ref": "capability:evidence-capture",
       "capability_type": "evidence_capture",
       "required": true
+    },
+    {
+      "ref": "capability:reviewed-connector-source-read",
+      "capability_type": "connector_source_read",
+      "required": false
     }
   ],
   "autonomy_level": "bounded_execute",
   "operating_constraints": [
     "act only inside Policy",
-    "create Request for review-required external source use",
+    "create Request for review-required connector-backed external source use",
     "propose learning without silently mutating memory"
   ],
-  "tool_access_profile": "profile:local-context-only",
+  "tool_access_profile": "profile:local-context-and-reviewed-connector",
   "memory_access_profile": "profile:proposal-only"
 }
 ```
@@ -793,6 +798,9 @@ Conformance gate:
 [EvidenceManifest Gate](../conformance/checklist.md#evidencemanifest-gate)
 
 EvidenceManifest export happens after terminal WorkSession state.
+The approved external source item represents connector-backed evidence. Hosts
+own connector execution and raw connector responses. Jarvis records only source
+event refs, redacted artifact refs, hashes, trust labels, and limitations.
 
 ```json
 {
@@ -824,10 +832,10 @@ EvidenceManifest export happens after terminal WorkSession state.
         "event-approved-source-fetch-001"
       ],
       "captured_by_actor_id": "actor-agent-research",
-      "evidence_type": "approved_external_source_summary",
-      "artifact_ref": "artifact:approved-source-summary",
-      "content_hash": "hash:evidence-approved-source",
-      "trust_label": "human_reviewed_source",
+      "evidence_type": "approved_connector_source_summary",
+      "artifact_ref": "artifact:approved-connector-source-summary",
+      "content_hash": "hash:evidence-approved-connector-source",
+      "trust_label": "human_reviewed_connector_source",
       "redaction_state": "redacted",
       "captured_at": "2026-06-24T09:16:00Z",
       "limitation_refs": [
@@ -978,7 +986,8 @@ Conformance gate:
   "status": "pending_review",
   "created_at": "2026-06-24T09:43:00Z",
   "required_tools": [
-    "capability:local-context-read"
+    "capability:local-context-read",
+    "capability:reviewed-connector-source-read"
   ],
   "source_event_refs": [
     "event-review-external-source-001",
@@ -1068,5 +1077,5 @@ Compatible implementations MUST preserve this order:
 ```
 
 The protocol defines record examples only. Hosts own execution architecture,
-including UI, storage, model provider, tool runner, memory engine, and
-deployment choices.
+including UI, storage, model provider, tool runner, connector implementation,
+memory engine, and deployment choices.

--- a/docs/planning/v0.1-acceptance-review/gate-4-compatibility-examples-audit.md
+++ b/docs/planning/v0.1-acceptance-review/gate-4-compatibility-examples-audit.md
@@ -1,0 +1,175 @@
+# Gate 4 Compatibility Examples Audit
+
+Status: pass.
+
+Review date: 2026-06-30.
+
+Branch: `codex/v0.1-gate-4-compatibility-examples`.
+
+Base commit audited: `fd360db`.
+
+Working-tree audit state: Gate 4 diff on top of `fd360db`.
+
+Decision: Gate 4 passes. Every required proof row passes and no blocker
+remains.
+
+## Scope
+
+Audited sources:
+
+- [../../examples/compatible-host-mapping.md](../../examples/compatible-host-mapping.md)
+- [../../examples/existing-agent-compatibility.md](../../examples/existing-agent-compatibility.md)
+- [../../examples/protocol-records.md](../../examples/protocol-records.md)
+- [../../conformance/compatibility-mapping.md](../../conformance/compatibility-mapping.md)
+- [../../conformance/existing-agent-proof-plan.md](../../conformance/existing-agent-proof-plan.md)
+- [../../conformance/golden-path.md](../../conformance/golden-path.md)
+- [../../conformance/fixtures/README.md](../../conformance/fixtures/README.md)
+
+Out of scope:
+
+```txt
+SDK implementation
+adapter implementation
+wrapper implementation
+host runtime behavior
+host UI behavior
+model orchestration
+tool execution
+storage behavior
+auth behavior
+billing behavior
+scoring behavior
+payment behavior
+deployment behavior
+```
+
+## Source Coverage
+
+| Source group | Covered paths | Gate 4 check | Result |
+| --- | --- | --- | --- |
+| Host compatibility example | `docs/examples/compatible-host-mapping.md` | Two host shapes, equivalent record graph, PolicyDecision, Request, Review, ApprovalScope, Takeover, Contribution, EvidenceManifest, LearningRecord, MemoryProposal, SkillProposal, OutcomeReport | pass |
+| Existing-agent example | `docs/examples/existing-agent-compatibility.md` | Existing native agent keeps native runtime; Jarvis records only portable protocol state | pass |
+| Protocol record example | `docs/examples/protocol-records.md` | Full record order, OpenAPI operation alignment, event chain, connector-backed evidence refs, EvidenceManifest export, governed learning, post-session OutcomeReport | pass |
+| Compatibility conformance source | `docs/conformance/compatibility-mapping.md`, `docs/conformance/existing-agent-proof-plan.md` | Stable mapping rules, host shape metadata boundary, unsupported native concepts, rejection gates, example entry gate | pass |
+| Conformance proof source | `docs/conformance/golden-path.md`, `docs/conformance/fixtures/README.md` | Fixture-backed golden path and invalid rejection proof used by examples | pass |
+| Acceptance audit artifact | `docs/planning/v0.1-acceptance-review/gate-4-compatibility-examples-audit.md` | Gate proof matrix, blocker ledger, command evidence, changed-file coverage | pass |
+
+Every changed file belongs to a coverage row:
+
+| Changed file | Coverage row |
+| --- | --- |
+| `docs/conformance/compatibility-mapping.md` | Compatibility conformance source |
+| `docs/conformance/existing-agent-proof-plan.md` | Compatibility conformance source |
+| `docs/examples/compatible-host-mapping.md` | Host compatibility example |
+| `docs/examples/existing-agent-compatibility.md` | Existing-agent example |
+| `docs/examples/protocol-records.md` | Protocol record example |
+| `docs/planning/v0.1-acceptance-review/gate-4-compatibility-examples-audit.md` | Acceptance audit artifact |
+
+## Required Proof Matrix
+
+| ID | Required proof | Evidence | Result |
+| --- | --- | --- | --- |
+| G4-01 | Compatible host mapping includes at least two host shapes. | `docs/examples/compatible-host-mapping.md`, `docs/conformance/compatibility-mapping.md` | pass |
+| G4-02 | Existing-agent compatibility preserves native execution. | `docs/examples/existing-agent-compatibility.md` | pass |
+| G4-03 | Examples map permissions into Policy, PolicyDecision, Request, Review, ApprovalScope, and Takeover. | `docs/examples/compatible-host-mapping.md`, `docs/examples/existing-agent-compatibility.md`, `docs/examples/protocol-records.md` | pass |
+| G4-04 | Examples map connectors and tools into host-owned execution with protocol-visible evidence refs. | `docs/examples/compatible-host-mapping.md`, `docs/examples/existing-agent-compatibility.md`, `docs/examples/protocol-records.md` | pass |
+| G4-05 | Examples map completed work into Contribution, EvidenceManifest, LearningRecord, MemoryProposal, SkillProposal, and OutcomeReport. | `docs/examples/compatible-host-mapping.md`, `docs/examples/existing-agent-compatibility.md`, `docs/examples/protocol-records.md` | pass |
+| G4-06 | Examples do not define adapters, wrappers, host runtime behavior, host UI behavior, model calls, tool execution, storage, auth, billing, scoring, payment, or deployment. | `docs/examples/compatible-host-mapping.md`, `docs/examples/existing-agent-compatibility.md`, `docs/examples/protocol-records.md` | pass |
+| G4-07 | Compatibility-facing docs use stable protocol and conformance language instead of stale week or chunk references. | `docs/conformance/compatibility-mapping.md`, `docs/conformance/existing-agent-proof-plan.md`, `docs/examples/compatible-host-mapping.md`, `docs/examples/existing-agent-compatibility.md` | pass |
+| G4-08 | Unsupported native concepts map to `limitations` or `unsupported_capability` without weakening protocol gates. | `docs/conformance/compatibility-mapping.md`, `docs/conformance/existing-agent-proof-plan.md`, `docs/examples/existing-agent-compatibility.md` | pass |
+
+## Source Findings
+
+| Finding ID | Blocker ID | Severity | Source | Gate proof affected | Finding | Resolution | Status |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| G4-F1 | G4-B1 | blocker | `docs/conformance/compatibility-mapping.md`, `docs/conformance/existing-agent-proof-plan.md`, `docs/examples/compatible-host-mapping.md`, `docs/examples/existing-agent-compatibility.md` | G4-07 | Compatibility-facing docs carried stale week and chunk wording. Public examples read like old planning artifacts instead of durable protocol examples. | Replaced week and chunk wording with stable compatibility fixture, conformance, and Gate 4 language. Removed planning chunk links from public example conformance links. | resolved |
+| G4-F2 | G4-B2 | blocker | `docs/examples/compatible-host-mapping.md`, `docs/examples/existing-agent-compatibility.md`, `docs/examples/protocol-records.md` | G4-04 | Gate 4 required connector and tool mapping, but the examples only showed tool and native source surfaces. | Added connector-backed source mapping. Hosts own connector execution and raw connector responses. Jarvis records only Review-bounded scope, EvidenceItemRef source event refs, artifact refs, content hashes, trust labels, limitations, and EvidenceManifest refs. | resolved |
+| G4-F3 | G4-B3 | blocker | `docs/conformance/compatibility-mapping.md`, `docs/conformance/existing-agent-proof-plan.md`, `docs/examples/compatible-host-mapping.md`, `docs/examples/existing-agent-compatibility.md` | G4-07 | Public examples and conformance docs used old completion headings and project-planning phrasing instead of protocol conformance language. | Replaced those sections with `Compatibility Conditions` and direct compatibility requirement language. | resolved |
+
+## Blocker List
+
+No blocker remains.
+
+| Blocker ID | Source | Gate proof failed | Resolution evidence | Status |
+| --- | --- | --- | --- | --- |
+| G4-B1 | Compatibility-facing stale planning wording | G4-07 | `docs/conformance/compatibility-mapping.md`, `docs/conformance/existing-agent-proof-plan.md`, `docs/examples/compatible-host-mapping.md`, `docs/examples/existing-agent-compatibility.md` | resolved |
+| G4-B2 | Missing connector example proof | G4-04 | `docs/examples/compatible-host-mapping.md`, `docs/examples/existing-agent-compatibility.md`, `docs/examples/protocol-records.md` | resolved |
+| G4-B3 | Completion phrasing in public compatibility docs | G4-07 | `docs/conformance/compatibility-mapping.md`, `docs/conformance/existing-agent-proof-plan.md`, `docs/examples/compatible-host-mapping.md`, `docs/examples/existing-agent-compatibility.md` | resolved |
+
+## Reviewer Evidence
+
+| Reviewer | Focus | Initial finding | Resolution | Final status |
+| --- | --- | --- | --- | --- |
+| Plato | protocol boundary drift | no blocker | no change required | no findings |
+| Hubble | conformance proof and audit evidence | missing connector proof; stale diff-stat evidence | added connector-backed evidence mapping and refreshed audit evidence | no findings |
+| Planck | existing-agent and SDK/runtime boundary | no blocker | no change required | no findings |
+| Sagan | public protocol wording | planning-style completion wording; missing connector proof | replaced completion wording with compatibility conditions and added connector-backed evidence mapping | no findings |
+
+## Command Evidence
+
+Commands run after Gate 4 fixes:
+
+| Command | Exit status | Output summary |
+| --- | --- | --- |
+| `python3 scripts/check_conformance_fixtures.py` | 0 | `conformance fixtures ok` |
+| `python3 scripts/check_openapi_contract.py` | 0 | `openapi contract ok` |
+| `python3 scripts/check_markdown_links.py` | 0 | `markdown links ok` |
+| `python3 scripts/check_protocol_wording.py` | 0 | `protocol wording ok` |
+| `git diff --check` | 0 | no output |
+| `node --check demo/assets/app.js` | 0 | no output |
+
+Pre-stage working-tree state at audit time:
+
+```txt
+ M docs/conformance/compatibility-mapping.md
+ M docs/conformance/existing-agent-proof-plan.md
+ M docs/examples/compatible-host-mapping.md
+ M docs/examples/existing-agent-compatibility.md
+ M docs/examples/protocol-records.md
+?? docs/planning/v0.1-acceptance-review/gate-4-compatibility-examples-audit.md
+```
+
+Tracked diff stat before staging:
+
+```txt
+ docs/conformance/compatibility-mapping.md        | 10 +++++-----
+ docs/conformance/existing-agent-proof-plan.md    | 10 +++++-----
+ docs/examples/compatible-host-mapping.md         | 14 ++++++++------
+ docs/examples/existing-agent-compatibility.md    | 14 ++++++++------
+ docs/examples/protocol-records.md                | 27 ++++++++++++++++++---------
+ 5 files changed, 44 insertions(+), 31 deletions(-)
+```
+
+Tracked diff name-only before staging:
+
+```txt
+docs/conformance/compatibility-mapping.md
+docs/conformance/existing-agent-proof-plan.md
+docs/examples/compatible-host-mapping.md
+docs/examples/existing-agent-compatibility.md
+docs/examples/protocol-records.md
+```
+
+## Gate 4 Decision
+
+Gate 4 status: pass.
+
+Accepted proof rows: G4-01 through G4-08.
+
+Resolved blockers: G4-B1, G4-B2, G4-B3.
+
+Remaining blockers: none.
+
+Decision rationale:
+
+```txt
+Jarvis v0.1 compatibility examples now prove that different host shapes and an
+existing native agent produce portable Jarvis records without rewriting the
+agent, defining adapters, executing tools, owning connector execution, owning
+UI, owning storage, owning runtime behavior, or moving host implementation into
+the protocol. The examples map policy-governed work, scoped Requests, human
+Review, Takeover, connector-backed evidence refs, attributable Contribution,
+portable EvidenceManifest records, governed LearningRecord records,
+MemoryProposal, SkillProposal, and OutcomeReport into the v0.1 protocol
+contract.
+```

--- a/docs/planning/v0.1-acceptance-review/gate-4-compatibility-examples-audit.md
+++ b/docs/planning/v0.1-acceptance-review/gate-4-compatibility-examples-audit.md
@@ -24,6 +24,8 @@ Audited sources:
 - [../../conformance/existing-agent-proof-plan.md](../../conformance/existing-agent-proof-plan.md)
 - [../../conformance/golden-path.md](../../conformance/golden-path.md)
 - [../../conformance/fixtures/README.md](../../conformance/fixtures/README.md)
+- [../../conformance/fixtures/valid/golden-path.json](../../conformance/fixtures/valid/golden-path.json)
+- [../../../scripts/check_conformance_fixtures.py](../../../scripts/check_conformance_fixtures.py)
 
 Out of scope:
 
@@ -52,6 +54,7 @@ deployment behavior
 | Protocol record example | `docs/examples/protocol-records.md` | Full record order, OpenAPI operation alignment, event chain, connector-backed evidence refs, EvidenceManifest export, governed learning, post-session OutcomeReport | pass |
 | Compatibility conformance source | `docs/conformance/compatibility-mapping.md`, `docs/conformance/existing-agent-proof-plan.md` | Stable mapping rules, host shape metadata boundary, unsupported native concepts, rejection gates, example entry gate | pass |
 | Conformance proof source | `docs/conformance/golden-path.md`, `docs/conformance/fixtures/README.md` | Fixture-backed golden path and invalid rejection proof used by examples | pass |
+| Post-merge Gate 3 conformance follow-up | `docs/conformance/fixtures/valid/golden-path.json`, `scripts/check_conformance_fixtures.py` | PR 48 CodeRabbit findings: fixture source trace, rejecting-operation error ids, ApprovalScope timestamp guard, stale Takeover epoch strictness, structural-before-semantic validation order | pass |
 | Acceptance audit artifact | `docs/planning/v0.1-acceptance-review/gate-4-compatibility-examples-audit.md` | Gate proof matrix, blocker ledger, command evidence, changed-file coverage | pass |
 
 Every changed file belongs to a coverage row:
@@ -60,10 +63,12 @@ Every changed file belongs to a coverage row:
 | --- | --- |
 | `docs/conformance/compatibility-mapping.md` | Compatibility conformance source |
 | `docs/conformance/existing-agent-proof-plan.md` | Compatibility conformance source |
+| `docs/conformance/fixtures/valid/golden-path.json` | Post-merge Gate 3 conformance follow-up |
 | `docs/examples/compatible-host-mapping.md` | Host compatibility example |
 | `docs/examples/existing-agent-compatibility.md` | Existing-agent example |
 | `docs/examples/protocol-records.md` | Protocol record example |
 | `docs/planning/v0.1-acceptance-review/gate-4-compatibility-examples-audit.md` | Acceptance audit artifact |
+| `scripts/check_conformance_fixtures.py` | Post-merge Gate 3 conformance follow-up |
 
 ## Required Proof Matrix
 
@@ -85,6 +90,7 @@ Every changed file belongs to a coverage row:
 | G4-F1 | G4-B1 | blocker | `docs/conformance/compatibility-mapping.md`, `docs/conformance/existing-agent-proof-plan.md`, `docs/examples/compatible-host-mapping.md`, `docs/examples/existing-agent-compatibility.md` | G4-07 | Compatibility-facing docs carried stale week and chunk wording. Public examples read like old planning artifacts instead of durable protocol examples. | Replaced week and chunk wording with stable compatibility fixture, conformance, and Gate 4 language. Removed planning chunk links from public example conformance links. | resolved |
 | G4-F2 | G4-B2 | blocker | `docs/examples/compatible-host-mapping.md`, `docs/examples/existing-agent-compatibility.md`, `docs/examples/protocol-records.md` | G4-04 | Gate 4 required connector and tool mapping, but the examples only showed tool and native source surfaces. | Added connector-backed source mapping. Hosts own connector execution and raw connector responses. Jarvis records only Review-bounded scope, EvidenceItemRef source event refs, artifact refs, content hashes, trust labels, limitations, and EvidenceManifest refs. | resolved |
 | G4-F3 | G4-B3 | blocker | `docs/conformance/compatibility-mapping.md`, `docs/conformance/existing-agent-proof-plan.md`, `docs/examples/compatible-host-mapping.md`, `docs/examples/existing-agent-compatibility.md` | G4-07 | Public examples and conformance docs used old completion headings and project-planning phrasing instead of protocol conformance language. | Replaced those sections with `Compatibility Conditions` and direct compatibility requirement language. | resolved |
+| G4-F4 | G4-B4 | blocker | `docs/conformance/fixtures/valid/golden-path.json`, `scripts/check_conformance_fixtures.py` | post-merge G3 conformance follow-up | PR 48 CodeRabbit identified validator over-acceptance and stability gaps after Gate 3 merged. Rejecting operations allowed missing fixture error ids, ApprovalScope comparison crashed on missing review timestamp, stale Takeover epoch accepted any different epoch, semantic validators ran before operation/assertion checks, and the golden fixture lacked the OpenAPI binding source ref. | Required fixture-level error ids for every rejecting operation, guarded ApprovalScope timestamps, required attempted Takeover epoch to be nonnegative and strictly older than nonnegative active lock epoch, moved semantic validation after operation/assertion validation, and added `docs/protocol/15-openapi-communication-binding.md` to golden-path `source_contract_refs`. | resolved |
 
 ## Blocker List
 
@@ -95,6 +101,7 @@ No blocker remains.
 | G4-B1 | Compatibility-facing stale planning wording | G4-07 | `docs/conformance/compatibility-mapping.md`, `docs/conformance/existing-agent-proof-plan.md`, `docs/examples/compatible-host-mapping.md`, `docs/examples/existing-agent-compatibility.md` | resolved |
 | G4-B2 | Missing connector example proof | G4-04 | `docs/examples/compatible-host-mapping.md`, `docs/examples/existing-agent-compatibility.md`, `docs/examples/protocol-records.md` | resolved |
 | G4-B3 | Completion phrasing in public compatibility docs | G4-07 | `docs/conformance/compatibility-mapping.md`, `docs/conformance/existing-agent-proof-plan.md`, `docs/examples/compatible-host-mapping.md`, `docs/examples/existing-agent-compatibility.md` | resolved |
+| G4-B4 | PR 48 post-merge conformance validator findings | post-merge G3 conformance follow-up | `docs/conformance/fixtures/valid/golden-path.json`, `scripts/check_conformance_fixtures.py` | resolved |
 
 ## Reviewer Evidence
 
@@ -104,6 +111,8 @@ No blocker remains.
 | Hubble | conformance proof and audit evidence | missing connector proof; stale diff-stat evidence | added connector-backed evidence mapping and refreshed audit evidence | no findings |
 | Planck | existing-agent and SDK/runtime boundary | no blocker | no change required | no findings |
 | Sagan | public protocol wording | planning-style completion wording; missing connector proof | replaced completion wording with compatibility conditions and added connector-backed evidence mapping | no findings |
+| Jason | PR 48 CodeRabbit fix verification | no blocker | no change required | no findings |
+| Russell | conformance validator stability | stale Takeover epoch accepted negative epochs | required nonnegative attempted and active lock epochs before strict stale comparison | no findings |
 
 ## Command Evidence
 
@@ -123,31 +132,39 @@ Pre-stage working-tree state at audit time:
 ```txt
  M docs/conformance/compatibility-mapping.md
  M docs/conformance/existing-agent-proof-plan.md
+ M docs/conformance/fixtures/valid/golden-path.json
  M docs/examples/compatible-host-mapping.md
  M docs/examples/existing-agent-compatibility.md
  M docs/examples/protocol-records.md
+ M scripts/check_conformance_fixtures.py
 ?? docs/planning/v0.1-acceptance-review/gate-4-compatibility-examples-audit.md
 ```
 
-Tracked diff stat before staging:
+Final branch diff stat against `main`:
 
 ```txt
- docs/conformance/compatibility-mapping.md        | 10 +++++-----
- docs/conformance/existing-agent-proof-plan.md    | 10 +++++-----
- docs/examples/compatible-host-mapping.md         | 14 ++++++++------
- docs/examples/existing-agent-compatibility.md    | 14 ++++++++------
- docs/examples/protocol-records.md                | 27 ++++++++++++++++++---------
- 5 files changed, 44 insertions(+), 31 deletions(-)
+ docs/conformance/compatibility-mapping.md          |  10 +-
+ docs/conformance/existing-agent-proof-plan.md      |  10 +-
+ docs/conformance/fixtures/valid/golden-path.json   |   1 +
+ docs/examples/compatible-host-mapping.md           |  14 +-
+ docs/examples/existing-agent-compatibility.md      |  14 +-
+ docs/examples/protocol-records.md                  |  27 ++-
+ .../gate-4-compatibility-examples-audit.md         | 192 +++++++++++++++++++++
+ scripts/check_conformance_fixtures.py              |  27 ++-
+ 8 files changed, 258 insertions(+), 37 deletions(-)
 ```
 
-Tracked diff name-only before staging:
+Final branch diff name-only against `main`:
 
 ```txt
 docs/conformance/compatibility-mapping.md
 docs/conformance/existing-agent-proof-plan.md
+docs/conformance/fixtures/valid/golden-path.json
 docs/examples/compatible-host-mapping.md
 docs/examples/existing-agent-compatibility.md
 docs/examples/protocol-records.md
+docs/planning/v0.1-acceptance-review/gate-4-compatibility-examples-audit.md
+scripts/check_conformance_fixtures.py
 ```
 
 ## Gate 4 Decision

--- a/scripts/check_conformance_fixtures.py
+++ b/scripts/check_conformance_fixtures.py
@@ -832,6 +832,10 @@ def validate_operation(
             raise FixtureError(f"{rel(path)}: {operation_id} requires work_session_id")
 
     if rejecting_operation(operation):
+        if expected_error_id is None:
+            raise FixtureError(
+                f"{rel(path)}: {operation_id} rejecting operation requires expected_error_id"
+            )
         if operation.get("expected_error_id") != expected_error_id:
             raise FixtureError(
                 f"{rel(path)}: {operation_id} expected_error_id must match fixture"
@@ -1088,6 +1092,12 @@ def validate_golden_path_semantics(path: Path, fixture: dict[str, Any]) -> None:
         raise FixtureError(f"{rel(path)}: golden Request MUST resolve by Review")
 
     approval_scope = review.get("approval_scope") if isinstance(review, dict) else None
+    approval_scope_expires_at = (
+        parse_utc_timestamp(approval_scope.get("expires_at"))
+        if isinstance(approval_scope, dict)
+        else None
+    )
+    review_timestamp = timestamp_field(review) if isinstance(review, dict) else None
     if (
         not isinstance(approval_scope, dict)
         or approval_scope.get("request_id") != request.get("id")
@@ -1098,9 +1108,9 @@ def validate_golden_path_semantics(path: Path, fixture: dict[str, Any]) -> None:
         or approval_scope.get("approved_action") != request.get("requested_action")
         or not is_int(approval_scope.get("max_uses"))
         or approval_scope.get("max_uses") <= 0
-        or not parse_utc_timestamp(approval_scope.get("expires_at"))
-        or parse_utc_timestamp(approval_scope.get("expires_at"))
-        <= timestamp_field(review)
+        or approval_scope_expires_at is None
+        or review_timestamp is None
+        or approval_scope_expires_at <= review_timestamp
         or not isinstance(approval_scope.get("normalized_action_hash"), str)
         or not approval_scope["normalized_action_hash"].startswith("hash:")
     ):
@@ -1392,13 +1402,17 @@ def validate_invalid_fixture_semantics(path: Path, fixture: dict[str, Any]) -> N
         )
         operation_snapshot = work_session_snapshot_for_operation(records, operation, body)
         attempted_lock_epoch = operation.get("attempted_takeover_lock_epoch")
+        active_lock_epoch = active_takeover.get("lock_epoch") if active_takeover else None
         stale_epoch = (
             isinstance(body, dict)
             and active_takeover is not None
             and body.get("work_session_id") == active_takeover.get("work_session_id")
             and body.get("actor_id") == operation.get("actor_id")
             and is_int(attempted_lock_epoch)
-            and attempted_lock_epoch != active_takeover.get("lock_epoch")
+            and is_int(active_lock_epoch)
+            and attempted_lock_epoch >= 0
+            and active_lock_epoch >= 0
+            and attempted_lock_epoch < active_lock_epoch
         )
         if (
             active_takeover is None
@@ -1636,8 +1650,6 @@ def validate_fixture(
     validate_host_shape(path, fixture)
     validate_forbidden_export_fields(path, fixture)
     validate_event_chain(path, fixture)
-    validate_golden_path_semantics(path, fixture)
-    validate_invalid_fixture_semantics(path, fixture)
 
     for operation in fixture["operations"]:
         if not isinstance(operation, dict):
@@ -1648,6 +1660,9 @@ def validate_fixture(
         if not isinstance(assertion, dict):
             raise FixtureError(f"{rel(path)}: assertion entries MUST be objects")
         validate_assertion(path, fixture, assertion)
+
+    validate_golden_path_semantics(path, fixture)
+    validate_invalid_fixture_semantics(path, fixture)
     return fixture
 
 


### PR DESCRIPTION
## Summary
- add the Gate 4 compatibility examples audit record
- remove stale week/chunk completion wording from compatibility-facing docs
- add connector-backed source evidence mapping while keeping connector execution host-owned
- record reviewer evidence for boundary, conformance, existing-agent, and wording reviews

## Checks
- python3 scripts/check_conformance_fixtures.py
- python3 scripts/check_openapi_contract.py
- python3 scripts/check_markdown_links.py
- python3 scripts/check_protocol_wording.py
- git diff --check
- node --check demo/assets/app.js