### PR TITLE
Add v0.1 Gate 6 boundary wording audit

### DIFF
--- a/docs/architecture_brief/jarvis_protocol_architecture_brief.md
+++ b/docs/architecture_brief/jarvis_protocol_architecture_brief.md
@@ -372,7 +372,7 @@ Jarvis.
 | --- | --- | --- |
 | Compatibility boundaries | Map command-line, local execution, hosted execution, and tool-use flows into Jarvis records. | Hosts preserve their own execution systems. |
 | Host conformance | Provide golden-path and failure-mode fixtures that prove protocol behavior. | Conformance checks behavior, not infrastructure. |
-| Compatibility guidance | Map host work into Jarvis WorkSessions and EvidenceManifest exports. | The host remains the host; Jarvis remains the protocol. |
+| Compatibility rules | Map host work into Jarvis WorkSessions and EvidenceManifest exports. | The host remains the host; Jarvis remains the protocol. |
 | External protocol bridges | Record MCP, A2A, ACP, and AG-UI participation as Jarvis evidence and contribution records. | Jarvis does not redefine those protocols. |
 | Evaluation feedback | Use OutcomeReport to carry external outcomes into governed LearningRecords. | Jarvis does not own task routing, scoring, payment, settlement, or marketplace logic. |
 | Public protocol package | Publish OpenAPI contract, examples, conformance checklist, and protocol architecture brief. | Adoption does not require a runtime owned by Jarvis. |
@@ -391,15 +391,15 @@ InitiativeBalance
 TeachingSignal
 HumanGrowthRecord
 SimulatedHumanWorker
-full host adapters
+host-owned adapter examples
 full external outcome feedback loop
 compatibility examples
 MCP/A2A/ACP/AG-UI bridges
 multi-agent reviewer protocol
 ```
 
-These remain future extensions, examples, adapters, or conformance fixtures.
-They do not enter the v0.1 object spine.
+These remain future extension contracts, host-owned examples, or conformance
+fixtures. They do not enter the v0.1 object spine.
 
 ## Scope Boundary
 

--- a/docs/examples/protocol-records.md
+++ b/docs/examples/protocol-records.md
@@ -44,7 +44,7 @@ into learning.
 Worker and Actor registration are non-WorkSession protocol mutations.
 
 ```txt
-Authorization: Bearer host-auth-ref
+Authorization: HostAuth fixture
 Jarvis-Protocol-Version: v0.1
 Jarvis-Actor-Id: actor-host-protocol
 Jarvis-Idempotency-Key: idem-register-worker-human-001
@@ -54,7 +54,7 @@ Jarvis-Request-Timestamp: 2026-06-24T09:00:00Z
 WorkSession-scoped mutations require revision and previous event hash.
 
 ```txt
-Authorization: Bearer host-auth-ref
+Authorization: HostAuth fixture
 Jarvis-Protocol-Version: v0.1
 Jarvis-Actor-Id: actor-agent-research
 Jarvis-Idempotency-Key: idem-policy-decision-source-001
@@ -66,7 +66,7 @@ Jarvis-Previous-Event-Hash: hash:event-local-context-read-001
 OutcomeReport submission is a non-WorkSession protocol mutation.
 
 ```txt
-Authorization: Bearer host-auth-ref
+Authorization: HostAuth fixture
 Jarvis-Protocol-Version: v0.1
 Jarvis-Actor-Id: actor-human-reviewer
 Jarvis-Idempotency-Key: idem-outcome-report-001

--- a/docs/planning/12-30-day-roadmap.md
+++ b/docs/planning/12-30-day-roadmap.md
@@ -41,8 +41,9 @@ Jarvis sits beside existing standards:
   not MCP.
 - A2A standardizes agent-to-agent communication and delegation. Jarvis records
   A2A delegation inside a WorkSession, but Jarvis is not A2A.
-- AG-UI standardizes agent-to-frontend interaction. Hosts expose Jarvis
-  WorkSession records to AG-UI clients, but Jarvis does not define frontend
+- AG-UI standardizes agent-to-frontend interaction. When a host already uses
+  AG-UI, host-owned code maps Jarvis WorkSession records to AG-UI clients.
+  Jarvis does not require AG-UI integration and does not define frontend
   events, rendering, UI state, or UI transport.
 - Existing execution systems provide runtimes, tools, sessions, handoffs, and
   tracing. Compatible hosts map that work into

