### PR TITLE
[codex] Add v0.1 release readiness

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,4 +3,3 @@ contact_links:
   - name: Security issue
     url: https://github.com/Flow-Research/jarvis/security/advisories/new
     about: Report protocol security issues privately.
-

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security issue
+    url: https://github.com/Flow-Research/jarvis/security/advisories/new
+    about: Report protocol security issues privately.
+

--- a/.github/ISSUE_TEMPLATE/conformance-failure.yml
+++ b/.github/ISSUE_TEMPLATE/conformance-failure.yml
@@ -1,0 +1,36 @@
+name: Conformance failure
+description: Report a conformance fixture, validator, or OpenAPI contract failure.
+title: "[conformance] "
+labels:
+  - conformance
+body:
+  - type: textarea
+    id: failing_check
+    attributes:
+      label: Failing check
+      description: Paste the command and failure output.
+      placeholder: python3 scripts/check_conformance_fixtures.py
+    validations:
+      required: true
+  - type: textarea
+    id: affected_files
+    attributes:
+      label: Affected files
+      description: List the fixture, OpenAPI, docs, or script files involved.
+    validations:
+      required: true
+  - type: textarea
+    id: expected_protocol_behavior
+    attributes:
+      label: Expected protocol behavior
+      description: State the protocol rule the check enforces.
+    validations:
+      required: true
+  - type: checkboxes
+    id: boundary
+    attributes:
+      label: Boundary confirmation
+      options:
+        - label: This issue is about protocol conformance, not host implementation behavior.
+          required: true
+

--- a/.github/ISSUE_TEMPLATE/conformance-failure.yml
+++ b/.github/ISSUE_TEMPLATE/conformance-failure.yml
@@ -33,4 +33,3 @@ body:
       options:
         - label: This issue is about protocol conformance, not host implementation behavior.
           required: true
-

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -25,4 +25,3 @@ body:
       description: Provide direct replacement wording when available.
     validations:
       required: false
-

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,28 @@
+name: Documentation issue
+description: Report unclear Jarvis protocol documentation.
+title: "[docs] "
+labels:
+  - documentation
+body:
+  - type: textarea
+    id: page
+    attributes:
+      label: Page or section
+      description: Link or name the documentation page and section.
+    validations:
+      required: true
+  - type: textarea
+    id: issue
+    attributes:
+      label: Issue
+      description: Describe the unclear wording, broken link, or protocol contradiction.
+    validations:
+      required: true
+  - type: textarea
+    id: direct_wording
+    attributes:
+      label: Direct protocol wording
+      description: Provide direct replacement wording when available.
+    validations:
+      required: false
+

--- a/.github/ISSUE_TEMPLATE/protocol-gap.yml
+++ b/.github/ISSUE_TEMPLATE/protocol-gap.yml
@@ -37,4 +37,3 @@ body:
       options:
         - label: This issue does not request host runtime, UI, auth, storage, billing, model orchestration, tool execution, scoring, payment, deployment, adapter, or wrapper work.
           required: true
-

--- a/.github/ISSUE_TEMPLATE/protocol-gap.yml
+++ b/.github/ISSUE_TEMPLATE/protocol-gap.yml
@@ -1,0 +1,40 @@
+name: Protocol gap
+description: Report a missing or unclear Jarvis protocol rule.
+title: "[protocol-gap] "
+labels:
+  - protocol
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for protocol contract gaps only.
+        Jarvis does not own host runtime, UI, auth, storage, billing, model orchestration, tool execution, scoring, payment, deployment, adapters, or wrappers.
+  - type: textarea
+    id: protocol_surface
+    attributes:
+      label: Protocol surface
+      description: Name the affected protocol object, lifecycle rule, OpenAPI operation, conformance fixture, or wording rule.
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: Describe the missing, ambiguous, or conflicting protocol rule.
+    validations:
+      required: true
+  - type: textarea
+    id: expected_rule
+    attributes:
+      label: Expected rule
+      description: State the direct protocol rule that resolves the gap.
+    validations:
+      required: true
+  - type: checkboxes
+    id: boundary
+    attributes:
+      label: Boundary confirmation
+      options:
+        - label: This issue does not request host runtime, UI, auth, storage, billing, model orchestration, tool execution, scoring, payment, deployment, adapter, or wrapper work.
+          required: true
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+## Summary
+
+- 
+
+## Protocol Surface
+
+- 
+
+## Boundary Check
+
+- [ ] This change keeps Jarvis protocol-only.
+- [ ] This change does not add host runtime, UI, auth, storage, billing, model orchestration, tool execution, scoring, payment, deployment, adapter, or wrapper code.
+
+## Compatibility Impact
+
+- 
+
+## Conformance Impact
+
+- 
+
+## Validation
+
+- [ ] `python3 scripts/check_conformance_fixtures.py`
+- [ ] `python3 scripts/check_openapi_contract.py`
+- [ ] `python3 scripts/check_markdown_links.py`
+- [ ] `python3 scripts/check_protocol_wording.py`
+- [ ] `git diff --check`
+- [ ] `node --check demo/assets/app.js` if demo JavaScript changed
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,10 @@
 ## Summary
 
