### PR TITLE
[codex] Add v0.1 Gate 8 publication discipline audit

### DIFF
--- a/docs/architecture_brief/README.md
+++ b/docs/architecture_brief/README.md
@@ -8,8 +8,8 @@ This folder contains the shareable Jarvis protocol architecture brief.
 - Diagram sources: [diagrams/](diagrams/)
 
 The brief packages the v0.1 first-30-days protocol architecture into a PDF the
-team reviews while the OpenAPI contract, examples, conformance entry, and
-adapter boundaries are developed.
+team reviews during v0.1 acceptance. It records the OpenAPI contract, examples,
+conformance entry, and host-owned adapter boundary.
 
 ## Render
 

--- a/docs/conformance/checklist.md
+++ b/docs/conformance/checklist.md
@@ -482,6 +482,20 @@ A product, host, SDK helper, or external system MUST NOT claim Jarvis
 compatibility because it has chat, approval buttons, logs, agent runs, or
 memory.
 
+Public compatibility claims MUST use this exact structure:
+
+```txt
+Implementation <name> supports Jarvis <protocol-version> compatibility,
+verified against <conformance-surface> on <date>.
+```
+
+The claim MUST name:
+
+- protocol version
+- conformance surface
+- fixture or checklist basis
+- verification date
+
 Jarvis compatibility requires this proof:
 
 ```txt

--- a/docs/conformance/existing-agent-proof-plan.md
+++ b/docs/conformance/existing-agent-proof-plan.md
@@ -63,7 +63,15 @@ export payloads.
 
 ## Required Compatibility Claim
 
-A compatible implementation proves this claim:
+A public compatibility claim for this proof MUST use this format:
+
+```txt
+Implementation <name> supports Jarvis v0.1 compatibility, verified against the
+existing-agent proof plan, public conformance checklist, and v0.1 golden-path
+and failure-mode fixtures on <verification-date>.
+```
+
+The proof behind that claim is:
 
 ```txt
 Different native host shapes produce equivalent Jarvis records for the same

--- a/docs/examples/compatible-host-mapping.md
+++ b/docs/examples/compatible-host-mapping.md
@@ -360,9 +360,9 @@ This example is governed by:
 - [Golden-path conformance entry](../conformance/golden-path.md)
 - [Fixture documentation](../conformance/fixtures/README.md)
 
-## Compatibility Conditions
+## Example Conditions
 
-This mapping is compatible only when:
+This mapping is valid only when:
 
 - both host shapes produce equivalent Jarvis records
 - `host_shape_ref` stays metadata only

--- a/docs/examples/existing-agent-compatibility.md
+++ b/docs/examples/existing-agent-compatibility.md
@@ -37,13 +37,22 @@ exports, and tests Jarvis records. It MUST NOT run the agent, plan the task,
 route the model, execute tools, own native memory, own UI, own auth, own
 storage, or become the host adapter.
 
-## Compatibility Claim
+## Example Scope
 
-A compatible implementation preserves this claim:
+This example demonstrates this protocol record shape:
 
 ```txt
 An existing native agent completes work in its own environment while Jarvis
 records the human-agent collaboration contract around that work.
+```
+
+A public compatibility claim using this example MUST use this format:
+
+```txt
+Implementation <name> supports Jarvis v0.1 compatibility, verified against the
+existing-agent compatibility example, existing-agent proof plan, public
+conformance checklist, and v0.1 golden-path and failure-mode fixtures on
+<verification-date>.
 ```
 
 The existing agent remains native. Jarvis records how the HumanWorker and
@@ -522,7 +531,7 @@ what policy governed the work, what was blocked, how the human resolved it, who
 contributed, what evidence exists, and what learning carries forward.
 ```
 
-What makes the example compatible?
+What proof does this example show?
 
 ```txt
 The existing native agent produces the same required Jarvis records without
@@ -537,9 +546,9 @@ being rewritten as a Jarvis agent.
 - [Golden-path conformance entry](../conformance/golden-path.md)
 - [Fixture documentation](../conformance/fixtures/README.md)
 
-## Compatibility Conditions
+## Example Conditions
 
-This example is compatible only when:
+This example is valid only when:
 
 - the existing native agent remains native
 - Jarvis records collaboration only