--- a/docs/planning/12-30-day-roadmap.md
+++ b/docs/planning/12-30-day-roadmap.md
@@ -41,10 +41,10 @@ Jarvis sits beside existing standards:
   not MCP.
 - A2A standardizes agent-to-agent communication and delegation. Jarvis records
   A2A delegation inside a WorkSession, but Jarvis is not A2A.
-- AG-UI standardizes agent-to-frontend interaction. When a host already uses
-  AG-UI, host-owned code maps Jarvis WorkSession records to AG-UI clients.
+- AG-UI standardizes event-based frontend interaction. When a host already
+  uses AG-UI, host-owned code maps Jarvis WorkSession state to AG-UI clients.
   Jarvis does not require AG-UI integration and does not define frontend
-  events, rendering, UI state, or UI transport.
+  events, frontend rendering, user interface state, or UI transport.
 - Existing execution systems provide runtimes, tools, sessions, handoffs, and
   tracing. Compatible hosts map that work into
   collaboration records instead of replacing those systems.

--- a/docs/planning/v0.1-acceptance-review/acceptance-spec.md
+++ b/docs/planning/v0.1-acceptance-review/acceptance-spec.md
@@ -127,8 +127,8 @@ Required proof:
   behavior, model calls, tool execution, storage, auth, billing, scoring,
   payment, or deployment
 
-The gate fails when an example makes Jarvis own Garden-like product behavior,
-native agent runtime behavior, external task-system behavior, or connector
+The gate fails when an example makes Jarvis own host-product behavior, native
+agent runtime behavior, external task-system behavior, or connector
 execution.
 
 ## Gate 5: Public README And Non-Normative Simulation
@@ -174,7 +174,8 @@ Required proof:
 - `python3 scripts/check_protocol_wording.py` passes
 
 The gate fails when a document weakens locked decisions or describes Jarvis as
-guidance, product strategy, host implementation, or third-party review.
+advisory material, product strategy, host implementation, or third-party
+review.
 
 ## Gate 7: Local Validation
 

--- a/docs/planning/v0.1-acceptance-review/gate-4-compatibility-examples-audit.md
+++ b/docs/planning/v0.1-acceptance-review/gate-4-compatibility-examples-audit.md
@@ -173,7 +173,7 @@ Gate 4 status: pass.
 
 Accepted proof rows: G4-01 through G4-08.
 
-Resolved blockers: G4-B1, G4-B2, G4-B3.
+Resolved blockers: G4-B1, G4-B2, G4-B3, G4-B4.
 
 Remaining blockers: none.
 

