### PR TITLE
[codex] Accept v0.1 as Protocol Alpha

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,21 +224,25 @@ and shared learning.
 
 ## Current Execution Focus
 
-The active focus is the v0.1 first-30-days protocol contract.
+The active focus is post-acceptance release preparation and next-phase protocol
+specification.
 
 Protocol lock is complete. Week 2 OpenAPI contract and conformance entry work
 is complete. Week 3 protocol compatibility mapping and conformance fixtures
 are complete. Week 4 compatible examples and public story are complete.
-Current work is v0.1 acceptance review after Week 4 closeout.
+The v0.1 acceptance review is complete. Jarvis v0.1 is accepted as Protocol
+Alpha. This does not release or tag v0.1, certify Jarvis or any
+implementation, designate an official host, claim production adoption,
+establish foundation governance, or create long-term support.
 
 Work on:
 
-- v0.1 acceptance review
-- protocol implementation helper boundary
-- protocol-publication discipline
-- public-readiness gap log
+- release notes required before tag
+- release-readiness gap closure
+- protocol implementation helper boundary after acceptance
+- protocol-publication discipline after acceptance
 - additional conformance evidence only when it preserves the protocol boundary
-- next-phase specification after acceptance review
+- next-phase specification
 
 The v0.1 acceptance review starts from
 [docs/planning/v0.1-acceptance-review/README.md](./docs/planning/v0.1-acceptance-review/README.md)
@@ -251,7 +255,7 @@ Do not add or own adapters, wrappers, host behavior, or integration code in this
 repo.
 Do not add host-specific assumptions to protocol records.
 Do not reopen locked protocol decisions unless a concrete contradiction blocks
-v0.1 acceptance review.
+post-acceptance release preparation or next-phase specification.
 
 ## Wording Rules
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ and shared learning.
 
 ## Status
 
-v0.1 acceptance review is active.
-Jarvis v0.1 is not accepted, released, or tagged until the acceptance decision
-records every required gate as passed.
+Jarvis v0.1 is accepted as Protocol Alpha.
+This does not release or tag v0.1, certify Jarvis or any implementation,
+designate an official host, claim production adoption, establish foundation
+governance, or create long-term support.
 
 ## Interactive Simulation
 

--- a/docs/planning/12-30-day-roadmap.md
+++ b/docs/planning/12-30-day-roadmap.md
@@ -246,13 +246,13 @@ Daily checks:
 
 ## v0.1 Acceptance Review
 
-The 30-day proof now enters
+The 30-day proof completed
 [v0.1 acceptance review](./v0.1-acceptance-review/README.md).
 
-Acceptance review audits the full protocol contract, OpenAPI binding,
+Acceptance review audited the full protocol contract, OpenAPI binding,
 conformance surface, public examples, README, non-normative simulation
-boundary, and protocol-publication discipline before v0.1 is called Protocol
-Alpha.
+boundary, and protocol-publication discipline before v0.1 was accepted as
+Protocol Alpha.
 
 The acceptance gates are defined in
 [acceptance-spec.md](./v0.1-acceptance-review/acceptance-spec.md).
@@ -261,6 +261,9 @@ The protocol-publication discipline review is recorded in
 [protocol-publication-discipline.md](./v0.1-acceptance-review/protocol-publication-discipline.md).
 It strengthens release, versioning, conformance-claim, extension, and
 governance-gap discipline without changing Jarvis protocol semantics.
+
+The acceptance decision is recorded in
+[acceptance-decision.md](./v0.1-acceptance-review/acceptance-decision.md).
 
 ## First 72 Hours
 

--- a/docs/planning/ROADMAP.md
+++ b/docs/planning/ROADMAP.md
@@ -17,8 +17,9 @@ For the OpenAPI entry gate, see
 
 Week 1 protocol lock is complete.
 
-Current active work: [v0.1 acceptance review](./v0.1-acceptance-review/README.md)
-after Week 4 closeout.
+Current protocol status: Jarvis v0.1 is accepted as Protocol Alpha.
+
+Current active work: next-phase specification after acceptance review.
 
 Week 2 completed the OpenAPI 3.1 component syntax, path syntax, security scheme
 encoding, protocol examples, and conformance entry rules from the locked Week 1