--- a/docs/openapi/jarvis-openapi.yaml
+++ b/docs/openapi/jarvis-openapi.yaml
@@ -127,8 +127,10 @@ paths:
       description: |
         Returns a WorkSession protocol record. Compatible implementations MUST
         verify HostAuth, Jarvis-Protocol-Version, Jarvis-Actor-Id, and Actor
-        read authority. Read operations MUST NOT require mutation-only
-        idempotency, expected revision, or previous event hash headers.
+        read authority. Read operations MAY include
+        Jarvis-Required-Capabilities and Jarvis-Extensions. Read operations
+        MUST NOT require mutation-only idempotency, expected revision, or
+        previous event hash headers.
       x-jarvis-operation-class: worksession_scoped_read
       tags:
         - WorkSessions
@@ -138,6 +140,8 @@ paths:
         - $ref: "#/components/parameters/WorkSessionIdPath"
         - $ref: "#/components/parameters/ProtocolVersionHeader"
         - $ref: "#/components/parameters/ActorHeader"
+        - $ref: "#/components/parameters/RequiredCapabilitiesHeader"
+        - $ref: "#/components/parameters/ExtensionsHeader"
       responses:
         "200":
           $ref: "#/components/responses/WorkSessionResponse"
@@ -417,8 +421,9 @@ paths:
         Exports portable EvidenceManifest proof from a terminal WorkSession
         state. Compatible implementations MUST verify HostAuth,
         Jarvis-Protocol-Version, Jarvis-Actor-Id, and Actor read authority.
-        Export reads MUST NOT require mutation-only idempotency, expected
-        revision, or previous event hash headers.
+        Export reads MAY include Jarvis-Required-Capabilities and
+        Jarvis-Extensions. Export reads MUST NOT require mutation-only
+        idempotency, expected revision, or previous event hash headers.
       x-jarvis-operation-class: export_read
       tags:
         - Evidence
@@ -428,6 +433,8 @@ paths:
         - $ref: "#/components/parameters/WorkSessionIdPath"
         - $ref: "#/components/parameters/ProtocolVersionHeader"
         - $ref: "#/components/parameters/ActorHeader"
+        - $ref: "#/components/parameters/RequiredCapabilitiesHeader"
+        - $ref: "#/components/parameters/ExtensionsHeader"
       responses:
         "200":
           $ref: "#/components/responses/EvidenceManifestResponse"
@@ -2634,6 +2641,22 @@ components:
         type: string
         minLength: 1
       description: Links the accepted mutation to the current WorkSession event chain. Genesis WorkSession creation uses the protocol genesis hash.
+    RequiredCapabilitiesHeader:
+      name: Jarvis-Required-Capabilities
+      in: header
+      required: false
+      schema:
+        type: string
+        minLength: 1
+      description: Declares caller-required optional Jarvis capabilities. Unsupported required capabilities reject as unsupported_capability.
+    ExtensionsHeader:
+      name: Jarvis-Extensions
+      in: header
+      required: false
+      schema:
+        type: string
+        minLength: 1
+      description: Declares requested extension namespaces. Extension fields remain namespaced and MUST NOT override core fields.
   headers:
     ProtocolVersionResponseHeader:
       description: Jarvis protocol version used by the response.

--- a/docs/planning/ROADMAP.md
+++ b/docs/planning/ROADMAP.md
@@ -95,21 +95,24 @@ adapters.
 ## Release Strategy
 
 ```txt
-v0.1 Protocol Alpha
+v0.1 target: Protocol Alpha
   locked vocabulary, OpenAPI 3.1 contract, event envelope, and golden-path
   conformance
 
-v0.2 Evidence And Learning Beta
+v0.2 target: Evidence And Learning Beta
   stronger EvidenceManifest, Contribution, MemoryProposal, and SkillProposal
   contracts
 
-v0.3 Ecosystem Conformance
+v0.3 target: Ecosystem Conformance
   host conformance suite, examples, and compatibility-mapping records
 
-v1.0 Stable Protocol
+v1.0 target: Stable Protocol
   stable public protocol, compatibility rules, export format, and migration
   policy
 ```
+
+These are roadmap targets. They are not release, tag, certification,
+long-term-support, governance, or adoption claims.
 
 ## v0.1 Protocol Alpha
 
@@ -412,7 +415,7 @@ Done when:
 - compatible hosts exchange WorkSession evidence without sharing
   infrastructure
 
-## v1.0 Stable Protocol
+## v1.0 Target: Stable Protocol
 
 Goal: freeze the protocol surface.
 