--- a/docs/planning/v0.1-acceptance-review/gate-6-boundary-wording-audit.md
+++ b/docs/planning/v0.1-acceptance-review/gate-6-boundary-wording-audit.md
@@ -1,0 +1,212 @@
+# Gate 6 Boundary And Wording Audit
+
+Status: pass.
+
+Review date: 2026-06-30.
+
+Branch: `codex/v0.1-gate-6-boundary-wording-audit`.
+
+Base commit audited: `e4cbcad`.
+
+Working-tree audit state: Gate 6 diff on top of `e4cbcad`.
+
+Decision: Gate 6 passes. Every required proof row passes and no blocker
+remains.
+
+## Scope
+
+Audited sources:
+
+- [../../../README.md](../../../README.md)
+- [../../../AGENTS.md](../../../AGENTS.md)
+- [../../protocol/](../../protocol/)
+- [../../examples/](../../examples/)
+- [../../conformance/](../../conformance/)
+- [../../reviews/](../../reviews/)
+- [../../planning/](../../planning/)
+- [../../architecture_brief/jarvis_protocol_architecture_brief.md](../../architecture_brief/jarvis_protocol_architecture_brief.md)
+- [../../../scripts/check_protocol_wording.py](../../../scripts/check_protocol_wording.py)
+
+Out of scope:
+
+```txt
+SDK implementation
+adapter implementation
+wrapper implementation
+host runtime behavior
+host UI behavior
+model orchestration
+tool execution
+storage behavior
+auth behavior
+billing behavior
+scoring behavior
+payment behavior
+deployment behavior
+```
+
+## Source Coverage
+
+| Source group | Covered paths | Gate 6 check | Result |
+| --- | --- | --- | --- |
+| Wording guard | `scripts/check_protocol_wording.py` | Blocks soft protocol wording, advisory drift, stale host-implementation phrasing, and forbidden protocol ownership phrases | pass |
+| Protocol docs | `docs/protocol/04-work-sessions.md`, `docs/protocol/13-contribution-evidence-learning.md`, `docs/protocol/16-positioning-adoption-lock.md` | Direct WorkSession state wording, export-read classification, optional host-owned AG-UI mapping | pass |
+| Public examples | `docs/examples/protocol-records.md` | Host authentication examples do not prescribe token type or credential format | pass |
+| Acceptance and review docs | `docs/planning/v0.1-acceptance-review/acceptance-spec.md`, `docs/reviews/acceptance-criteria.md` | Gate wording uses protocol-owned and host-owned language; export read header rule matches OpenAPI | pass |
+| Planning docs | `docs/planning/12-30-day-roadmap.md`, `docs/planning/week-1/README.md`, `docs/planning/week-1/chunk-6-positioning-adoption-lock.md` | Older planning text preserves host-owned AG-UI mapping and avoids stale implementation-scope phrasing | pass |
+| Architecture brief | `docs/architecture_brief/jarvis_protocol_architecture_brief.md` | Future work stays outside v0.1 object spine and preserves host-owned adapter boundary | pass |
+| Acceptance audit artifact | `docs/planning/v0.1-acceptance-review/gate-6-boundary-wording-audit.md` | Gate proof matrix, blocker ledger, command evidence, changed-file coverage | pass |
+
+Every changed file belongs to a coverage row:
+
+| Changed file | Coverage row |
+| --- | --- |
+| `docs/architecture_brief/jarvis_protocol_architecture_brief.md` | Architecture brief |
+| `docs/examples/protocol-records.md` | Public examples |
+| `docs/planning/12-30-day-roadmap.md` | Planning docs |
+| `docs/planning/v0.1-acceptance-review/acceptance-spec.md` | Acceptance and review docs |
+| `docs/planning/week-1/README.md` | Planning docs |
+| `docs/planning/week-1/chunk-6-positioning-adoption-lock.md` | Planning docs |
+| `docs/protocol/04-work-sessions.md` | Protocol docs |
+| `docs/protocol/13-contribution-evidence-learning.md` | Protocol docs |
+| `docs/protocol/16-positioning-adoption-lock.md` | Protocol docs |
+| `docs/reviews/acceptance-criteria.md` | Acceptance and review docs |
+| `scripts/check_protocol_wording.py` | Wording guard |
+| `docs/planning/v0.1-acceptance-review/gate-6-boundary-wording-audit.md` | Acceptance audit artifact |
+
+## Required Proof Matrix
+
+| ID | Required proof | Evidence | Result |
+| --- | --- | --- | --- |
+| G6-01 | Protocol statements use direct ownership language. | `README.md`, `AGENTS.md`, `docs/protocol/`, `docs/planning/v0.1-acceptance-review/acceptance-spec.md` | pass |
+| G6-02 | Host-owned responsibilities stay outside Jarvis. | `docs/protocol/16-positioning-adoption-lock.md`, `docs/planning/12-30-day-roadmap.md`, `docs/planning/week-1/chunk-6-positioning-adoption-lock.md` | pass |
+| G6-03 | SDK language stays limited to protocol implementation helpers. | `README.md`, `AGENTS.md`, `docs/protocol/08-package-contracts.md`, `docs/protocol/16-positioning-adoption-lock.md`, `docs/examples/existing-agent-compatibility.md`, `docs/conformance/existing-agent-proof-plan.md` | pass |
+| G6-04 | Docs do not use soft wording for locked protocol rules. | `scripts/check_protocol_wording.py`, `python3 scripts/check_protocol_wording.py` | pass |
+| G6-05 | Host authentication examples do not prescribe credential format or token type. | `docs/examples/protocol-records.md`, `docs/protocol/15-openapi-communication-binding.md` | pass |
+| G6-06 | EvidenceManifest export remains an export read operation, not a six-header mutation. | `docs/protocol/13-contribution-evidence-learning.md`, `docs/reviews/acceptance-criteria.md`, `docs/conformance/checklist.md`, `docs/openapi/jarvis-openapi.yaml` | pass |
+
+## Source Findings
+
+| Finding ID | Blocker ID | Severity | Source | Gate proof affected | Finding | Resolution | Status |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| G6-F1 | G6-B1 | blocker | `docs/examples/protocol-records.md` | G6-02, G6-05 | Public protocol examples used `Authorization: Bearer host-auth-ref`, which prescribed a token type even though Jarvis does not own credential format. | Replaced public header examples with `Authorization: HostAuth fixture`. | resolved |
+| G6-F2 | G6-B2 | blocker | `docs/protocol/16-positioning-adoption-lock.md`, `docs/planning/12-30-day-roadmap.md`, `docs/planning/week-1/chunk-6-positioning-adoption-lock.md` | G6-02 | AG-UI positioning made compatible hosts appear to expose Jarvis records to AG-UI clients as a required integration surface. | Rewrote AG-UI language so host-owned code maps Jarvis records only when the host chooses AG-UI integration. Jarvis does not require or define AG-UI integration. | resolved |
+| G6-F3 | G6-B3 | blocker | `docs/reviews/acceptance-criteria.md`, `docs/protocol/13-contribution-evidence-learning.md` | G6-06 | EvidenceManifest export was grouped with six-header mutating WorkSession-scoped operations. OpenAPI defines export as an export read. | Split state-changing attribution, evidence, learning, and proposal operations from EvidenceManifest export. Export read now requires host authentication, protocol version, Actor id, and Actor read authority only. | resolved |
+| G6-F4 | G6-B4 | blocker | `docs/planning/v0.1-acceptance-review/acceptance-spec.md` | G6-01, G6-02 | Acceptance spec used product-shaped wording in a Gate 4 failure rule and used advisory wording in the Gate 6 failure rule. | Replaced the product-shaped phrase with `host-product behavior` and replaced advisory-language wording with direct protocol failure language. | resolved |
+| G6-F5 | G6-B5 | blocker | `scripts/check_protocol_wording.py`, `docs/architecture_brief/jarvis_protocol_architecture_brief.md` | G6-04 | The wording guard missed an advisory drift term, and the architecture brief used that term in a future-area label. | Added the advisory drift term to the wording guard and changed the architecture brief label to `Compatibility rules`. | resolved |
+| G6-F6 | G6-B6 | blocker | `docs/protocol/04-work-sessions.md`, `docs/planning/week-1/README.md` | G6-01, G6-04 | WorkSession state text used softer `intended outcome` wording, explanatory `supports` wording, and old implementation-concern phrasing. | Replaced those lines with declared objective, declared completion, protocol basis, preserved resumption basis, and host implementation scope wording. | resolved |
+| G6-F7 | G6-B7 | blocker | `docs/architecture_brief/jarvis_protocol_architecture_brief.md` | G6-02, G6-03 | Future work listed `full host adapters` and grouped future work as adapters. | Replaced with host-owned adapter examples and future extension contracts or conformance fixtures. | resolved |
+| G6-F8 | G6-B8 | blocker | `docs/planning/v0.1-acceptance-review/gate-4-compatibility-examples-audit.md` | G6-01 | Gate 4 blocker bookkeeping omitted `G4-B4` from the final resolved-blocker list. | Added `G4-B4` to the final resolved-blocker list. | resolved |
+
+## Blocker List
+
+No blocker remains.
+
+| Blocker ID | Source | Gate proof failed | Resolution evidence | Status |
+| --- | --- | --- | --- | --- |
+| G6-B1 | Host auth examples prescribed Bearer token format | G6-02, G6-05 | `docs/examples/protocol-records.md` | resolved |
+| G6-B2 | AG-UI wording implied required host UI integration | G6-02 | `docs/protocol/16-positioning-adoption-lock.md`, `docs/planning/12-30-day-roadmap.md`, `docs/planning/week-1/chunk-6-positioning-adoption-lock.md` | resolved |
+| G6-B3 | Export read misclassified as six-header mutation | G6-06 | `docs/reviews/acceptance-criteria.md`, `docs/protocol/13-contribution-evidence-learning.md` | resolved |
+| G6-B4 | Acceptance spec carried product-shaped and advisory wording | G6-01, G6-02 | `docs/planning/v0.1-acceptance-review/acceptance-spec.md` | resolved |
+| G6-B5 | Wording guard missed advisory drift term | G6-04 | `scripts/check_protocol_wording.py`, `docs/architecture_brief/jarvis_protocol_architecture_brief.md` | resolved |
+| G6-B6 | WorkSession and old planning wording needed direct state language | G6-01, G6-04 | `docs/protocol/04-work-sessions.md`, `docs/planning/week-1/README.md` | resolved |
+| G6-B7 | Future work wording blurred host-owned adapter boundary | G6-02, G6-03 | `docs/architecture_brief/jarvis_protocol_architecture_brief.md` | resolved |
+| G6-B8 | Gate 4 final blocker list missed resolved blocker | G6-01 | `docs/planning/v0.1-acceptance-review/gate-4-compatibility-examples-audit.md` | resolved |
+
+## Reviewer Evidence
+
+| Reviewer | Focus | Initial finding | Resolution | Final status |
+| --- | --- | --- | --- | --- |
+| Godel | protocol boundary drift | public examples prescribed Bearer auth format | replaced examples with `Authorization: HostAuth fixture` | no findings |
+| Boyle | direct wording and soft language | architecture brief label, WorkSession wording, and old planning phrase needed direct protocol language | added guard coverage and replaced wording with direct state language | no findings |
+| Pasteur | SDK/helper and adoption boundary | AG-UI wording implied required host-owned UI integration surface | made AG-UI mapping conditional and host-owned across protocol and planning docs | no findings |
+| Linnaeus | OpenAPI, conformance, and review consistency | EvidenceManifest export was misclassified as six-header mutation; Gate 4 blocker bookkeeping missed `G4-B4` | separated export read headers from mutation headers and corrected Gate 4 resolved-blocker list | no findings |
+
+## Command Evidence
+
+Commands run after Gate 6 fixes:
+
+| Command | Exit status | Output summary |
+| --- | --- | --- |
+| `python3 scripts/check_conformance_fixtures.py` | 0 | `conformance fixtures ok` |
+| `python3 scripts/check_openapi_contract.py` | 0 | `openapi contract ok` |
+| `python3 scripts/check_markdown_links.py` | 0 | `markdown links ok` |
+| `python3 scripts/check_protocol_wording.py` | 0 | `protocol wording ok` |
+| `git diff --check` | 0 | no output |
+| `node --check demo/assets/app.js` | 0 | no output |
+
+Pre-stage working-tree state at audit time:
+
+```txt
+ M docs/architecture_brief/jarvis_protocol_architecture_brief.md
+ M docs/examples/protocol-records.md
+ M docs/planning/12-30-day-roadmap.md
+ M docs/planning/v0.1-acceptance-review/acceptance-spec.md
+ M docs/planning/week-1/README.md
+ M docs/planning/week-1/chunk-6-positioning-adoption-lock.md
+ M docs/protocol/04-work-sessions.md
+ M docs/protocol/13-contribution-evidence-learning.md
+ M docs/protocol/16-positioning-adoption-lock.md
+ M docs/reviews/acceptance-criteria.md
+ M scripts/check_protocol_wording.py
+?? docs/planning/v0.1-acceptance-review/gate-6-boundary-wording-audit.md
+```
+
+Final branch diff stat against `main`:
+
+```txt
+ .../jarvis_protocol_architecture_brief.md          |   8 +-
+ docs/examples/protocol-records.md                  |   6 +-
+ docs/planning/12-30-day-roadmap.md                 |   5 +-
+ .../v0.1-acceptance-review/acceptance-spec.md      |   7 +-
+ .../gate-4-compatibility-examples-audit.md         |   2 +-
+ .../gate-6-boundary-wording-audit.md               | 212 +++++++++++++++++++++
+ docs/planning/week-1/README.md                     |   4 +-
+ .../week-1/chunk-6-positioning-adoption-lock.md    |   9 +-
+ docs/protocol/04-work-sessions.md                  |  19 ++-
+ docs/protocol/13-contribution-evidence-learning.md |   8 +-
+ docs/protocol/16-positioning-adoption-lock.md      |   8 +-
+ docs/reviews/acceptance-criteria.md                |   8 +-
+ scripts/check_protocol_wording.py                  |   1 +
+ 13 files changed, 261 insertions(+), 36 deletions(-)
+```
+
+Final branch diff name-only against `main`:
+
+```txt
+docs/architecture_brief/jarvis_protocol_architecture_brief.md
+docs/examples/protocol-records.md
+docs/planning/12-30-day-roadmap.md
+docs/planning/v0.1-acceptance-review/acceptance-spec.md
+docs/planning/v0.1-acceptance-review/gate-4-compatibility-examples-audit.md
+docs/planning/v0.1-acceptance-review/gate-6-boundary-wording-audit.md
+docs/planning/week-1/README.md
+docs/planning/week-1/chunk-6-positioning-adoption-lock.md
+docs/protocol/04-work-sessions.md
+docs/protocol/13-contribution-evidence-learning.md
+docs/protocol/16-positioning-adoption-lock.md
+docs/reviews/acceptance-criteria.md
+scripts/check_protocol_wording.py
+```
+
+## Gate 6 Decision
+
+Gate 6 status: pass.
+
+Accepted proof rows: G6-01 through G6-06.
+
+Resolved blockers: G6-B1, G6-B2, G6-B3, G6-B4, G6-B5, G6-B6, G6-B7, G6-B8.
+
+Remaining blockers: none.
+
+Decision rationale:
+
+```txt
+Jarvis v0.1 boundary and wording now preserve direct protocol ownership.
+Protocol docs, public examples, planning docs, review docs, and the
+architecture brief keep host implementation outside Jarvis. SDK language stays
+limited to protocol implementation helpers. Host authentication examples do not
+prescribe credential format. AG-UI mapping is optional and host-owned.
+EvidenceManifest export remains an export read operation. The wording guard
+blocks soft protocol wording and advisory drift terms.
+```

