### PR TITLE
Add v0.1 publication discipline gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,6 +235,7 @@ Work on:
 
 - v0.1 acceptance review
 - protocol implementation helper boundary
+- protocol-publication discipline
 - public-readiness gap log
 - additional conformance evidence only when it preserves the protocol boundary
 - next-phase specification after acceptance review

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Jarvis is the compatibility protocol for any HumanWorker, AgentWorker, host, or
 external system that needs to participate in governed human-agent collaboration
 and shared learning.
 
+## Status
+
+v0.1 acceptance review is active.
+Jarvis v0.1 is not accepted, released, or tagged until the acceptance decision
+records every required gate as passed.
+
 ## Interactive Simulation
 
 The simulation is non-normative public explanation. It is not protocol proof

--- a/docs/openapi/jarvis-openapi.yaml
+++ b/docs/openapi/jarvis-openapi.yaml
@@ -2972,7 +2972,6 @@ components:
         trace_id: trace:protocol-error-001
 x-jarvis-protocol:
   version: v0.1
-  openapi_artifact_version: 0.1.0
   layer: OpenAPI 3.1 communication binding
   source_of_truth:
     - docs/protocol/14-protocol-lock.md

--- a/docs/openapi/jarvis-openapi.yaml
+++ b/docs/openapi/jarvis-openapi.yaml
@@ -2972,6 +2972,7 @@ components:
         trace_id: trace:protocol-error-001
 x-jarvis-protocol:
   version: v0.1
+  openapi_artifact_version: 0.1.0
   layer: OpenAPI 3.1 communication binding
   source_of_truth:
     - docs/protocol/14-protocol-lock.md

--- a/docs/planning/12-30-day-roadmap.md
+++ b/docs/planning/12-30-day-roadmap.md
@@ -249,11 +249,17 @@ The 30-day proof now enters
 [v0.1 acceptance review](./v0.1-acceptance-review/README.md).
 
 Acceptance review audits the full protocol contract, OpenAPI binding,
-conformance surface, public examples, README, and non-normative simulation
-boundary before v0.1 is called Protocol Alpha.
+conformance surface, public examples, README, non-normative simulation
+boundary, and protocol-publication discipline before v0.1 is called Protocol
+Alpha.
 
 The acceptance gates are defined in
 [acceptance-spec.md](./v0.1-acceptance-review/acceptance-spec.md).
+
+The protocol-publication discipline review is recorded in
+[protocol-publication-discipline.md](./v0.1-acceptance-review/protocol-publication-discipline.md).
+It strengthens release, versioning, conformance-claim, extension, and
+governance-gap discipline without changing Jarvis protocol semantics.
 
 ## First 72 Hours
 

--- a/docs/planning/ROADMAP.md
+++ b/docs/planning/ROADMAP.md
@@ -3,8 +3,8 @@
 Jarvis is the open-source human-agent collaboration and learning-loop
 compatibility protocol.
 
-The roadmap turns the protocol into a stable OpenAPI 3.1 contract,
-conformance tests, examples, and documentation. It does not create an execution
+The roadmap turns the protocol into a locked OpenAPI 3.1 contract, conformance
+tests, examples, and documentation. It does not create an execution
 stack.
 
 For the immediate execution plan, see
@@ -30,6 +30,10 @@ adapters, runtimes, wrappers, host behavior, or integration code.
 
 Week 4 completed compatible examples, public README tightening, published
 conformance checklist, protocol record examples, and public story.
+
+The v0.1 acceptance review now includes protocol-publication discipline:
+version consistency, precise conformance-claim language, release-readiness gap
+logging, extension boundary checks, and governance-gap classification.
 
 ## Roadmap Contract
 