--- a/docs/planning/v0.1-acceptance-review/README.md
+++ b/docs/planning/v0.1-acceptance-review/README.md
@@ -57,6 +57,7 @@ The acceptance review starts from:
 - [../../examples/existing-agent-compatibility.md](../../examples/existing-agent-compatibility.md)
 - [../../examples/protocol-records.md](../../examples/protocol-records.md)
 - [protocol-publication-discipline.md](./protocol-publication-discipline.md)
+- [acceptance-decision.md](./acceptance-decision.md)
 - [../../../README.md](../../../README.md)
 - [../../../demo/index.html](../../../demo/index.html)
 - [../../../demo/assets/app.js](../../../demo/assets/app.js)
@@ -111,6 +112,10 @@ resolved-finding log
 acceptance decision record
 next-phase entry notes
 ```
+
+The acceptance decision record starts as pending in
+[acceptance-decision.md](./acceptance-decision.md). Gate 9 updates it after all
+acceptance gates pass and every blocker is resolved.
 
 The review rejects any attempt to turn Jarvis into an agent framework, runtime,
 host product, adapter layer, tool executor, UI surface, auth system, storage

--- a/docs/planning/v0.1-acceptance-review/acceptance-decision.md
+++ b/docs/planning/v0.1-acceptance-review/acceptance-decision.md
@@ -1,0 +1,25 @@
+# v0.1 Acceptance Decision Record
+
+Status: pending Gate 9.
+
+Current decision state: not accepted.
+
+Jarvis v0.1 is not accepted, released, tagged, certified, or claimed as
+production adopted by this record.
+
+Gate 9 finalizes this record after every acceptance gate passes and every
+blocker is resolved.
+
+The final decision record MUST include:
+
+```txt
+accepted gates
+resolved blockers
+future-work deferrals outside acceptance gates
+remaining risks
+release notes required before tag
+next-phase entry scope
+```
+
+This pending record exists so public v0.1 status stays consistent during Gate 8
+publication review.

--- a/docs/planning/v0.1-acceptance-review/gate-8-protocol-publication-discipline-audit.md
+++ b/docs/planning/v0.1-acceptance-review/gate-8-protocol-publication-discipline-audit.md
@@ -1,0 +1,229 @@
+# Gate 8 Protocol Publication Discipline Audit
+
+Status: pass.
+
+Review date: 2026-06-30.
+
+Branch: `codex/v0.1-gate-8-publication-discipline-audit`.
+
+Base commit audited: `5fc2651`.
+
+Working-tree audit state: Gate 8 audit artifact and publication-discipline
+tightening on top of `5fc2651`.
+
+Decision: Gate 8 passes. Public protocol materials use consistent v0.1 status
+language, precise conformance claim language, visible release-readiness gaps,
+and consistent version labels.
+
+## Scope
+
+Audited sources:
+
+- [acceptance-spec.md](./acceptance-spec.md)
+- [protocol-publication-discipline.md](./protocol-publication-discipline.md)
+- [../../../README.md](../../../README.md)
+- [../../openapi/jarvis-openapi.yaml](../../openapi/jarvis-openapi.yaml)
+- [../../architecture_brief/jarvis_protocol_architecture_brief.md](../../architecture_brief/jarvis_protocol_architecture_brief.md)
+- [../../architecture_brief/README.md](../../architecture_brief/README.md)
+- [../../conformance/README.md](../../conformance/README.md)
+- [../../conformance/checklist.md](../../conformance/checklist.md)
+- [../../conformance/fixtures/README.md](../../conformance/fixtures/README.md)
+- [../../conformance/fixtures/valid/golden-path.json](../../conformance/fixtures/valid/golden-path.json)
+- [../../examples/compatible-host-mapping.md](../../examples/compatible-host-mapping.md)
+- [../../examples/existing-agent-compatibility.md](../../examples/existing-agent-compatibility.md)
+- [../../examples/protocol-records.md](../../examples/protocol-records.md)
+- [../ROADMAP.md](../ROADMAP.md)
+- [../12-30-day-roadmap.md](../12-30-day-roadmap.md)
+- [acceptance-decision.md](./acceptance-decision.md)
+- [../../../demo/index.html](../../../demo/index.html)
+- [../../../demo/assets/app.js](../../../demo/assets/app.js)
+
+Out of scope:
+
+```txt
+SDK implementation
+adapter implementation
+wrapper implementation
+host runtime behavior
+host UI behavior
+model orchestration
+tool execution
+storage behavior
+auth behavior
+billing behavior
+scoring behavior
+payment behavior
+deployment behavior
+certification program
+governance program
+public adopter registry
+```
+
+## Source Coverage
+
+| Source group | Covered paths | Gate 8 check | Result |
+| --- | --- | --- | --- |
+| Acceptance rule | `docs/planning/v0.1-acceptance-review/acceptance-spec.md` | Gate 8 proof list and failure rule | pass |
+| Publication input | `docs/planning/v0.1-acceptance-review/protocol-publication-discipline.md` | version, claim, release-gap, extension, and contract cross-check rules | pass |
+| Public README | `README.md` | v0.1 acceptance status, protocol-only boundary, compatible implementation proof | pass |
+| OpenAPI metadata | `docs/openapi/jarvis-openapi.yaml` | `info.version: 0.1.0`, `x-jarvis-protocol.version: v0.1`, OpenAPI binding scope | pass |
+| Architecture brief | `docs/architecture_brief/` | v0.1 first-30-days status and future interoperability boundary | pass |
+| Conformance docs | `docs/conformance/` | exact proof language, fixture/checklist basis, public compatibility claim structure | pass |
+| Examples | `docs/examples/` | examples remain examples and do not make unverified compatibility claims | pass |
+| Roadmap | `docs/planning/ROADMAP.md`, `docs/planning/12-30-day-roadmap.md` | current status, roadmap-target labels, release-readiness gap entry | pass |
+| Acceptance decision status | `docs/planning/v0.1-acceptance-review/acceptance-decision.md` | pending Gate 9 status and not-accepted release status | pass |
+| Demo text | `demo/index.html`, `demo/assets/app.js` | v0.1 walkthrough label and non-normative boundary | pass |
+| OpenAPI checker | `scripts/check_openapi_contract.py` | version, optional negotiation headers, extension schema, required path/header contract | pass |
+| Acceptance audit artifact | `docs/planning/v0.1-acceptance-review/gate-8-protocol-publication-discipline-audit.md` | proof matrix, gap log, blocker ledger, reviewer evidence | pass |
+
+Every changed file belongs to a coverage row:
+
+| Changed file | Coverage row |
+| --- | --- |
+| `docs/architecture_brief/README.md` | Architecture brief |
+| `docs/conformance/checklist.md` | Conformance docs |
+| `docs/conformance/existing-agent-proof-plan.md` | Conformance docs |
+| `docs/examples/compatible-host-mapping.md` | Examples |
+| `docs/examples/existing-agent-compatibility.md` | Examples |
+| `docs/openapi/jarvis-openapi.yaml` | OpenAPI metadata |
+| `docs/planning/ROADMAP.md` | Roadmap |
+| `docs/planning/v0.1-acceptance-review/README.md` | Acceptance decision status |
+| `docs/planning/v0.1-acceptance-review/acceptance-decision.md` | Acceptance decision status |
+| `docs/planning/v0.1-acceptance-review/gate-8-protocol-publication-discipline-audit.md` | Acceptance audit artifact |
+| `docs/protocol/15-openapi-communication-binding.md` | Publication input |
+| `scripts/check_openapi_contract.py` | OpenAPI checker |
+
+## Required Proof Matrix
+
+| ID | Required proof | Evidence | Result |
+| --- | --- | --- | --- |
+| G8-01 | README, OpenAPI metadata, architecture brief, conformance docs, examples, roadmap, demo text, and acceptance decision record use consistent v0.1 status language. | `README.md`, `docs/openapi/jarvis-openapi.yaml`, `docs/architecture_brief/`, `docs/conformance/`, `docs/examples/`, `docs/planning/ROADMAP.md`, `docs/planning/12-30-day-roadmap.md`, `docs/planning/v0.1-acceptance-review/acceptance-decision.md`, `demo/` | pass |
+| G8-02 | OpenAPI `info.version`, OpenAPI `x-jarvis-protocol.version`, fixture `protocol_version`, README status, and acceptance decision status do not conflict. | `info.version: 0.1.0`, `x-jarvis-protocol.version: v0.1`, fixture `protocol_version: v0.1`, README active acceptance status | pass |
+| G8-03 | OpenAPI `info.version: 0.1.0` identifies the OpenAPI artifact version and `x-jarvis-protocol.version: v0.1` identifies the protocol line. | `docs/openapi/jarvis-openapi.yaml` | pass |
+| G8-04 | Public conformance wording uses exact proof language instead of vague compliance language. | `docs/conformance/checklist.md` | pass |
+| G8-05 | Compatibility claims include protocol version, conformance surface, fixture or checklist basis, and verification date. | `docs/conformance/checklist.md#public-compatibility-claim` | pass |
+| G8-06 | Public docs reject `certified`, `official host`, and unverified compatibility claims before future governance defines them. | `docs/planning/v0.1-acceptance-review/protocol-publication-discipline.md`, `docs/reviews/acceptance-criteria.md`, `docs/conformance/checklist.md` | pass |
+| G8-07 | Extension text preserves namespaced extensions and rejects core-field override. | `docs/protocol/15-openapi-communication-binding.md`, `docs/openapi/jarvis-openapi.yaml`, `scripts/check_openapi_contract.py`, `docs/conformance/checklist.md` | pass |
+| G8-08 | Prose docs, OpenAPI, examples, fixtures, and validator checks agree on the same contract without claiming fixture coverage for non-fixture-backed extension and capability errors. | `docs/protocol/`, `docs/openapi/jarvis-openapi.yaml`, `docs/examples/`, `docs/conformance/fixtures/`, `docs/conformance/checklist.md#non-fixture-backed-protocol-error-ids`, `scripts/check_openapi_contract.py`, `scripts/check_conformance_fixtures.py` | pass |
+| G8-09 | Release-readiness gap log classifies required publication infrastructure. | Release-readiness gap log in this audit | pass |
+| G8-10 | v0.1 public docs do not claim v1.0 stability, long-term support, foundation governance, production adoption, or certification. | public-claim scan and roadmap target wording | pass |
+| G8-11 | Research lessons stay scoped to publication discipline and do not add host implementation to Jarvis. | `protocol-publication-discipline.md`, this audit scope | pass |
+
+## Version And Status Ledger
+
+| Surface | Version or status | Gate 8 decision |
+| --- | --- | --- |
+| README status | `v0.1 acceptance review is active`; v0.1 is not accepted, released, or tagged | pass |
+| OpenAPI artifact version | `info.version: 0.1.0` | pass |
+| OpenAPI protocol line | `x-jarvis-protocol.version: v0.1` | pass |
+| Fixtures | `protocol_version: v0.1` | pass |
+| Architecture brief | `Scope: v0.1 first 30 days` | pass |
+| Roadmap | active work is v0.1 acceptance review; future release rows are roadmap targets | pass |
+| Demo | `Jarvis v0.1` walkthrough with non-normative boundary | pass |
+| Acceptance decision | `Status: pending Gate 9`; current decision state is not accepted | pass |
+
+## Release-Readiness Gap Log
+
+| Item | Current state | Classification | Reason |
+| --- | --- | --- | --- |
+| CHANGELOG | absent | next-phase deferral | v0.1 is not tagged. Release notes before tag cover the first public release record. |
+| CONTRIBUTING guide | absent | next-phase deferral | contribution workflow does not block protocol contract acceptance. |
+| SECURITY policy | absent | next-phase deferral | disclosure process is required before public tag. It does not change v0.1 protocol semantics. |
+| CITATION metadata | absent | next-phase deferral | citation metadata improves public research use. It does not block contract acceptance. |
+| license clarity | `LICENSE` present | not applicable for v0.1 | no missing license gap exists in v0.1 acceptance review. |
+| issue templates | absent | next-phase deferral | public triage templates belong to repository operations before wider adoption. |
+| PR template | absent | next-phase deferral | PR template improves maintainer workflow before wider adoption. |
+| CI workflows | GitHub Pages workflow present only | next-phase deferral | validation CI for protocol checks remains required before tag. |
+| governance process | absent | next-phase deferral | governance is required before certification, adopter registry, or official status claims. |
+| public website | GitHub Pages simulation present | not applicable for v0.1 | public website gap is not present for v0.1 acceptance; the demo remains non-normative explanation and not protocol proof. |
+| release notes | absent | next-phase deferral | release notes are required before tag. |
+| known-limit coverage | present in acceptance review and roadmap boundaries | not applicable for v0.1 | known-limit coverage gap is not present; v0.1 excludes host implementation, runtime, adapters, governance, certification, and release claims. |
+| conformance report format | public claim structure added to conformance checklist | not applicable for v0.1 | conformance report format gap is not present; claims name protocol version, conformance surface, fixture or checklist basis, and verification date. |
+
+## Source Findings
+
+No blocker finding remains.
+
+| Finding ID | Blocker ID | Severity | Source | Gate proof affected | Finding | Resolution | Status |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| G8-F1 | G8-B1 | blocker | `docs/conformance/checklist.md` | G8-04, G8-05 | Public compatibility claim structure was not present in the public conformance checklist. | Added exact claim structure requiring protocol version, conformance surface, fixture or checklist basis, and verification date. | resolved |
+| G8-F2 | G8-B2 | blocker | `docs/planning/ROADMAP.md` | G8-10 | Future release labels used milestone names that read as release claims without an explicit target boundary. | Reworded release strategy rows as roadmap targets and added a sentence rejecting release, tag, certification, long-term-support, governance, and adoption claims. | resolved |
+| G8-F3 | none | note | `docs/architecture_brief/README.md` | G8-01 | Architecture brief README used stale in-progress wording for developed artifacts. | Reworded the brief as v0.1 acceptance material and preserved the host-owned adapter boundary. | closed |
+| G8-F4 | G8-B3 | blocker | acceptance decision status | G8-01, G8-02 | Gate 8 required an acceptance decision status surface, but Gate 9 had not yet created the final decision record. | Added a pending acceptance decision record that states v0.1 is not accepted, released, tagged, certified, or production-adoption claimed. Gate 9 still owns final decision content. | resolved |
+| G8-F5 | G8-B4 | blocker | `docs/conformance/existing-agent-proof-plan.md`, `docs/examples/existing-agent-compatibility.md`, `docs/examples/compatible-host-mapping.md` | G8-04, G8-05 | Compatibility-facing docs used claim-shaped wording without protocol version, conformance surface, fixture or checklist basis, and verification date. | Added exact public compatibility claim formats and changed example condition headings from compatibility claims to example validity conditions. | resolved |
+| G8-F6 | G8-B5 | blocker | `gate-8-protocol-publication-discipline-audit.md` | G8-09 | Release-readiness rows used `pass`, which is not an allowed publication-discipline classification. | Reclassified existing non-gaps as `not applicable for v0.1` and kept missing publication infrastructure as `next-phase deferral`. | resolved |
+| G8-F7 | G8-B6 | blocker | `docs/protocol/15-openapi-communication-binding.md`, `docs/openapi/jarvis-openapi.yaml` | G8-07, G8-08 | Capability and extension request headers were present in prose but not encoded as OpenAPI parameters. | Added optional `RequiredCapabilitiesHeader` and `ExtensionsHeader` OpenAPI parameters to WorkSession read and export read operations, and updated the OpenAPI checker to enforce them. | resolved |
+| G8-F8 | G8-B7 | blocker | Gate 8 proof wording | G8-08 | The audit row overclaimed fixture-backed proof for extension and capability rejection even though those errors are non-fixture-backed in v0.1. | Clarified Gate 8 proof so extension and capability errors are checklist/OpenAPI-backed and not claimed as fixture-backed. | resolved |
+
+## Blocker List
+
+No blocker remains.
+
+| Blocker ID | Source | Gate proof failed | Resolution evidence | Status |
+| --- | --- | --- | --- | --- |
+| G8-B1 | missing public compatibility claim structure | G8-04, G8-05 | `docs/conformance/checklist.md#public-compatibility-claim` | resolved |
+| G8-B2 | ambiguous future release target wording | G8-10 | `docs/planning/ROADMAP.md#release-strategy` | resolved |
+| G8-B3 | missing acceptance decision status surface | G8-01, G8-02 | `docs/planning/v0.1-acceptance-review/acceptance-decision.md` | resolved |
+| G8-B4 | claim-shaped compatibility examples missing Gate 8 claim fields | G8-04, G8-05 | `docs/conformance/existing-agent-proof-plan.md`, `docs/examples/existing-agent-compatibility.md`, `docs/examples/compatible-host-mapping.md` | resolved |
+| G8-B5 | invalid release-readiness gap classifications | G8-09 | `docs/planning/v0.1-acceptance-review/gate-8-protocol-publication-discipline-audit.md#release-readiness-gap-log` | resolved |
+| G8-B6 | prose/OpenAPI negotiation header mismatch | G8-07, G8-08 | `docs/openapi/jarvis-openapi.yaml`, `scripts/check_openapi_contract.py` | resolved |
+| G8-B7 | overclaimed fixture-backed extension proof | G8-08 | `docs/planning/v0.1-acceptance-review/gate-8-protocol-publication-discipline-audit.md#required-proof-matrix` | resolved |
+
+## Non-Blocking Future Work
+
+These items stay outside v0.1 acceptance gates until public release preparation:
+
+- add `CHANGELOG.md`
+- add `CONTRIBUTING.md`
+- add `SECURITY.md`
+- add citation metadata
+- add issue templates
+- add PR template
+- add validation CI for local protocol checks
+- add release notes before tag
+- define governance before certification, adopter registry, or official status
+  claims
+
+## Reviewer Evidence
+
+| Reviewer | Focus | Initial finding | Resolution | Final status |
+| --- | --- | --- | --- | --- |
+| Locke | status and version consistency | no blocker; version labels and acceptance status were consistent | kept roadmap target wording because it strengthens public status clarity | no findings |
+| Popper | conformance and compatibility claim wording | compatibility proof and examples used claim-shaped language without Gate 8 claim fields | added exact public compatibility claim format and changed example conditions to validity conditions | no findings |
+| Poincare | release-readiness gaps and forbidden claims | missing pending acceptance decision record, pending reviewer/command placeholders, and invalid gap-log classifications | added pending decision record, replaced placeholders, and used only allowed gap classifications | no findings |
+| Faraday | prose, OpenAPI, fixture, and extension consistency | unresolved audit evidence, missing optional negotiation headers in OpenAPI, and overclaimed fixture-backed extension proof | added optional negotiation header parameters to OpenAPI and checker, completed evidence rows, and narrowed extension proof wording to checklist/OpenAPI-backed coverage | no findings |
+
+## Command Evidence
+
+Commands run for Gate 8:
+
+| Command | Exit status | Output summary |
+| --- | --- | --- |
+| `python3 scripts/check_protocol_wording.py` | 0 | `protocol wording ok` |
+| `python3 scripts/check_conformance_fixtures.py` | 0 | `conformance fixtures ok` |
+| `python3 scripts/check_openapi_contract.py` | 0 | `openapi contract ok` |
+| `python3 scripts/check_markdown_links.py` | 0 | `markdown links ok` |
+| `git diff --check` | 0 | no output |
+| `node --check demo/assets/app.js` | 0 | no output |
+
+## Gate 8 Decision
+
+Gate 8 status: pass.
+
+Accepted proof rows: G8-01 through G8-11.
+
+Resolved blockers: G8-B1 through G8-B7.
+
+Remaining blockers: none.
+
+Decision rationale:
+
+```txt
+Jarvis v0.1 publication discipline now records version consistency, exact
+compatibility claim structure, release-readiness gap classification,
+extension-boundary preservation, and non-normative simulation status. Public
+materials keep v0.1 in active acceptance review until Gate 9 records the final
+decision. The roadmap uses future targets without claiming release, tag,
+certification, long-term support, governance, adoption, or production status.
+Jarvis remains protocol-only.
+```