-- 
+-
 
 ## Protocol Surface
 
-- 
+-
 
 ## Boundary Check
 
@@ -13,11 +13,11 @@
 
 ## Compatibility Impact
 
-- 
+-
 
 ## Conformance Impact
 
-- 
+-
 
 ## Validation
 
@@ -27,4 +27,3 @@
 - [ ] `python3 scripts/check_protocol_wording.py`
 - [ ] `git diff --check`
 - [ ] `node --check demo/assets/app.js` if demo JavaScript changed
-

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,52 @@
+name: Validate Jarvis protocol
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Python dependencies
+        run: python -m pip install pyyaml
+
+      - name: Validate conformance fixtures
+        run: python3 scripts/check_conformance_fixtures.py
+
+      - name: Validate OpenAPI contract
+        run: python3 scripts/check_openapi_contract.py
+
+      - name: Validate Markdown links
+        run: python3 scripts/check_markdown_links.py
+
+      - name: Validate protocol wording
+        run: python3 scripts/check_protocol_wording.py
+
+      - name: Check committed whitespace
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch origin "${{ github.base_ref }}" --depth=1
+            git diff --check "origin/${{ github.base_ref }}...HEAD"
+          else
+            git diff-tree --check --no-commit-id --root -r HEAD
+          fi
+
+      - name: Validate demo JavaScript syntax
+        run: node --check demo/assets/app.js

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -40,10 +41,13 @@ jobs:
         run: python3 scripts/check_protocol_wording.py
 
       - name: Check committed whitespace
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            git fetch origin "${{ github.base_ref }}" --depth=1
-            git diff --check "origin/${{ github.base_ref }}...HEAD"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            git fetch origin "$BASE_REF" --depth=1
+            git diff --check "origin/$BASE_REF...HEAD"
           else
             git diff-tree --check --no-commit-id --root -r HEAD
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+All notable Jarvis protocol changes are recorded here.
+
+## v0.1.0 - Protocol Alpha
+
+Status: planned tag.
+
+Jarvis v0.1 is accepted as Protocol Alpha by the v0.1 acceptance decision.
+This changelog entry prepares the public tag. It does not release, tag,
+certify, designate an official host, claim production adoption, establish
+foundation governance, or create long-term support.
+
+### Added
+
+- Human-agent collaboration and shared-learning thesis.
+- Core protocol object model:
+  `Worker`, `Actor`, `HumanWorker`, `AgentWorker`, `WorkSession`,
+  `JarvisEvent`, `Policy`, `PolicyDecision`, `Request`, `Review`, `Takeover`,
+  `Contribution`, `EvidenceManifest`, `LearningRecord`, `MemoryProposal`,
+  `SkillProposal`, and `OutcomeReport`.
+- Request, Review, ApprovalScope, and Takeover lifecycle rules.
+- Contribution, evidence, governed learning, memory proposal, skill proposal,
+  and outcome report contracts.
+- OpenAPI 3.1 communication binding.
+- Zero-trust mutation headers and protocol error envelope.
+- Conformance checklist, golden-path fixture, invalid fixtures, and fixture
+  validator.
+- Existing-agent compatibility mapping and protocol-record examples.
+- Public non-normative simulation.
+- v0.1 acceptance review with Gates 1 through 8 accepted and Gate 9 decision
+  recorded.
+
+### Boundary
+
+- Hosts own UI, auth, storage, queues, execution, isolation, models, tools,
+  billing, monitoring, deployment, and host workflow.
+- Jarvis does not include SDK implementation, adapters, wrappers, runtime
+  behavior, host UI, model orchestration, tool execution, storage behavior,
+  auth behavior, billing behavior, scoring behavior, payment behavior, or
+  deployment behavior.
+
+### Validation
+
+- `python3 scripts/check_conformance_fixtures.py`
+- `python3 scripts/check_openapi_contract.py`
+- `python3 scripts/check_markdown_links.py`
+- `python3 scripts/check_protocol_wording.py`
+- `git diff --check`
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,4 +47,3 @@ foundation governance, or create long-term support.
 - `python3 scripts/check_markdown_links.py`
 - `python3 scripts/check_protocol_wording.py`
 - `git diff --check`