@@ -34,6 +35,11 @@ conformance checklist, protocol record examples, and public story.
 The v0.1 acceptance review now includes protocol-publication discipline:
 version consistency, precise conformance-claim language, release-readiness gap
 logging, extension boundary checks, and governance-gap classification.
+
+Jarvis v0.1 is accepted as Protocol Alpha. This does not release or tag v0.1,
+certify Jarvis or any implementation, designate an official host, claim
+production adoption, establish foundation governance, or create long-term
+support.
 
 ## Roadmap Contract
 
@@ -92,10 +98,10 @@ run agents, orchestrate models, execute tools, own memory engines, provide UI,
 manage auth, store records, run sandboxes, schedule work, or become host
 adapters.
 
-## Release Strategy
+## Protocol Version Targets
 
 ```txt
-v0.1 target: Protocol Alpha
+v0.1 accepted: Protocol Alpha
   locked vocabulary, OpenAPI 3.1 contract, event envelope, and golden-path
   conformance
 
@@ -111,8 +117,8 @@ v1.0 target: Stable Protocol
   policy
 ```
 
-These are roadmap targets. They are not release, tag, certification,
-long-term-support, governance, or adoption claims.
+Rows after v0.1 are roadmap targets. These rows are not release, tag,
+certification, long-term-support, governance, or adoption claims.
 
 ## v0.1 Protocol Alpha
 
@@ -363,7 +369,9 @@ Done when:
 
 ## v0.1 Acceptance
 
-v0.1 is accepted when:
+Status: complete.
+
+v0.1 is accepted because:
 
 - OpenAPI contract passes the v0.1 acceptance review
 - conformance tests cover the golden path
@@ -402,7 +410,7 @@ Goal: make Jarvis implementable across independent hosts.
 Output:
 
 - host conformance suite
-- compatibility badges
+- compatibility evidence labels
 - version negotiation rules
 - migration examples
 - public implementation checklist
@@ -485,11 +493,12 @@ and example record mappers.
 1. Keep the repository protocol-only.
 2. Keep execution and cloud ownership outside the protocol.
 3. Use `11-core-protocol-objects.md`, `jarvis-openapi.yaml`, and
-   `docs/conformance/` as the source of truth for v0.1 acceptance review.
-4. Review Week 4 closeout against the OpenAPI contract, conformance fixtures,
-   public examples, README, and non-normative simulation boundary.
-5. Record public-readiness gaps before starting next-phase specification.
+   `docs/conformance/` with the accepted v0.1 decision record.
+4. Prepare release notes before any v0.1 tag.
+5. Close release-readiness gaps recorded outside the acceptance gates:
+   `CHANGELOG.md`, `CONTRIBUTING.md`, `SECURITY.md`, citation metadata, issue
+   templates, PR template, and validation CI.
 6. Keep adapter code, wrappers, host behavior, and integration code outside
    Jarvis.
 7. Keep every Jarvis SDK discussion limited to protocol implementation helpers.
-8. Complete protocol-publication discipline review before v0.1 acceptance.
+8. Start next-phase specification only inside protocol-owned scope.

--- a/docs/planning/v0.1-acceptance-review/README.md
+++ b/docs/planning/v0.1-acceptance-review/README.md
@@ -1,12 +1,12 @@
 # v0.1 Acceptance Review
 
-Status: active.
+Status: complete; Jarvis v0.1 is accepted as Protocol Alpha.
 
-This review decides whether Jarvis v0.1 is ready to be called Protocol Alpha.
+This review accepts Jarvis v0.1 as Protocol Alpha.
 
-The review starts after Week 4 closeout. It audits the full protocol contract,
-OpenAPI binding, conformance surface, public examples, README, and
-non-normative simulation boundary before any v0.1 acceptance decision.
+The review started after Week 4 closeout. It audited the full protocol
+contract, OpenAPI binding, conformance surface, public examples, README, and
+non-normative simulation boundary before the v0.1 acceptance decision.
 
 Jarvis records protocol proof. Hosts own native execution.
 