--- a/docs/protocol/15-openapi-communication-binding.md
+++ b/docs/protocol/15-openapi-communication-binding.md
@@ -342,6 +342,16 @@ PreviousHashHeader
   binds the request to `Jarvis-Previous-Event-Hash`
 ```
 
+Optional negotiation header parameters:
+
+```txt
+RequiredCapabilitiesHeader
+  binds the request to `Jarvis-Required-Capabilities`
+
+ExtensionsHeader
+  binds the request to `Jarvis-Extensions`
+```
+
 Authentication proves caller identity to the host. Authorization verifies that
 `Jarvis-Actor-Id` has authority for the requested protocol operation. Jarvis
 records the Actor and authority check result. Jarvis does not own the host

--- a/scripts/check_openapi_contract.py
+++ b/scripts/check_openapi_contract.py
@@ -121,6 +121,8 @@ REQUIRED_PARAMETERS = {
     "RequestTimestampHeader",
     "RevisionHeader",
     "PreviousHashHeader",
+    "RequiredCapabilitiesHeader",
+    "ExtensionsHeader",
 }
 
 HEADER_PARAMETER_NAMES = {
@@ -130,6 +132,11 @@ HEADER_PARAMETER_NAMES = {
     "RequestTimestampHeader": "Jarvis-Request-Timestamp",
     "RevisionHeader": "Jarvis-Expected-WorkSession-Revision",
     "PreviousHashHeader": "Jarvis-Previous-Event-Hash",
+}
+
+OPTIONAL_HEADER_PARAMETER_NAMES = {
+    "RequiredCapabilitiesHeader": "Jarvis-Required-Capabilities",
+    "ExtensionsHeader": "Jarvis-Extensions",
 }
 
 REQUIRED_REQUEST_BODIES = {
@@ -297,6 +304,11 @@ READ_HEADERS = {
     "ActorHeader",
 }
 
+READ_OPTIONAL_NEGOTIATION_HEADERS = {
+    "RequiredCapabilitiesHeader",
+    "ExtensionsHeader",
+}
+
 REQUIRED_OPERATIONS = {
     ("put", "/workers/{worker_id}"): {
         "operation_id": "registerWorker",
@@ -332,7 +344,7 @@ REQUIRED_OPERATIONS = {
         "operation_id": "getWorkSession",
         "operation_class": "worksession_scoped_read",
         "tag": "WorkSessions",
-        "headers": READ_HEADERS,
+        "headers": READ_HEADERS | READ_OPTIONAL_NEGOTIATION_HEADERS,
         "path_parameters": {"WorkSessionIdPath"},
         "request_body": None,
         "success_status": "200",
@@ -432,7 +444,7 @@ REQUIRED_OPERATIONS = {
         "operation_id": "exportEvidenceManifest",
         "operation_class": "export_read",
         "tag": "Evidence",
-        "headers": READ_HEADERS,
+        "headers": READ_HEADERS | READ_OPTIONAL_NEGOTIATION_HEADERS,
         "path_parameters": {"WorkSessionIdPath"},
         "request_body": None,
         "success_status": "200",
@@ -2158,6 +2170,14 @@ def main() -> int:
             return fail(f"{name} must use header name {header_name}")
         if parameter.get("required") is not True:
             return fail(f"{name} must be required")
+    for name, header_name in OPTIONAL_HEADER_PARAMETER_NAMES.items():
+        parameter = parameters[name]
+        if parameter.get("in") != "header":
+            return fail(f"{name} must be a header parameter")
+        if parameter.get("name") != header_name:
+            return fail(f"{name} must use header name {header_name}")
+        if parameter.get("required") is not False:
+            return fail(f"{name} must be optional")
     for name in ("WorkerIdPath", "ActorIdPath", "WorkSessionIdPath"):
         parameter = parameters[name]
         if parameter.get("in") != "path":


### PR DESCRIPTION
## Summary

Adds the v0.1 Gate 8 protocol publication discipline audit and a pending Gate 9 acceptance decision record.

This PR also tightens publication-facing protocol surfaces:

- records exact public compatibility claim structure in the conformance checklist and existing-agent proof plan
- changes example compatibility sections into example validity conditions so examples do not make unverified compatibility claims
- clarifies roadmap release labels as future targets, not release, tag, certification, governance, adoption, or long-term-support claims
- encodes optional `Jarvis-Required-Capabilities` and `Jarvis-Extensions` request headers in the OpenAPI read/export operations
- updates the OpenAPI checker so optional negotiation headers stay machine-checked
- records release-readiness gap classifications for v0.1 publication discipline

## Validation

- `python3 scripts/check_conformance_fixtures.py`
- `python3 scripts/check_openapi_contract.py`
- `python3 scripts/check_markdown_links.py`
- `python3 scripts/check_protocol_wording.py`
- `git diff --check`
- `node --check demo/assets/app.js`

Note: one parallel `check_conformance_fixtures.py` run exited with code 139 during final validation. A serial rerun passed with `conformance fixtures ok`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional negotiation headers for read and export operations, allowing requests to include capability and extension information.
  * Introduced a clearer acceptance review record and decision flow for v0.1 release readiness.

* **Documentation**
  * Clarified compatibility claim wording and required format across protocol and example docs.
  * Updated roadmap and architecture brief language to better distinguish targets, scope, and acceptance artifacts.
  * Added a detailed Gate 8 publication discipline audit and acceptance decision documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->