-

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,11 @@
+cff-version: 1.2.0
+message: "If you use Jarvis, cite the repository release for the protocol version you used."
+title: "Jarvis Human-Agent Collaboration and Learning-Loop Protocol"
+type: software
+authors:
+  - name: "Flow Research"
+version: "0.1.0-alpha"
+repository-code: "https://github.com/Flow-Research/jarvis"
+url: "https://github.com/Flow-Research/jarvis"
+license: "MIT"
+abstract: "Jarvis is the human-agent collaboration and learning-loop protocol for governed WorkSessions, reviewable Requests, attributable Contributions, portable EvidenceManifest records, and governed shared Learning."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,4 +84,3 @@ Soft protocol wording is a defect. The wording guard enforces this rule.
 
 Existing agents remain first-class. A compatible implementation emits Jarvis
 protocol records without rewriting the agent as a Jarvis-owned agent.
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,87 @@
+# Contributing
+
+Jarvis accepts contributions that strengthen the human-agent collaboration and
+learning-loop protocol.
+
+## Contribution Scope
+
+Accepted contribution scope:
+
+- protocol object definitions
+- lifecycle rules
+- OpenAPI 3.1 communication binding
+- protocol error definitions
+- conformance fixtures
+- conformance validators
+- compatible protocol examples
+- public protocol documentation
+- release-readiness documentation
+
+Rejected contribution scope:
+
+- host runtime implementation
+- agent framework implementation
+- model orchestration
+- tool execution
+- storage backend
+- auth provider
+- billing system
+- scoring system
+- payment system
+- deployment stack
+- adapter or wrapper code in this repository
+
+## Required Local Checks
+
+Every protocol PR MUST run:
+
+```txt
+python3 scripts/check_conformance_fixtures.py
+python3 scripts/check_openapi_contract.py
+python3 scripts/check_markdown_links.py
+python3 scripts/check_protocol_wording.py
+git diff --check
+```
+
+Fixture changes MUST run:
+
+```txt
+python3 scripts/check_conformance_fixtures.py
+```
+
+Demo JavaScript changes MUST run:
+
+```txt
+node --check demo/assets/app.js
+```
+
+## Pull Request Requirements
+
+Every PR MUST state:
+
+- protocol surface changed
+- reason for the change
+- compatibility impact
+- conformance impact
+- validation commands run
+
+Every PR MUST keep Jarvis protocol-only. Hosts own implementation details.
+
+## Wording Requirement
+
+Use direct protocol language:
+
+```txt
+Jarvis defines...
+Hosts own...
+Compatible implementations MUST...
+The protocol rejects...
+```
+
+Soft protocol wording is a defect. The wording guard enforces this rule.
+
+## Compatibility Requirement
+
+Existing agents remain first-class. A compatible implementation emits Jarvis
+protocol records without rewriting the agent as a Jarvis-owned agent.
+

--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ This does not release or tag v0.1, certify Jarvis or any implementation,
 designate an official host, claim production adoption, establish foundation
 governance, or create long-term support.
 
+Release preparation lives in:
+
+- [CHANGELOG.md](./CHANGELOG.md)
+- [CONTRIBUTING.md](./CONTRIBUTING.md)
+- [SECURITY.md](./SECURITY.md)
+- [docs/releases/v0.1.0.md](./docs/releases/v0.1.0.md)
+
 ## Interactive Simulation
 
 The simulation is non-normative public explanation. It is not protocol proof
@@ -336,6 +343,8 @@ v0.1 acceptance requires proof for this loop.
   planning sheets.
 - [docs/reviews/](./docs/reviews/) - protocol readiness and acceptance review
   criteria.