@@ -95,11 +95,11 @@ implementation scope.
 
 ## Acceptance Rule
 
-v0.1 is accepted only when every acceptance gate in
-[acceptance-spec.md](./acceptance-spec.md) passes.
+v0.1 is accepted because every acceptance gate in
+[acceptance-spec.md](./acceptance-spec.md) passed.
 
-The acceptance decision MUST be a separate record. This README starts the
-review. It does not accept v0.1.
+The acceptance decision is recorded in
+[acceptance-decision.md](./acceptance-decision.md).
 
 ## Review Output
 
@@ -113,9 +113,10 @@ acceptance decision record
 next-phase entry notes
 ```
 
-The acceptance decision record starts as pending in
-[acceptance-decision.md](./acceptance-decision.md). Gate 9 updates it after all
-acceptance gates pass and every blocker is resolved.
+The acceptance decision record marks Jarvis v0.1 accepted as Protocol Alpha.
+This does not release or tag v0.1, certify Jarvis or any implementation,
+designate an official host, claim production adoption, establish foundation
+governance, or create long-term support.
 
 The review rejects any attempt to turn Jarvis into an agent framework, runtime,
 host product, adapter layer, tool executor, UI surface, auth system, storage

--- a/docs/planning/v0.1-acceptance-review/acceptance-decision.md
+++ b/docs/planning/v0.1-acceptance-review/acceptance-decision.md
@@ -1,25 +1,167 @@
 # v0.1 Acceptance Decision Record
 
-Status: pending Gate 9.
+Status: accepted Protocol Alpha.
 
-Current decision state: not accepted.
+Decision date: 2026-06-30.
 
-Jarvis v0.1 is not accepted, released, tagged, certified, or claimed as
-production adopted by this record.
+Current decision state: accepted Protocol Alpha.
 
-Gate 9 finalizes this record after every acceptance gate passes and every
-blocker is resolved.
+Jarvis v0.1 is accepted as Protocol Alpha. This does not release or tag v0.1,
+certify Jarvis or any implementation, designate an official host, claim
+production adoption, establish foundation governance, or create long-term
+support.
 
-The final decision record MUST include:
+Gate 9 records this decision because every acceptance gate passed, every
+blocker is resolved, and every accepted gate links evidence.
 
-```txt
-accepted gates
-resolved blockers
-future-work deferrals outside acceptance gates
-remaining risks
-release notes required before tag
-next-phase entry scope
-```
+## Accepted Gates
 
-This pending record exists so public v0.1 status stays consistent during Gate 8
-publication review.
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| Gate 1: Protocol Contract | accepted | [gate-1-protocol-contract-audit.md](./gate-1-protocol-contract-audit.md) |
+| Gate 2: OpenAPI Binding | accepted | [gate-2-openapi-binding-audit.md](./gate-2-openapi-binding-audit.md) |
+| Gate 3: Conformance Surface | accepted | [gate-3-conformance-surface-audit.md](./gate-3-conformance-surface-audit.md) |
+| Gate 4: Compatibility Examples | accepted | [gate-4-compatibility-examples-audit.md](./gate-4-compatibility-examples-audit.md) |
+| Gate 5: Public README And Non-Normative Simulation | accepted | [gate-5-public-readme-simulation-audit.md](./gate-5-public-readme-simulation-audit.md) |
+| Gate 6: Boundary And Wording | accepted | [gate-6-boundary-wording-audit.md](./gate-6-boundary-wording-audit.md) |
+| Gate 7: Local Validation | accepted | [gate-7-local-validation-audit.md](./gate-7-local-validation-audit.md) |
+| Gate 8: Protocol Publication Discipline | accepted | [gate-8-protocol-publication-discipline-audit.md](./gate-8-protocol-publication-discipline-audit.md) |
+
+## Resolved Blockers
+
+| Gate | Resolved blockers |
+| --- | --- |
+| Gate 1 | G1-B1, G1-B2, G1-B3, G1-B4, G1-B5, G1-B6 |
+| Gate 2 | G2-B1, G2-B2, G2-B3 |
+| Gate 3 | G3-B1, G3-B2, G3-B3, G3-B4, G3-B5, G3-B6, G3-B7 |
+| Gate 4 | G4-B1, G4-B2, G4-B3, G4-B4 |
+| Gate 5 | G5-B1, G5-B2, G5-B3, G5-B4, G5-B5, G5-B6, G5-B7 |
+| Gate 6 | G6-B1, G6-B2, G6-B3, G6-B4, G6-B5, G6-B6, G6-B7, G6-B8 |
+| Gate 7 | none |
+| Gate 8 | G8-B1, G8-B2, G8-B3, G8-B4, G8-B5, G8-B6, G8-B7 |
+
+No acceptance-gate blocker remains.
+
+## Future-Work Deferrals Outside Acceptance Gates
+
+These items stay outside v0.1 acceptance. They belong to release preparation,
+repository operations, or next-phase protocol work:
+
+- `CHANGELOG.md`
+- `CONTRIBUTING.md`
+- `SECURITY.md`
+- citation metadata
+- issue templates
+- PR template
+- validation CI for local protocol checks
+- release notes before tag
+- governance before certification, adopter registry, official-host status,
+  foundation-governance, production-adoption, or long-term-support claims
+- next-phase protocol specification
+
+## Remaining Risks
+
+No protocol-acceptance risk remains inside the v0.1 acceptance gates.
+
+Remaining risks are outside the acceptance gates:
+
+- Execution creep: Hosts own execution, cloud, isolation, storage, queues, and
+  deployment.
+- Host implementation creep: Hosts implement Jarvis. Jarvis does not own UI,
+  identity, operations, or enterprise controls.
+- Task-system creep: Task systems own tasks, rubrics, evaluation, and
+  settlement. Jarvis owns the collaboration record that external reviewers and
+  systems evaluate.
+- Weak evidence: EvidenceManifest entries are captured during the WorkSession.
+- Silent learning: learning becomes MemoryProposal or SkillProposal until
+  reviewed.
+- SDK creep: Jarvis SDK work stays limited to protocol implementation helpers.
+- Release-status drift: release notes before tag MUST record known limits and
+  MUST NOT claim release, certification, official host status, production
+  adoption, governance, or long-term support.
+- Foundation-governance drift: governance claims are rejected until governance
+  exists.
+
+## Release Notes Required Before Tag
+
+Before any v0.1 tag, release notes MUST record:
+
+- Jarvis v0.1 is Protocol Alpha for governed human-agent collaboration and
+  shared learning.
+- OpenAPI `info.version: 0.1.0` identifies the OpenAPI artifact.
+- OpenAPI `x-jarvis-protocol.version: v0.1` identifies the protocol line.
+- Gates 1 through 8 passed and all recorded blockers are resolved.
+- compatibility claims require protocol version, conformance surface, fixture
+  or checklist basis, and verification date.
+- Hosts own UI, auth, storage, queues, execution, isolation, models, tools,
+  billing, monitoring, deployment, and host workflow.
+- Jarvis v0.1 does not include SDK implementation, adapters, wrappers, runtime
+  behavior, host UI, model orchestration, tool execution, storage behavior,
+  auth behavior, billing behavior, scoring behavior, payment behavior,
+  deployment behavior, certification, adopter registry, official host status,
+  long-term support, or production adoption claims.
+- Release-readiness deferrals remain visible.
+
+## Next-Phase Entry Scope
+
+Next-phase work starts only after preserving the v0.1 protocol boundary.
+
+Allowed next-phase entry:
+
+- public release preparation: release notes, `SECURITY.md`, validation CI, and
+  visible release-readiness gap tracking
+- repository participation readiness: `CHANGELOG.md`, `CONTRIBUTING.md`,
+  citation metadata, issue templates, and PR template
+- v0.2 Evidence And Learning Beta: richer Contribution taxonomy, stronger
+  EvidenceManifest export profiles, limitation and uncertainty records,
+  LearningRecord, MemoryProposal, and SkillProposal review-state rules, memory
+  scope compatibility rules, and skill proposal compatibility rules
+- governance-gap tracking and no-claim rules before any external governance,
+  certification, adopter registry, or official-status claim exists outside
+  Jarvis
+- protocol implementation helper boundary: SDK work remains limited to
+  protocol types, OpenAPI clients, event helpers, hash-chain helpers, header
+  helpers, validation helpers, EvidenceManifest helpers, conformance fixture
+  runners, protocol error helpers, and example record mappers
+
+Rejected next-phase entry:
+
+- host runtime implementation
+- agent framework implementation
+- model orchestration
+- tool execution
+- storage backend
+- auth provider
+- billing system
+- scoring system
+- deployment stack
+- adapter or wrapper code in this repository
+
+## Decision
+
+Jarvis v0.1 is accepted as Protocol Alpha.
+
+Jarvis remains the human-agent collaboration and learning-loop protocol.
+Hosts own implementation.
+
+## Reviewer Evidence
+
+| Reviewer | Focus | Initial finding | Resolution | Final status |
+| --- | --- | --- | --- | --- |
+| Goodall | gate evidence and blocker status | acceptance-decision record needed final accepted state and required Decision Rule fields | final record now includes accepted gates, resolved blockers, deferrals, risks, release-note requirements, next-phase scope, and evidence links | no findings |
+| Harvey | public status consistency | public status surfaces needed direct accepted Protocol Alpha language | README, roadmap, acceptance review README, and decision record now use accepted Protocol Alpha status without release or tag claims | no findings |
+| Peirce | release, tag, certification, public-status boundary | no-claim language omitted official host, foundation governance, and long-term support | public status surfaces now reject release, tag, certification, official host, production adoption, foundation governance, and long-term support claims | no findings |
+| Aquinas | future-work deferrals, remaining risks, release notes, next-phase scope | no Gate 9 blocker; provided concrete entries | decision record includes deferrals, risks, release-note requirements, and next-phase entry scope | no findings |
+
+## Command Evidence
+
+Commands run for Gate 9:
+
+| Command | Exit status | Output summary |
+| --- | --- | --- |
+| `python3 scripts/check_conformance_fixtures.py` | 0 | `conformance fixtures ok` |
+| `python3 scripts/check_openapi_contract.py` | 0 | `openapi contract ok` |
+| `python3 scripts/check_markdown_links.py` | 0 | `markdown links ok` |
+| `python3 scripts/check_protocol_wording.py` | 0 | `protocol wording ok` |
+| `git diff --check` | 0 | no output |
+| `node --check demo/assets/app.js` | 0 | no output |

--- a/docs/planning/v0.1-acceptance-review/protocol-publication-discipline.md
+++ b/docs/planning/v0.1-acceptance-review/protocol-publication-discipline.md
@@ -1,6 +1,6 @@
 # Protocol Publication Discipline
 
-Status: active input.
+Status: adopted input.
 
 Review date: 2026-06-30.
 


### PR DESCRIPTION
## Summary
- accepts Jarvis v0.1 as Protocol Alpha in the Gate 9 decision record
- updates public status surfaces after acceptance review completion
- records accepted gates, resolved blockers, deferred future work, remaining risks, required release-note content, next-phase entry scope, reviewer evidence, and command evidence

## Boundary
- does not release or tag v0.1
- does not certify Jarvis or any implementation
- does not designate an official host, claim production adoption, establish foundation governance, or create long-term support
- keeps host runtime, UI, auth, storage, model calls, tool execution, scoring, payment, and adapter work outside Jarvis

## Reviewer agents
- Pauli: gate evidence and blocker ledger
- Carver: public status consistency
- Hume: boundary and next-phase creep
- Maxwell: direct wording and local validation evidence

## Validation
- python3 scripts/check_conformance_fixtures.py
- python3 scripts/check_openapi_contract.py
- python3 scripts/check_markdown_links.py
- python3 scripts/check_protocol_wording.py
- git diff --check
- node --check demo/assets/app.js