### PR TITLE
Add v0.1 Gate 7 local validation audit

### DIFF
--- a/docs/planning/v0.1-acceptance-review/gate-7-local-validation-audit.md
+++ b/docs/planning/v0.1-acceptance-review/gate-7-local-validation-audit.md
@@ -1,0 +1,171 @@
+# Gate 7 Local Validation Audit
+
+Status: pass.
+
+Review date: 2026-06-30.
+
+Branch: `codex/v0.1-gate-7-local-validation-audit`.
+
+Base commit audited: `6f768d7`.
+
+Working-tree audit state: Gate 7 audit artifact on top of `6f768d7`.
+
+Decision: Gate 7 passes. Every required local validation command exits cleanly
+and no blocker remains.
+
+## Scope
+
+Audited sources:
+
+- [acceptance-spec.md](./acceptance-spec.md)
+- [../../../AGENTS.md](../../../AGENTS.md)
+- [../../../scripts/check_markdown_links.py](../../../scripts/check_markdown_links.py)
+- [../../../scripts/check_protocol_wording.py](../../../scripts/check_protocol_wording.py)
+- [../../../scripts/check_openapi_contract.py](../../../scripts/check_openapi_contract.py)
+- [../../../scripts/check_conformance_fixtures.py](../../../scripts/check_conformance_fixtures.py)
+- [../../../demo/assets/app.js](../../../demo/assets/app.js)
+
+Out of scope:
+
+```txt
+SDK implementation
+adapter implementation
+wrapper implementation
+host runtime behavior
+host UI behavior
+model orchestration
+tool execution
+storage behavior
+auth behavior
+billing behavior
+scoring behavior
+payment behavior
+deployment behavior
+```
+
+## Source Coverage
+
+| Source group | Covered paths | Gate 7 check | Result |
+| --- | --- | --- | --- |
+| Acceptance rule | `docs/planning/v0.1-acceptance-review/acceptance-spec.md` | Gate 7 command set and demo public-readiness check | pass |
+| Maintainer rule | `AGENTS.md` | Required local check commands for protocol PRs | pass |
+| Markdown link validation | `scripts/check_markdown_links.py` | Repository markdown links resolve | pass |
+| Protocol wording validation | `scripts/check_protocol_wording.py` | Soft protocol wording and boundary drift terms reject | pass |
+| OpenAPI validation | `scripts/check_openapi_contract.py` | OpenAPI contract, schemas, operations, headers, security, examples, and error envelope validate | pass |
+| Conformance fixture validation | `scripts/check_conformance_fixtures.py` | Golden-path and invalid fixtures validate against protocol conformance rules | pass |
+| Demo public-readiness syntax | `demo/assets/app.js` | Non-normative demo script parses cleanly | pass |
+| Git whitespace validation | Git working tree diff | Branch diff contains no whitespace errors | pass |
+| Acceptance audit artifact | `docs/planning/v0.1-acceptance-review/gate-7-local-validation-audit.md` | Gate proof matrix, blocker ledger, command evidence, changed-file coverage | pass |
+
+Every changed file belongs to a coverage row:
+
+| Changed file | Coverage row |
+| --- | --- |
+| `docs/planning/v0.1-acceptance-review/gate-7-local-validation-audit.md` | Acceptance audit artifact |
+
+## Required Proof Matrix
+
+| ID | Required proof | Evidence | Result |
+| --- | --- | --- | --- |
+| G7-01 | Markdown link check passes. | `python3 scripts/check_markdown_links.py` | pass |
+| G7-02 | Protocol wording check passes. | `python3 scripts/check_protocol_wording.py` | pass |
+| G7-03 | OpenAPI contract check passes. | `python3 scripts/check_openapi_contract.py` | pass |
+| G7-04 | Conformance fixture check passes. | `python3 scripts/check_conformance_fixtures.py` | pass |
+| G7-05 | Git whitespace check passes. | `git diff --check` | pass |
+| G7-06 | Demo public-readiness syntax check passes as supplemental evidence. | `node --check demo/assets/app.js` | pass |
+| G7-07 | Local validation scripts do not execute host behavior. | `scripts/check_conformance_fixtures.py`, `scripts/check_openapi_contract.py`, `scripts/check_markdown_links.py`, `scripts/check_protocol_wording.py` | pass |
+
+## Source Findings
+
+No blocker finding remains.
+
+| Finding ID | Blocker ID | Severity | Source | Gate proof affected | Finding | Resolution | Status |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| G7-F1 | none | note | Gate 7 command run | G7-01 through G7-06 | Required commands passed on clean `main` state after Gate 6 merge. | Recorded command evidence in this audit. | closed |
+
+## Blocker List
+
+No blocker remains.
+
+| Blocker ID | Source | Gate proof failed | Resolution evidence | Status |
+| --- | --- | --- | --- | --- |
+| none | none | none | command evidence | closed |
+
+## Non-Blocking Future Hardening
+
+These items do not block Gate 7. They improve future validation strictness
+without changing v0.1 acceptance commands:
+
+- Future `check_openapi_contract.py` hardening rejects unexpected extra OpenAPI
+  paths/operations after the v0.1 path set is fully frozen.
+- Future `check_conformance_fixtures.py` hardening enforces repository
+  containment for local `source_contract_refs`.
+- Future `check_markdown_links.py` hardening enforces repository containment
+  for local markdown link targets.
+- Future `check_protocol_wording.py` hardening extends wording coverage beyond
+  markdown when future public artifacts become protocol text.
+
+## Reviewer Evidence
+
+| Reviewer | Focus | Initial finding | Resolution | Final status |
+| --- | --- | --- | --- | --- |
+| Darwin | command coverage | no blocker; required Gate 7 command set complete | no change required | no findings |
+| Bernoulli | script protocol boundary | no blocker; validators stay local and artifact-focused | recorded future hardening notes as non-blocking | no findings |
+| Erdos | audit structure | reviewer evidence and branch diff placeholders were pending | replaced pending reviewer rows and final diff evidence before staging | no findings |
+| Dirac | demo public-readiness check | no blocker; demo syntax check is correct supplemental evidence and no demo misrepresentation found | clarified supplemental public-readiness role | no findings |
+
+## Command Evidence
+
+Commands run for Gate 7:
+
+| Command | Exit status | Output summary |
+| --- | --- | --- |
+| `python3 scripts/check_markdown_links.py` | 0 | `markdown links ok` |
+| `python3 scripts/check_protocol_wording.py` | 0 | `protocol wording ok` |
+| `python3 scripts/check_openapi_contract.py` | 0 | `openapi contract ok` |
+| `python3 scripts/check_conformance_fixtures.py` | 0 | `conformance fixtures ok` |
+| `git diff --check` | 0 | no output |
+| `node --check demo/assets/app.js` | 0 | no output |
+
+Pre-stage working-tree state at audit time:
+
+```txt
+?? docs/planning/v0.1-acceptance-review/gate-7-local-validation-audit.md
+```
+
+Final branch diff stat against `main`:
+
+```txt
+ .../gate-7-local-validation-audit.md               | 171 +++++++++++++++++++++
+ 1 file changed, 171 insertions(+)
+```
+
+Final branch diff name-only against `main`:
+
+```txt
+docs/planning/v0.1-acceptance-review/gate-7-local-validation-audit.md
+```
+
+## Gate 7 Decision
+
+Gate 7 status: pass.
+
+Accepted proof rows: G7-01 through G7-05.
+
+Supplemental public-readiness and script-boundary rows: G7-06 and G7-07.
+
+Resolved blockers: none.
+
+Remaining blockers: none.
+
+Decision rationale:
+
+```txt
+Jarvis v0.1 local validation passes the required protocol command set.
+Markdown links, protocol wording, OpenAPI contract checks, conformance
+fixtures, Git whitespace checks, and non-normative demo syntax all pass. The
+validation commands inspect protocol, documentation, fixtures, OpenAPI records,
+and demo syntax only. They do not execute host behavior, runtime behavior,
+model calls, tool calls, storage behavior, auth behavior, billing behavior, or
+deployment behavior.
+```


### PR DESCRIPTION
## Summary
- adds the Gate 7 local validation acceptance audit
- records required protocol validation command evidence
- records supplemental demo public-readiness and script-boundary evidence

## Validation
- python3 scripts/check_markdown_links.py
- python3 scripts/check_protocol_wording.py
- python3 scripts/check_openapi_contract.py
- python3 scripts/check_conformance_fixtures.py
- node --check demo/assets/app.js
- git diff --check