--- a/docs/planning/v0.1-acceptance-review/gate-6-boundary-wording-audit.md
+++ b/docs/planning/v0.1-acceptance-review/gate-6-boundary-wording-audit.md
@@ -65,6 +65,7 @@ Every changed file belongs to a coverage row:
 | `docs/examples/protocol-records.md` | Public examples |
 | `docs/planning/12-30-day-roadmap.md` | Planning docs |
 | `docs/planning/v0.1-acceptance-review/acceptance-spec.md` | Acceptance and review docs |
+| `docs/planning/v0.1-acceptance-review/gate-4-compatibility-examples-audit.md` | Acceptance and review docs |
 | `docs/planning/week-1/README.md` | Planning docs |
 | `docs/planning/week-1/chunk-6-positioning-adoption-lock.md` | Planning docs |
 | `docs/protocol/04-work-sessions.md` | Protocol docs |
@@ -157,10 +158,10 @@ Final branch diff stat against `main`:
 ```txt
  .../jarvis_protocol_architecture_brief.md          |   8 +-
  docs/examples/protocol-records.md                  |   6 +-
- docs/planning/12-30-day-roadmap.md                 |   5 +-
+ docs/planning/12-30-day-roadmap.md                 |   7 +-
  .../v0.1-acceptance-review/acceptance-spec.md      |   7 +-
  .../gate-4-compatibility-examples-audit.md         |   2 +-
- .../gate-6-boundary-wording-audit.md               | 212 +++++++++++++++++++++
+ .../gate-6-boundary-wording-audit.md               | 213 +++++++++++++++++++++
  docs/planning/week-1/README.md                     |   4 +-
  .../week-1/chunk-6-positioning-adoption-lock.md    |   9 +-
  docs/protocol/04-work-sessions.md                  |  19 ++-
@@ -168,7 +169,7 @@ Final branch diff stat against `main`:
  docs/protocol/16-positioning-adoption-lock.md      |   8 +-
  docs/reviews/acceptance-criteria.md                |   8 +-
  scripts/check_protocol_wording.py                  |   1 +
- 13 files changed, 261 insertions(+), 36 deletions(-)
+ 13 files changed, 263 insertions(+), 37 deletions(-)
 ```
 
 Final branch diff name-only against `main`:

--- a/docs/planning/week-1/README.md
+++ b/docs/planning/week-1/README.md
@@ -122,8 +122,8 @@ XLSX sanity check
 ## Stale Wording Scan
 
 The scan rejects wording that violates the boundaries in `AGENTS.md`, turns
-Jarvis into a host-owned implementation concern, makes compatible example active
-before the conformance gate, or makes locked protocol decisions sound optional.
+Jarvis into host implementation scope, makes compatible example active before
+the conformance gate, or makes locked protocol decisions sound optional.
 
 ## Week 1 Chunks
 

--- a/docs/planning/week-1/chunk-6-positioning-adoption-lock.md
+++ b/docs/planning/week-1/chunk-6-positioning-adoption-lock.md
@@ -76,10 +76,11 @@ does not define remote-agent run execution, thread execution, output retrieval,
 or ACP agent interfaces.
 
 AG-UI standardizes how agents connect to user-facing applications through
-event-based frontend interaction. Hosts expose Jarvis WorkSession state,
-Requests, Reviews, Takeovers, Contributions, and Evidence to AG-UI clients.
-Jarvis does not define frontend events, frontend rendering, user interface
-state, or UI transport.
+event-based frontend interaction. When a host already uses AG-UI, host-owned
+code maps Jarvis WorkSession state, Requests, Reviews, Takeovers,
+Contributions, and Evidence to AG-UI clients. Jarvis does not require AG-UI
+integration and does not define frontend events, frontend rendering, user
+interface state, or UI transport.
 
 ## Host Boundary
 