+- [docs/releases/](./docs/releases/) - protocol release notes and tag
+  readiness.
 
 ## Local Checks
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,76 @@
+# Security
+
+Jarvis defines protocol security requirements. Hosts own implementation
+security.
+
+## Protocol Security Boundary
+
+Jarvis owns:
+
+- required protocol headers
+- Actor identity references
+- Actor authority checks
+- WorkSession revision checks
+- previous event hash checks
+- idempotency requirements
+- request timestamp requirements
+- host-private export exclusions
+- protocol error envelope
+
+Hosts own:
+
+- identity provider
+- authentication backend
+- authorization backend
+- credential storage
+- network security
+- runtime isolation
+- model execution
+- tool execution
+- storage security
+- deployment security
+- monitoring and incident response
+
+## Reporting Security Issues
+
+Report protocol security issues through a private maintainer channel until a
+public security advisory process exists.
+
+Do not open a public issue for a vulnerability that exposes credentials,
+private keys, private records, or exploitable security details.
+
+## Supported Security Scope
+
+Current security support covers Jarvis v0.1 protocol text, OpenAPI binding,
+conformance fixtures, validators, and public examples.
+
+Jarvis v0.1 does not provide long-term support, implementation security
+certification, host certification, or production-adoption guarantees.
+
+## Required Security Checks
+
+Every WorkSession-scoped mutating operation requires:
+
+```txt
+Jarvis-Protocol-Version
+Jarvis-Actor-Id
+Jarvis-Idempotency-Key
+Jarvis-Request-Timestamp
+Jarvis-Expected-WorkSession-Revision
+Jarvis-Previous-Event-Hash
+```
+
+Every non-WorkSession protocol mutation requires:
+
+```txt
+Jarvis-Protocol-Version
+Jarvis-Actor-Id
+Jarvis-Idempotency-Key
+Jarvis-Request-Timestamp
+```
+
+Every EvidenceManifest export excludes host-private fields, credentials,
+secrets, raw runtime state, host-only database ids, deployment details, billing
+data, private scores, UI state, raw auth tokens, provider secrets, session
+cookies, and private keys.
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -73,4 +73,3 @@ Every EvidenceManifest export excludes host-private fields, credentials,
 secrets, raw runtime state, host-only database ids, deployment details, billing
 data, private scores, UI state, raw auth tokens, provider secrets, session
 cookies, and private keys.
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -65,6 +65,13 @@ The architecture brief packages the protocol architecture into a shareable PDF.
 - [architecture_brief/jarvis_protocol_architecture_brief.md](./architecture_brief/jarvis_protocol_architecture_brief.md)
 - [architecture_brief/jarvis_protocol_architecture_brief.pdf](./architecture_brief/jarvis_protocol_architecture_brief.pdf)
 
+## Releases
+
+Release docs record protocol scope, validation requirements, and tag readiness.
+
+- [releases/README.md](./releases/README.md)
+- [releases/v0.1.0.md](./releases/v0.1.0.md)
+
 ## Readiness
 
 Readiness docs lock OpenAPI entry criteria and acceptance criteria without

--- a/docs/planning/ROADMAP.md
+++ b/docs/planning/ROADMAP.md
@@ -21,6 +21,17 @@ Current protocol status: Jarvis v0.1 is accepted as Protocol Alpha.
 
 Current active work: next-phase specification after acceptance review.
 
+Release-readiness work for the v0.1.0 tag tracks:
+
+- changelog
+- contribution rules
+- security policy
+- citation metadata
+- issue templates
+- PR template
+- validation CI
+- release notes before tag
+
 Week 2 completed the OpenAPI 3.1 component syntax, path syntax, security scheme
 encoding, protocol examples, and conformance entry rules from the locked Week 1
 protocol decisions.
@@ -494,10 +505,8 @@ and example record mappers.
 2. Keep execution and cloud ownership outside the protocol.
 3. Use `11-core-protocol-objects.md`, `jarvis-openapi.yaml`, and
    `docs/conformance/` with the accepted v0.1 decision record.
-4. Prepare release notes before any v0.1 tag.
-5. Close release-readiness gaps recorded outside the acceptance gates:
-   `CHANGELOG.md`, `CONTRIBUTING.md`, `SECURITY.md`, citation metadata, issue
-   templates, PR template, and validation CI.
+4. Merge release-readiness files before any v0.1 tag.
+5. Run local validation and GitHub validation CI before the tag.
 6. Keep adapter code, wrappers, host behavior, and integration code outside
    Jarvis.
 7. Keep every Jarvis SDK discussion limited to protocol implementation helpers.

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -4,4 +4,3 @@ Jarvis release notes record protocol scope, validation requirements, and public
 status for each protocol tag.
 
 - [v0.1.0.md](./v0.1.0.md) - Protocol Alpha release notes prepared before tag.