@@ -92,7 +96,7 @@ adapters.
 
 ```txt
 v0.1 Protocol Alpha
-  stable vocabulary, OpenAPI 3.1 contract, event envelope, and golden-path
+  locked vocabulary, OpenAPI 3.1 contract, event envelope, and golden-path
   conformance
 
 v0.2 Evidence And Learning Beta
@@ -152,6 +156,7 @@ MemoryProposal and SkillProposal remain governed
 - non-normative public simulation boundary
 - compatible implementation guide
 - protocol implementation helper boundary
+- protocol-publication discipline gate
 
 ### v0.1 Excludes
 
@@ -364,6 +369,8 @@ v0.1 is accepted when:
 - public docs describe Jarvis as protocol only
 - live simulation, when present, describes Jarvis as protocol only
 - any Jarvis SDK surface is limited to protocol implementation helpers
+- public version labels, conformance claims, release-readiness gaps, and
+  extension rules pass protocol-publication discipline review
 
 ## v0.2 Evidence And Learning Beta
 
@@ -482,3 +489,4 @@ and example record mappers.
 6. Keep adapter code, wrappers, host behavior, and integration code outside
    Jarvis.
 7. Keep every Jarvis SDK discussion limited to protocol implementation helpers.
+8. Complete protocol-publication discipline review before v0.1 acceptance.

--- a/docs/planning/v0.1-acceptance-review/README.md
+++ b/docs/planning/v0.1-acceptance-review/README.md
@@ -56,6 +56,7 @@ The acceptance review starts from:
 - [../../examples/compatible-host-mapping.md](../../examples/compatible-host-mapping.md)
 - [../../examples/existing-agent-compatibility.md](../../examples/existing-agent-compatibility.md)
 - [../../examples/protocol-records.md](../../examples/protocol-records.md)
+- [protocol-publication-discipline.md](./protocol-publication-discipline.md)
 - [../../../README.md](../../../README.md)
 - [../../../demo/index.html](../../../demo/index.html)
 - [../../../demo/assets/app.js](../../../demo/assets/app.js)
@@ -68,7 +69,7 @@ runtime, framework, host UI, or host implementation.
 
 ## Review Units
 
-The v0.1 acceptance review has eight units:
+The v0.1 acceptance review has nine units:
 
 ```txt
 1. protocol contract audit
@@ -78,11 +79,18 @@ The v0.1 acceptance review has eight units:
 5. README and non-normative simulation boundary audit
 6. boundary and wording audit
 7. local validation audit
-8. acceptance decision record
+8. protocol publication discipline audit
+9. acceptance decision record
 ```
 
 Each unit records findings, blockers, decisions, and required fixes before the
 acceptance decision.
+
+Protocol publication discipline uses
+[protocol-publication-discipline.md](./protocol-publication-discipline.md).
+The review adopts release, versioning, conformance-claim, extension, and
+governance-gap discipline only. It does not change Jarvis semantics or add host
+implementation scope.
 
 ## Acceptance Rule
 

--- a/docs/planning/v0.1-acceptance-review/acceptance-spec.md
+++ b/docs/planning/v0.1-acceptance-review/acceptance-spec.md
@@ -201,6 +201,49 @@ Demo syntax failure creates a public-readiness finding. It does not fail the
 protocol acceptance gate unless the demo misrepresents Jarvis as a product,
 runtime, framework, host UI, or host implementation.
 
+## Gate 8: Protocol Publication Discipline
+
+Protocol publication discipline passes when:
+
+```txt
+public protocol materials use consistent v0.1 status language, precise
+conformance claim language, visible release-readiness gaps, and consistent
+version labels.
+```
+
+Required proof:
+
+- README, OpenAPI metadata, architecture brief, conformance docs, examples,
+  roadmap, demo text, and acceptance decision record use consistent v0.1
+  status language
+- OpenAPI `info.version`, OpenAPI `x-jarvis-protocol.version`, fixture
+  `protocol_version`, README status, and acceptance decision status do not
+  conflict
+- OpenAPI `info.version: 0.1.0` identifies the OpenAPI artifact version, and
+  OpenAPI `x-jarvis-protocol.version: v0.1` identifies the protocol line
+- public conformance wording uses exact proof language instead of vague
+  compliance language
+- compatibility claims include protocol version, conformance surface, fixture
+  or checklist basis, and verification date
+- public docs reject `certified`, `official host`, and unverified
+  compatibility claims unless a future governance process defines them
+- extension text preserves namespaced extensions and rejects core-field
+  override
+- prose docs, OpenAPI, examples, fixtures, and validator checks agree on the
+  same contract
+- release-readiness gap log classifies changelog, contributing guide, security
+  policy, citation metadata, license clarity, issue templates, PR template, CI
+  workflows, governance process, website, release notes, known-limit coverage,
+  and conformance report format
+- v0.1 public docs do not claim v1.0 stability, long-term support, foundation
+  governance, production adoption, or certification
+- research lessons stay scoped to publication discipline and do not add host
+  implementation to Jarvis
+
+The gate fails when public materials contain version drift, vague conformance
+claims, unverified certification language, missing release-readiness
+classification, or non-Jarvis copying that changes Jarvis semantics.
+
 ## Decision Rule
 
 The v0.1 acceptance decision MUST record:

--- a/docs/planning/v0.1-acceptance-review/protocol-publication-discipline.md
+++ b/docs/planning/v0.1-acceptance-review/protocol-publication-discipline.md
@@ -17,14 +17,14 @@ routing, tool execution, runtime behavior, or product workflow.
 Jarvis v0.1 acceptance includes these protocol-publication rules:
 
 ```txt