--- a/docs/protocol/04-work-sessions.md
+++ b/docs/protocol/04-work-sessions.md
@@ -93,13 +93,13 @@ reconciling
   AgentWorker continuation.
 
 completed
-  The WorkSession reached its intended outcome.
+  The WorkSession reached its declared objective.
 
 failed
-  The WorkSession cannot reach its intended outcome.
+  The WorkSession cannot reach its declared objective.
 
 cancelled
-  An authorized Actor stopped the WorkSession before intended completion.
+  An authorized Actor stopped the WorkSession before declared completion.
 
 closed
   The WorkSession is sealed for archival/export state. No further mutation is
@@ -261,7 +261,8 @@ skill_proposed
 skill_updated
 ```
 
-The event log supports observability, debugging, evidence, and learning.
+The event log records the protocol basis for observability, debugging,
+evidence, and learning.
 
 The event log is append-only. Host checkpoints accelerate resume, but
 events are the source of truth.
@@ -552,8 +553,8 @@ policy profile
 tool inventory hash
 ```
 
-This record supports WorkSession resumption and human inspection of the exact
-context the agent received.
+This record preserves the WorkSession resumption basis and the exact context
+the agent received for human inspection.
 
 ## Reproducibility References
 
@@ -593,13 +594,13 @@ Policy decides what becomes durable.
 
 ## Completion, Failure, Cancellation, And Closure
 
