### PR TITLE
Add v0.1 Gate 5 public demo audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,16 @@ Contributions, governed shared Learning, and portable Evidence.
 
 ## Plain English Definition
 
-Jarvis is how humans and agents work together properly.
+Jarvis defines protocol rules for humans and agents to work together under
+policy, review, evidence, and shared learning.
 
 The human does not just prompt. The agent does not just answer. They both
 participate in the work.
 
 The human gives direction, judgment, context, correction, approval, and
-accountability. The agent plans, executes, researches, drafts, uses tools,
-collects evidence, and proposes improvements.
+accountability. The AgentWorker contributes planning, research, drafting,
+evidence collection, and improvement proposals through host-owned execution
+and tool use.
 
 Jarvis defines the rules of that collaboration. Hosts and external systems
 implement those rules.

--- a/demo/assets/app.js
+++ b/demo/assets/app.js
@@ -10,7 +10,7 @@ const steps = [
     summary:
       "The WorkSession-scoped mutation enters through the OpenAPI binding with protocol version, actor id, idempotency key, timestamp, expected revision, and previous event hash.",
     events: [
-      "Authorization: Bearer host-auth-ref",
+      "Authorization: HostAuth fixture",
       "Jarvis-Protocol-Version: v0.1",
       "Jarvis-Actor-Id: actor-human-reviewer",
       "Jarvis-Idempotency-Key: idem-work-session-create-001",
@@ -41,7 +41,7 @@ const steps = [
     summary:
       "Jarvis verifies Actor authority, checks the WorkSession revision, and links the previous event hash before accepting protocol state.",
     events: [
-      "Actor authority permits work_session.create.",
+      "Actor authority permits createWorkSession.",
       "Expected revision matches current revision.",
       "Previous event hash matches the chain head."
     ],
@@ -282,7 +282,7 @@ const steps = [
     activeNodes: ["kernel", "host"],
     activeBeams: ["beam-host"],
     summary:
-      "EvidenceManifest exports portable proof after terminal WorkSession state without host-private fields.",
+      "EvidenceManifest exports a portable evidence record after terminal WorkSession state without host-private fields.",
     events: [
       "WorkSession status: completed.",
       "EvidenceManifest includes event chain root.",
@@ -309,14 +309,14 @@ const steps = [
     activeNodes: ["human", "agent", "kernel"],
     activeBeams: ["beam-human", "beam-agent"],
     summary:
-      "OutcomeReport enters post-session feedback without rewriting the sealed WorkSession or EvidenceManifest. A new LearningRecord carries the feedback forward.",
+      "OutcomeReport enters post-session feedback without rewriting the sealed WorkSession or EvidenceManifest. A governed LearningRecord carries the feedback forward.",
     events: [
       "OutcomeReport arrives after WorkSession completion.",
       "OutcomeReport references learning-record-outcome-001.",
       "Sealed WorkSession and EvidenceManifest remain unchanged."
     ],
     memory: [
-      "Post-session feedback becomes governed learning.",
+      "Post-session feedback is linked to governed learning.",
       "Next WorkSession inherits accepted learning only.",
       "Human-agent pair improves without changing history."
     ],

--- a/demo/assets/styles.css
+++ b/demo/assets/styles.css
@@ -195,6 +195,16 @@ button {
   overflow-wrap: break-word;
 }
 
+.demo-boundary {
+  max-width: 760px;
+  margin: 18px 0 0;
+  color: var(--bone);
+  font-size: 0.88rem;
+  font-weight: 800;
+  line-height: 1.6;
+  overflow-wrap: break-word;
+}
+
 .hero-actions {
   display: flex;
   flex-wrap: wrap;

--- a/demo/index.html
+++ b/demo/index.html
@@ -6,7 +6,7 @@
     <title>Jarvis</title>
     <meta
       name="description"
-      content="An interactive simulation of Jarvis as the human-agent collaboration and learning-loop protocol."
+      content="A non-normative public walkthrough of Jarvis as the human-agent collaboration and learning-loop protocol."
     />
     <link rel="icon" href="./assets/favicon.svg?v=protocol7" type="image/svg+xml" />
     <link rel="stylesheet" href="./assets/styles.css?v=protocol7" />
@@ -14,7 +14,7 @@
   <body>
     <canvas id="signalCanvas" aria-hidden="true"></canvas>
     <main class="shell">
-      <header class="topbar" aria-label="Jarvis simulation header">
+      <header class="topbar" aria-label="Jarvis walkthrough header">
         <a class="brand" href="./">
           <span class="brand-mark">J</span>
           <span>
@@ -23,7 +23,7 @@
           </span>
         </a>
         <div class="topbar-meta">
-          <span>WorkSession WS-1042</span>
+          <span>Example WorkSession WS-1042</span>
           <span>OpenAPI 3.1 binding</span>
           <span id="topbarStatus">created</span>
         </div>
@@ -40,9 +40,13 @@
             AG-UI connects agents to UI. Jarvis records how HumanWorkers and
             AgentWorkers collaborate, produce evidence, and learn.
           </p>
-          <div class="hero-actions" aria-label="Simulation controls">
+          <p class="demo-boundary">
+            Non-normative walkthrough. Not protocol proof. Not a host UI
+            implementation.
+          </p>
+          <div class="hero-actions" aria-label="Walkthrough controls">
             <button class="command primary" id="startBtn" type="button">
-              Launch WorkSession
+              Start Walkthrough
             </button>
             <button class="command" id="prevBtn" type="button">Back</button>
             <button class="command" id="nextBtn" type="button">Advance</button>
@@ -58,7 +62,7 @@
           </div>
         </div>
 
-        <aside class="mission-panel" aria-label="Live mission state">
+        <aside class="mission-panel" aria-label="Walkthrough state">
           <div class="mission-header">
             <span class="pulse"></span>
             <span id="missionState">Ready</span>
@@ -84,13 +88,13 @@
         </aside>
       </section>
 
-      <section class="simulator" aria-label="Jarvis operating simulation">
+      <section class="simulator" aria-label="Jarvis protocol walkthrough">
         <nav class="sequence" aria-label="WorkSession steps">
           <div class="section-label">OpenAPI record path</div>
           <ol id="timeline"></ol>
         </nav>
 
-        <section class="operating-stage" aria-label="Operating surface">
+        <section class="operating-stage" aria-label="Protocol record path">
           <div class="stage-top">
             <div>
               <span class="section-label">Current phase</span>
@@ -109,7 +113,7 @@
             <div class="node agent" data-node="agent">
               <span>AgentWorker</span>
               <strong>autonomous worker</strong>
-              <small>plan, execute, learn</small>
+              <small>plan, research, learn</small>
             </div>
 
             <div class="core" data-node="kernel">
@@ -148,7 +152,7 @@
           </div>
         </section>
 
-        <aside class="right-stack" aria-label="State rails">
+        <aside class="right-stack" aria-label="Record rails">
           <section class="rail policy-rail" aria-labelledby="policyTitle">
               <div class="rail-head">
               <span class="section-label">Mutation gate</span>
@@ -162,7 +166,7 @@
 
           <section class="rail" aria-labelledby="memoryTitle">
             <div class="rail-head">
-              <span class="section-label">Context plane</span>
+              <span class="section-label">Record context</span>
               <h3 id="memoryTitle">Protocol records</h3>
             </div>
             <ul id="memoryList"></ul>
@@ -170,8 +174,8 @@
 
           <section class="rail" aria-labelledby="evidenceTitle">
             <div class="rail-head">
-              <span class="section-label">Proof plane</span>
-              <h3 id="evidenceTitle">Evidence ledger</h3>
+              <span class="section-label">Evidence export</span>
+              <h3 id="evidenceTitle">EvidenceManifest</h3>
             </div>
             <ul id="evidenceList"></ul>
           </section>
@@ -181,7 +185,7 @@
       <section class="story-strip" aria-label="Jarvis model summary">
         <article>
           <span>01</span>
-          <h3>WorkSession is the surface</h3>
+          <h3>WorkSession is the record</h3>
           <p>
             WorkSession is the durable protocol record for human-agent work:
             goals, events, requests, reviews, contributions, evidence, and

--- a/docs/planning/v0.1-acceptance-review/gate-5-public-readme-simulation-audit.md
+++ b/docs/planning/v0.1-acceptance-review/gate-5-public-readme-simulation-audit.md
@@ -1,0 +1,176 @@
+# Gate 5 Public README And Non-Normative Simulation Audit
+
+Status: pass.
+
+Review date: 2026-06-30.
+
+Branch: `codex/v0.1-gate-5-public-readme-simulation-audit`.
+
+Base commit audited: `3b62951`.
+
+Working-tree audit state: Gate 5 diff on top of `3b62951`.
+
+Decision: Gate 5 passes. Every required proof row passes and no blocker
+remains.
+
+## Scope
+
+Audited sources:
+
+- [../../../README.md](../../../README.md)
+- [../../../demo/index.html](../../../demo/index.html)
+- [../../../demo/assets/app.js](../../../demo/assets/app.js)
+- [../../../demo/assets/styles.css](../../../demo/assets/styles.css)
+- [acceptance-spec.md](./acceptance-spec.md)
+
+Out of scope:
+
+```txt
+SDK implementation
+adapter implementation
+wrapper implementation
+host runtime behavior
+host UI behavior
+model orchestration
+tool execution
+storage behavior
+auth behavior
+billing behavior
+scoring behavior
+payment behavior
+deployment behavior
+```
+
+## Source Coverage
+
+| Source group | Covered paths | Gate 5 check | Result |
+| --- | --- | --- | --- |
+| Public README | `README.md` | Protocol-only definition, MCP/A2A/AG-UI positioning, host-owned responsibilities, compatible implementation proof language | pass |
+| Demo HTML | `demo/index.html` | Visible non-normative boundary, walkthrough labels, no host UI claim, no extra protocol object or operation names | pass |
+| Demo script | `demo/assets/app.js` | Canonical OpenAPI operation naming, host-auth fixture wording, protocol record sequence, no conformance-proof claim | pass |
+| Demo styles | `demo/assets/styles.css` | Presentation only, no protocol rule or host behavior | pass |
+| Acceptance spec | `docs/planning/v0.1-acceptance-review/acceptance-spec.md` | Gate 5 proof rows and failure conditions | pass |
+| Acceptance audit artifact | `docs/planning/v0.1-acceptance-review/gate-5-public-readme-simulation-audit.md` | Gate proof matrix, blocker ledger, command evidence, changed-file coverage | pass |
+
+Every changed file belongs to a coverage row:
+
+| Changed file | Coverage row |
+| --- | --- |
+| `README.md` | Public README |
+| `demo/assets/app.js` | Demo script |
+| `demo/assets/styles.css` | Demo styles |
+| `demo/index.html` | Demo HTML |
+| `docs/planning/v0.1-acceptance-review/gate-5-public-readme-simulation-audit.md` | Acceptance audit artifact |
+
+## Required Proof Matrix
+
+| ID | Required proof | Evidence | Result |
+| --- | --- | --- | --- |
+| G5-01 | README one-line definition matches protocol docs. | `README.md`, `docs/protocol/14-protocol-lock.md`, `docs/protocol/16-positioning-adoption-lock.md` | pass |
+| G5-02 | README positions Jarvis beside MCP, A2A, and AG-UI without replacing them. | `README.md` | pass |
+| G5-03 | README states that hosts own UI, storage, auth, execution, models, tools, memory engines, deployment, monitoring, and workflow. | `README.md` | pass |
+| G5-04 | Simulation is treated as public explanation only. | `README.md`, `demo/index.html` | pass |
+| G5-05 | Simulation remains static public explanation, not host UI implementation. | `README.md`, `demo/index.html`, `demo/assets/app.js`, `demo/assets/styles.css` | pass |
+| G5-06 | Simulation does not define additional protocol objects, operations, or conformance rules. | `demo/index.html`, `demo/assets/app.js`, `docs/openapi/jarvis-openapi.yaml` | pass |
+
+## Source Findings
+
+| Finding ID | Blocker ID | Severity | Source | Gate proof affected | Finding | Resolution | Status |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| G5-F1 | G5-B1 | blocker | `docs/planning/v0.1-acceptance-review/` | G5-04, G5-05, G5-06 | Gate 5 had no dedicated audit artifact. The acceptance review requires a gate-level evidence record before a gate is accepted. | Added this Gate 5 audit artifact with source coverage, proof matrix, blocker ledger, reviewer evidence, command evidence, changed-file coverage, and decision. | resolved |
+| G5-F2 | G5-B2 | blocker | `demo/assets/app.js` | G5-06 | The demo used `work_session.create`, which looked like an added operation name and did not match the OpenAPI `createWorkSession` operation id. | Replaced the phrase with `createWorkSession`. | resolved |
+| G5-F3 | G5-B3 | blocker | `demo/index.html` | G5-04, G5-05 | The public demo page lacked a visible non-normative boundary even though README carried one. A direct page visitor had no page-level boundary separating the walkthrough from protocol proof or host UI. | Added a visible boundary statement: non-normative walkthrough, not protocol proof, not a host UI implementation. | resolved |
+| G5-F4 | G5-B4 | blocker | `demo/index.html`, `demo/assets/app.js` | G5-04, G5-05 | Demo labels used `Launch WorkSession`, `Live mission state`, `operating simulation`, `Operating surface`, `State rails`, `Proof plane`, `Evidence ledger`, and `WorkSession is the surface`, which made the public page read closer to host UI or conformance evidence. | Replaced those labels with walkthrough, record, EvidenceManifest, and protocol-record wording. | resolved |
+| G5-F5 | G5-B5 | blocker | `README.md`, `demo/index.html`, `demo/assets/app.js` | G5-03, G5-05 | Public wording described agent execution and tool use without immediately preserving the host-owned execution boundary. | Tightened README and demo wording so AgentWorker contribution is expressed through protocol records and host-owned execution/tool use remains explicit. | resolved |
+| G5-F6 | G5-B6 | blocker | `demo/assets/app.js` | G5-05 | The demo used `Authorization: Bearer host-auth-ref`, which implied a credential format that Jarvis does not define. | Replaced it with `Authorization: HostAuth fixture`. | resolved |
+| G5-F7 | G5-B7 | blocker | `demo/assets/app.js` | G5-05 | OutcomeReport wording implied post-session feedback directly creates or mutates learning state. | Reworded OutcomeReport as feedback linked to governed LearningRecord state without rewriting sealed WorkSession or EvidenceManifest records. | resolved |
+
+## Blocker List
+
+No blocker remains.
+
+| Blocker ID | Source | Gate proof failed | Resolution evidence | Status |
+| --- | --- | --- | --- | --- |
+| G5-B1 | Missing Gate 5 audit artifact | G5-04, G5-05, G5-06 | `docs/planning/v0.1-acceptance-review/gate-5-public-readme-simulation-audit.md` | resolved |
+| G5-B2 | Noncanonical operation-shaped demo wording | G5-06 | `demo/assets/app.js` | resolved |
+| G5-B3 | Missing visible demo boundary | G5-04, G5-05 | `demo/index.html` | resolved |
+| G5-B4 | Demo labels read like host UI or proof surface | G5-04, G5-05 | `demo/index.html`, `demo/assets/app.js` | resolved |
+| G5-B5 | README and demo execution wording needed sharper host boundary | G5-03, G5-05 | `README.md`, `demo/index.html`, `demo/assets/app.js` | resolved |
+| G5-B6 | Demo auth wording implied a credential format | G5-05 | `demo/assets/app.js` | resolved |
+| G5-B7 | OutcomeReport demo wording implied learning mutation | G5-05 | `demo/assets/app.js` | resolved |
+
+## Reviewer Evidence
+
+| Reviewer | Focus | Initial finding | Resolution | Final status |
+| --- | --- | --- | --- | --- |
+| Chandrasekhar | acceptance artifact and demo proof boundary | missing Gate 5 artifact; demo proof terminology needed explicit review | added Gate 5 artifact and replaced demo proof/ledger labels with EvidenceManifest and evidence-record wording | no findings |
+| Socrates | README/simulation boundary and canonical operation naming | missing Gate 5 artifact; demo used noncanonical `work_session.create`; visible demo boundary missing | added Gate 5 artifact, changed operation text to `createWorkSession`, and added visible demo boundary | no findings |
+| Mencius | public README and protocol-boundary drift | README plain-English section and demo proof terms were clarity risks | tightened README host-owned execution language and replaced demo proof terms | no findings |
+| Boole | demo object accuracy and non-normative boundary | auth fixture implied bearer credential format; `Context plane` sounded like a new layer | changed auth wording to `HostAuth fixture` and changed label to `Record context` | no findings |
+
+## Command Evidence
+
+Commands run after Gate 5 fixes:
+
+| Command | Exit status | Output summary |
+| --- | --- | --- |
+| `python3 scripts/check_conformance_fixtures.py` | 0 | `conformance fixtures ok` |
+| `python3 scripts/check_openapi_contract.py` | 0 | `openapi contract ok` |
+| `python3 scripts/check_markdown_links.py` | 0 | `markdown links ok` |
+| `python3 scripts/check_protocol_wording.py` | 0 | `protocol wording ok` |
+| `git diff --check` | 0 | no output |
+| `node --check demo/assets/app.js` | 0 | no output |
+
+Pre-stage working-tree state at audit time:
+
+```txt
+ M README.md
+ M demo/assets/app.js
+ M demo/assets/styles.css
+ M demo/index.html
+?? docs/planning/v0.1-acceptance-review/gate-5-public-readme-simulation-audit.md
+```
+
+Final branch diff stat against `main`:
+
+```txt
+ README.md                                          |   8 +-
+ demo/assets/app.js                                 |  10 +-
+ demo/assets/styles.css                             |  10 ++
+ demo/index.html                                    |  32 ++--
+ .../gate-5-public-readme-simulation-audit.md       | 176 +++++++++++++++++++++
+ 5 files changed, 214 insertions(+), 22 deletions(-)
+```
+
+Final branch diff name-only against `main`:
+
+```txt
+README.md
+demo/assets/app.js
+demo/assets/styles.css
+demo/index.html
+docs/planning/v0.1-acceptance-review/gate-5-public-readme-simulation-audit.md
+```
+
+## Gate 5 Decision
+
+Gate 5 status: pass.
+
+Accepted proof rows: G5-01 through G5-06.
+
+Resolved blockers: G5-B1, G5-B2, G5-B3, G5-B4, G5-B5, G5-B6, G5-B7.
+
+Remaining blockers: none.
+
+Decision rationale:
+
+```txt
+Jarvis v0.1 public README and non-normative demo now preserve the protocol
+boundary. README defines Jarvis as the human-agent collaboration and
+learning-loop protocol, positions Jarvis beside MCP, A2A, and AG-UI without
+replacing them, and states that hosts own implementation. The demo is a static
+public walkthrough of protocol records. It does not define host UI behavior,
+runtime behavior, model execution, tool execution, adapter behavior,
+additional protocol operations, additional protocol objects, or conformance
+proof.
+```


### PR DESCRIPTION
## Summary
- adds the Gate 5 acceptance audit for README and non-normative simulation boundary
- tightens README plain-English wording around host-owned execution and tool use
- updates the public demo so it reads as a non-normative protocol walkthrough, not protocol proof or host UI

## Validation
- python3 scripts/check_conformance_fixtures.py
- python3 scripts/check_openapi_contract.py
- python3 scripts/check_markdown_links.py
- python3 scripts/check_protocol_wording.py
- node --check demo/assets/app.js
- git diff --check