-

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -1,0 +1,7 @@
+# Releases
+
+Jarvis release notes record protocol scope, validation requirements, and public
+status for each protocol tag.
+
+- [v0.1.0.md](./v0.1.0.md) - Protocol Alpha release notes prepared before tag.
+

--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -1,0 +1,85 @@
+# Jarvis v0.1.0 Release Notes
+
+Status: release notes prepared before tag.
+
+Jarvis v0.1.0 is Protocol Alpha for governed human-agent collaboration and
+shared learning.
+
+These release notes do not release, tag, certify, designate an official host,
+claim production adoption, establish foundation governance, or create long-term
+support.
+
+## Protocol Identity
+
+- OpenAPI `info.version: 0.1.0` identifies the OpenAPI artifact.
+- OpenAPI `x-jarvis-protocol.version: v0.1` identifies the protocol line.
+- Jarvis v0.1 is accepted as Protocol Alpha by
+  [acceptance-decision.md](../planning/v0.1-acceptance-review/acceptance-decision.md).
+
+## Included In v0.1.0
+
+- HumanWorker and AgentWorker collaboration model.
+- WorkSession as the durable source of truth.
+- Policy-governed AgentWorker action through PolicyDecision.
+- Request, Review, ApprovalScope, and Takeover control-plane rules.
+- Contribution records.
+- EvidenceManifest export rules.
+- LearningRecord, MemoryProposal, and SkillProposal governance.
+- OutcomeReport feedback ingress.
+- OpenAPI 3.1 communication binding.
+- Required protocol headers.
+- Protocol error envelope.
+- Conformance checklist and fixtures.
+- Compatible protocol examples.
+- Non-normative public simulation.
+
+## Not Included In v0.1.0
+
+- SDK implementation.
+- host runtime.
+- adapters or wrappers.
+- model orchestration.
+- tool execution.
+- storage backend.
+- auth provider.
+- UI implementation.
+- billing behavior.
+- scoring behavior.
+- payment behavior.
+- deployment stack.
+- certification.
+- adopter registry.
+- official host status.
+- production-adoption claim.
+- foundation governance.
+- long-term support.
+
+## Compatibility Claims
+
+Compatibility claims require:
+
+- protocol version
+- conformance surface
+- fixture or checklist basis
+- verification date
+
+The protocol rejects unverified compatibility claims.
+
+## Validation
+
+The v0.1.0 release tag MUST pass:
+
+```txt
+python3 scripts/check_conformance_fixtures.py
+python3 scripts/check_openapi_contract.py
+python3 scripts/check_markdown_links.py
+python3 scripts/check_protocol_wording.py
+git diff --check
+```
+
+Demo JavaScript MUST pass:
+
+```txt
+node --check demo/assets/app.js
+```
+

--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -82,4 +82,3 @@ Demo JavaScript MUST pass:
 ```txt
 node --check demo/assets/app.js
 ```
-


### PR DESCRIPTION
## Summary
- adds v0.1 release-readiness files: changelog, contribution rules, security policy, citation metadata, and release notes
- adds GitHub issue templates, PR template, and validation CI
- links release docs from README, docs index, and roadmap

## Boundary
- keeps Jarvis protocol-only
- does not tag or release v0.1
- does not certify Jarvis or any implementation
- does not designate an official host, claim production adoption, establish foundation governance, or create long-term support
- keeps host runtime, UI, auth, storage, model calls, tool execution, scoring, payment, deployment, adapters, and wrappers outside Jarvis

## Reviewer agents
- Anscombe: release-status boundary
- Euclid: workflow and template correctness
- Laplace: documentation navigation and link consistency
- Heisenberg: security and contribution scope

## Validation
- python3 scripts/check_conformance_fixtures.py
- python3 scripts/check_openapi_contract.py
- python3 scripts/check_markdown_links.py
- python3 scripts/check_protocol_wording.py
- git diff --check
- node --check demo/assets/app.js
- YAML parse for .github/*.yml and CITATION.cff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added issue and pull request templates to make reporting problems and submitting changes more structured.
  * Added a validation workflow to automatically check protocol-related content and repository formatting.

* **Documentation**
  * Added release notes, changelog, contributor guidance, security guidance, citation details, and release documentation.
  * Updated project docs to point to release information and readiness notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->