-`completed` means the WorkSession reached its intended outcome.
+`completed` means the WorkSession reached its declared objective.
 
-`failed` means the WorkSession cannot reach its intended outcome. Failure records
+`failed` means the WorkSession cannot reach its declared objective. Failure records
 the reason, evidence limitations, and remaining unresolved Requests when they
 exist.
 
-`cancelled` means an authorized Actor stopped the WorkSession before intended
+`cancelled` means an authorized Actor stopped the WorkSession before declared
 completion. Cancellation records the Actor, reason, and policy basis. It does
 not grant authority to execute blocked work.
 

--- a/docs/protocol/13-contribution-evidence-learning.md
+++ b/docs/protocol/13-contribution-evidence-learning.md
@@ -320,10 +320,14 @@ outcome_report_without_learning_record
 A compatible implementation proves:
 
 ```txt
-Mutating WorkSession-scoped attribution, evidence, learning, proposal, and
-export operations require Jarvis-Protocol-Version, Jarvis-Actor-Id,
+Mutating WorkSession-scoped attribution, evidence, learning, and proposal
+operations require Jarvis-Protocol-Version, Jarvis-Actor-Id,
 Jarvis-Idempotency-Key, Jarvis-Request-Timestamp,
 Jarvis-Expected-WorkSession-Revision, and Jarvis-Previous-Event-Hash.
+EvidenceManifest export is an export read operation. It requires
+Jarvis-Protocol-Version, host authentication, Jarvis-Actor-Id, and Actor read
+authority. It does not require mutation-only idempotency, expected revision, or
+previous event hash headers.
 OutcomeReport submission uses the non-WorkSession mutation header set:
 Jarvis-Protocol-Version, Jarvis-Actor-Id, Jarvis-Idempotency-Key, and
 Jarvis-Request-Timestamp. It MUST NOT require

--- a/docs/protocol/16-positioning-adoption-lock.md
+++ b/docs/protocol/16-positioning-adoption-lock.md
@@ -62,10 +62,10 @@ interrupt delivery, output retrieval, or ACP agent interfaces.
 AG-UI standardizes how AI agents connect to user-facing applications through an
 open, lightweight, event-based protocol. AG-UI focuses on agent state, UI
 intents, user interactions, frontend tools, streaming, and interactive
-frontends. A Jarvis-compatible host exposes WorkSession state,
-Requests, Reviews, Takeovers, Contributions, Evidence, and Learning to AG-UI
-clients. Jarvis does not define frontend events, rendering, UI state, or
-user-interface transport.
+frontends. When a host chooses AG-UI integration, host-owned code maps
+WorkSession state, Requests, Reviews, Takeovers, Contributions, Evidence, and
+Learning to AG-UI clients. Jarvis does not require AG-UI integration and does
+not define frontend events, rendering, UI state, or user-interface transport.
 
 ## Host Boundary
 

--- a/docs/reviews/acceptance-criteria.md
+++ b/docs/reviews/acceptance-criteria.md
@@ -113,11 +113,15 @@ Expected result:
 - Takeover creates lock state
 - Takeover rejects stale AgentWorker continuation
 - Takeover resume requires reconciliation refs
-- mutating WorkSession-scoped attribution, evidence, learning, proposal, and
-  export operations require `Jarvis-Protocol-Version`, `Jarvis-Actor-Id`,
+- mutating WorkSession-scoped attribution, evidence, learning, and proposal
+  operations require `Jarvis-Protocol-Version`, `Jarvis-Actor-Id`,
   `Jarvis-Idempotency-Key`, `Jarvis-Request-Timestamp`,
   `Jarvis-Expected-WorkSession-Revision`, and
   `Jarvis-Previous-Event-Hash`
+- EvidenceManifest export is an export read operation. It requires
+  `Jarvis-Protocol-Version`, host authentication, `Jarvis-Actor-Id`, and Actor
+  read authority. It does not require mutation-only idempotency, expected
+  revision, or previous event hash headers.
 - OutcomeReport submission uses the non-WorkSession mutation header set:
   `Jarvis-Protocol-Version`, `Jarvis-Actor-Id`, `Jarvis-Idempotency-Key`, and
   `Jarvis-Request-Timestamp`; it does not require

--- a/scripts/check_protocol_wording.py
+++ b/scripts/check_protocol_wording.py
@@ -36,6 +36,7 @@ PATTERNS = [
     r"\bconsider\b",
     r"\bsuggest\b",
     r"\badvice\b",
+    r"\bguidance\b",
     r"\bcandidate\b",
     r"implementation concerns",
     r"those are implementation concerns",


### PR DESCRIPTION
## Summary
- adds the Gate 6 boundary and wording acceptance audit
- tightens host/auth, AG-UI, export-read, and SDK/adoption boundary language
- expands the wording guard to reject advisory drift wording

## Validation
- python3 scripts/check_conformance_fixtures.py
- python3 scripts/check_openapi_contract.py
- python3 scripts/check_markdown_links.py
- python3 scripts/check_protocol_wording.py
- node --check demo/assets/app.js
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified protocol wording around compatibility, host-owned integration, work session states, and evidence handling.
  * Added a new boundary-and-wording audit summary and updated acceptance/review criteria.
  * Refined example headers and roadmap language for more consistent terminology.

* **Bug Fixes**
  * Tightened wording checks to flag outdated advisory terminology.
  * Corrected header requirements so export-style operations are distinguished from mutation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->