-public version labels stay consistent
-conformance claims use a precise claim format
-conformance proof names the tested suite or fixture set
-extension rules preserve the rigid core
-public release notes record known limits
-security disclosure and governance gaps stay visible
-machine-readable contracts and prose contracts cross-check each other
-public examples stay separate from protocol claims
+public version labels MUST stay consistent
+conformance claims MUST use a precise claim format
+conformance proof MUST name the tested suite or fixture set
+extension rules MUST preserve the rigid core
+public release notes MUST record known limits
+security disclosure and governance gaps MUST stay visible
+machine-readable contracts and prose contracts MUST cross-check each other
+public examples MUST stay separate from protocol claims
 ```
 
 These rules strengthen Jarvis as a protocol.

--- a/docs/planning/v0.1-acceptance-review/protocol-publication-discipline.md
+++ b/docs/planning/v0.1-acceptance-review/protocol-publication-discipline.md
@@ -1,0 +1,234 @@
+# Protocol Publication Discipline
+
+Status: active input.
+
+Review date: 2026-06-30.
+
+This review records Jarvis-owned publication rules for v0.1 acceptance.
+Research inputs stay outside this repository.
+Jarvis records only the discipline it adopts.
+
+This review does not change Jarvis semantics.
+This review does not add host execution, adapters, UI, auth, storage, model
+routing, tool execution, runtime behavior, or product workflow.
+
+## Adopted Publication Rules
+
+Jarvis v0.1 acceptance includes these protocol-publication rules:
+
+```txt
+public version labels stay consistent
+conformance claims use a precise claim format
+conformance proof names the tested suite or fixture set
+extension rules preserve the rigid core
+public release notes record known limits
+security disclosure and governance gaps stay visible
+machine-readable contracts and prose contracts cross-check each other
+public examples stay separate from protocol claims
+```
+
+These rules strengthen Jarvis as a protocol.
+They do not add host-owned implementation scope to Jarvis.
+
+## v0.1 Acceptance Additions
+
+Jarvis v0.1 acceptance includes a protocol-publication discipline gate.
+
+The gate checks:
+
+- `README.md`, `docs/openapi/jarvis-openapi.yaml`, architecture brief,
+  conformance docs, examples, demo text, and roadmap use consistent v0.1
+  status language.
+- Public conformance wording names exact proof instead of vague compliance.
+- Compatibility claims include protocol version, conformance surface, fixture
+  or checklist basis, and verification date.
+- Public docs reject `certified` language unless a governance process creates
+  certification later.
+- Extension and capability text preserves namespaced extensions and rejects
+  core-field override.
+- Release-readiness notes record missing or deferred governance, changelog,
+  citation, security, license, issue-template, PR-template, CI, release-note,
+  known-limit, website, and conformance-report work.
+- Jarvis v0.1 does not claim long-term stable support language before v1.0.
+- The non-normative simulation remains public explanation, not conformance
+  proof.
+
+## Adopted Shape
+
+Jarvis keeps the current v0.1 protocol contract and adds publication discipline
+around it.
+
+```txt
+Protocol contract
+  -> OpenAPI 3.1 binding
+  -> conformance fixtures
+  -> compatibility examples
+  -> public README and simulation boundary
+  -> protocol-publication discipline
+  -> acceptance decision
+```
+
+## Deferred From v0.1
+
+These repo-shape items remain outside v0.1 acceptance unless they block public
+correctness:
+
+- installable SDK packages
+- adapter packages
+- bridge packages
+- public adopter registry
+- full governance process
+- trademark process
+- foundation transition process
+- paid or third-party certification
+- long-term support commitments
+- multi-year standards-body roadmap
+- production reference implementation packages
+
+The acceptance decision records these as next-phase work when they remain
+missing.
+Their absence does not block v0.1 Protocol Alpha unless public docs claim they
+exist.
+
+## Conformance Claims
+
+Jarvis compatibility claims MUST use a precise format:
+
+```txt
+Implementation <name> supports Jarvis <protocol-version> compatibility,
+verified against <conformance-surface> on <date>.
+```
+
+Example:
+
+```txt
+Implementation ExampleHost supports Jarvis v0.1 compatibility, verified
+against the v0.1 golden-path and failure-mode fixtures on 2026-07-03.
+```
+
+Jarvis rejects vague claims:
+
+```txt
+Jarvis compliant
+Jarvis certified
+fully Jarvis ready
+official Jarvis host
+```
+
+## Version Consistency
+
+Jarvis v0.1 acceptance MUST verify public version consistency.
+
+The check covers:
+
+```txt
+README status
+OpenAPI info.version
+OpenAPI x-jarvis-protocol.version
+architecture brief status
+conformance fixture protocol_version
+roadmap status
+demo text
+acceptance decision record
+release notes when present
+citation metadata when present
+```
+
+OpenAPI `info.version: 0.1.0` identifies the OpenAPI artifact version.
+OpenAPI `x-jarvis-protocol.version: v0.1` identifies the Jarvis protocol line.
+Those labels do not conflict when each public document preserves that mapping.
+
+Version drift is an acceptance blocker.
+
+## Rigid Core And Extensions
+
+Jarvis keeps a rigid v0.1 core.
+
+Extensions use namespaced extension fields.
+Extensions MUST NOT override core object fields, core lifecycle meanings,
+required headers, event-chain rules, conformance gates, or forbidden export
+fields.
+
+The protocol rejects extension core-field override through
+`extension_core_field_override`.
+
+## Prose And Machine Contract Cross-Check
+
+Jarvis treats prose docs and OpenAPI as one contract with two views.
+
+The acceptance review checks that:
+
+```txt
+prose object fields match OpenAPI schema fields
+prose operation rules match OpenAPI path requirements
+prose security rules match OpenAPI security requirements
+prose error ids match OpenAPI error examples
+fixtures exercise the same contract
+```
+
+When prose and OpenAPI conflict, acceptance fails until the contradiction is
+resolved.
+
+## Release-Readiness Gap Log
+
+Jarvis v0.1 acceptance MUST record a release-readiness gap log.
+
+The gap log covers:
+
+```txt
+CHANGELOG status
+CONTRIBUTING status
+SECURITY policy status
+CITATION metadata status
+license clarity
+issue template status
+PR template status
+CI workflow status
+governance process status
+public website status
+release notes status
+known-limit coverage
+conformance report format status
+```
+
+Missing publication infrastructure becomes either:
+
+```txt
+acceptance blocker
+next-phase deferral
+not applicable for v0.1
+```
+
+Each classification MUST record a reason.
+
+## Not Adopted Into Jarvis v0.1
+
+Jarvis does not adopt non-Jarvis:
+
+- domain vocabulary
+- producer/subscriber model
+- transport-neutral event stream model
+- conformance level names
+- subscription handshake
+- confirmation reply tokens
+- reference producer packages
+- reference subscriber packages
+- bridge packages
+- domain extension examples
+
+Jarvis has its own primitive:
+
+```txt
+HumanWorker + AgentWorker + WorkSession + Policy + Request + Review +
+Contribution + EvidenceManifest + LearningRecord
+```
+
+Research inputs inform publication discipline only.
+Jarvis remains the human-agent collaboration and learning-loop protocol.
+
+## Acceptance Impact
+
+This review creates Gate 8 in
+[acceptance-spec.md](./acceptance-spec.md): Protocol Publication Discipline.
+
+Gate 8 must pass before v0.1 is accepted as Protocol Alpha.

--- a/docs/reviews/acceptance-criteria.md
+++ b/docs/reviews/acceptance-criteria.md
@@ -168,6 +168,20 @@ Expected result:
   `missing_expected_work_session_revision`, `missing_previous_event_hash`,
   `invalid_extension_namespace`, and `extension_core_field_override`
 - protocol error responses exclude forbidden host-private fields
+- public version labels agree across README, OpenAPI metadata, conformance
+  fixtures, architecture brief, roadmap, demo text, and acceptance decision
+- OpenAPI `info.version: 0.1.0` is treated as the OpenAPI artifact version, and
+  OpenAPI `x-jarvis-protocol.version: v0.1` is treated as the protocol line
+- public conformance claims include protocol version, conformance surface,
+  fixture or checklist basis, and verification date
+- public docs reject vague compliance, unverified certification, and official
+  host claims before governance defines those claims
+- release-readiness gaps classify changelog, contributing guide, security
+  policy, citation metadata, license clarity, issue templates, PR template, CI
+  workflows, governance process, website, release notes, known-limit coverage,
+  and conformance report format
+- v0.1 docs do not claim v1.0 stability, long-term support, foundation
+  governance, production adoption, or certification
 
 ## Conformance Acceptance
 


### PR DESCRIPTION
## Summary
- add Gate 8 for protocol-publication discipline in v0.1 acceptance review
- add a Jarvis-owned publication-discipline review covering version consistency, precise conformance claims, release-readiness gaps, extension boundaries, and prose/OpenAPI cross-checks
- add explicit README v0.1 acceptance-review status and OpenAPI artifact/protocol version mapping

## Validation
- python3 scripts/check_conformance_fixtures.py
- python3 scripts/check_openapi_contract.py
- python3 scripts/check_markdown_links.py
- python3 scripts/check_protocol_wording.py
- git diff --check
- node --check demo/assets/app.js

## Reviewer Agents
- Franklin: no blockers
- James: no blockers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clearer v0.1 acceptance and publication-review flow, including new checks for version consistency, conformance wording, and release-readiness gaps.
  * Introduced a dedicated publication-discipline review with pass/fail criteria for public protocol materials.

* **Documentation**
  * Updated roadmap and acceptance documents to reflect the new review gate and expanded review scope.
  * Clarified project status, protocol version labeling, and release expectations in the overview and API metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->