### PR TITLE
[codex] Finalize v0.1.0 release status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,14 @@ All notable Jarvis protocol changes are recorded here.
 
 ## v0.1.0 - Protocol Alpha
 
-Status: planned tag.
+Status: released.
 
-Jarvis v0.1 is accepted as Protocol Alpha by the v0.1 acceptance decision.
-This changelog entry prepares the public tag. It does not release, tag,
-certify, designate an official host, claim production adoption, establish
-foundation governance, or create long-term support.
+Release date: 2026-07-01.
+
+Jarvis v0.1.0 is the first Protocol Alpha release. This release does not
+certify Jarvis or any implementation, designate an official host, claim
+production adoption, establish foundation governance, or create long-term
+support.
 
 ### Added
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,8 @@ title: "Jarvis Human-Agent Collaboration and Learning-Loop Protocol"
 type: software
 authors:
   - name: "Flow Research"
-version: "0.1.0-alpha"
+version: "0.1.0"
+date-released: "2026-07-01"
 repository-code: "https://github.com/Flow-Research/jarvis"
 url: "https://github.com/Flow-Research/jarvis"
 license: "MIT"

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ and shared learning.
 
 ## Status
 
-Jarvis v0.1 is accepted as Protocol Alpha.
-This does not release or tag v0.1, certify Jarvis or any implementation,
-designate an official host, claim production adoption, establish foundation
-governance, or create long-term support.
+Jarvis v0.1.0 is released as Protocol Alpha.
+This release does not certify Jarvis or any implementation, designate an
+official host, claim production adoption, establish foundation governance, or
+create long-term support.
 
-Release preparation lives in:
+Release materials:
 
 - [CHANGELOG.md](./CHANGELOG.md)
 - [CONTRIBUTING.md](./CONTRIBUTING.md)

--- a/docs/planning/ROADMAP.md
+++ b/docs/planning/ROADMAP.md
@@ -17,11 +17,11 @@ For the OpenAPI entry gate, see
 
 Week 1 protocol lock is complete.
 
-Current protocol status: Jarvis v0.1 is accepted as Protocol Alpha.
+Current protocol status: Jarvis v0.1.0 is released as Protocol Alpha.
 
 Current active work: next-phase specification after acceptance review.
 
-Release-readiness work for the v0.1.0 tag tracks:
+Release-readiness work for the v0.1.0 tag is complete:
 
 - changelog
 - contribution rules
@@ -30,7 +30,7 @@ Release-readiness work for the v0.1.0 tag tracks:
 - issue templates
 - PR template
 - validation CI
-- release notes before tag
+- release notes
 
 Week 2 completed the OpenAPI 3.1 component syntax, path syntax, security scheme
 encoding, protocol examples, and conformance entry rules from the locked Week 1
@@ -47,10 +47,9 @@ The v0.1 acceptance review now includes protocol-publication discipline:
 version consistency, precise conformance-claim language, release-readiness gap
 logging, extension boundary checks, and governance-gap classification.
 
-Jarvis v0.1 is accepted as Protocol Alpha. This does not release or tag v0.1,
-certify Jarvis or any implementation, designate an official host, claim
-production adoption, establish foundation governance, or create long-term
-support.
+Jarvis v0.1.0 is released as Protocol Alpha. This release does not certify
+Jarvis or any implementation, designate an official host, claim production
+adoption, establish foundation governance, or create long-term support.
 
 ## Roadmap Contract
 
@@ -505,8 +504,8 @@ and example record mappers.
 2. Keep execution and cloud ownership outside the protocol.
 3. Use `11-core-protocol-objects.md`, `jarvis-openapi.yaml`, and
    `docs/conformance/` with the accepted v0.1 decision record.
-4. Merge release-readiness files before any v0.1 tag.
-5. Run local validation and GitHub validation CI before the tag.
+4. Keep v0.1.0 release materials aligned with the tag.
+5. Run local validation and GitHub validation CI before every protocol change.
 6. Keep adapter code, wrappers, host behavior, and integration code outside
    Jarvis.
 7. Keep every Jarvis SDK discussion limited to protocol implementation helpers.

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -3,4 +3,4 @@
 Jarvis release notes record protocol scope, validation requirements, and public
 status for each protocol tag.
 
-- [v0.1.0.md](./v0.1.0.md) - Protocol Alpha release notes prepared before tag.
+- [v0.1.0.md](./v0.1.0.md) - Protocol Alpha release notes.

--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -1,19 +1,19 @@
 # Jarvis v0.1.0 Release Notes
 
-Status: release notes prepared before tag.
+Status: released Protocol Alpha.
 
 Jarvis v0.1.0 is Protocol Alpha for governed human-agent collaboration and
 shared learning.
 
-These release notes do not release, tag, certify, designate an official host,
-claim production adoption, establish foundation governance, or create long-term
-support.
+This release does not certify Jarvis or any implementation, designate an
+official host, claim production adoption, establish foundation governance, or
+create long-term support.
 
 ## Protocol Identity
 
 - OpenAPI `info.version: 0.1.0` identifies the OpenAPI artifact.
 - OpenAPI `x-jarvis-protocol.version: v0.1` identifies the protocol line.
-- Jarvis v0.1 is accepted as Protocol Alpha by
+- Jarvis v0.1.0 is released as Protocol Alpha after
   [acceptance-decision.md](../planning/v0.1-acceptance-review/acceptance-decision.md).
 
 ## Included In v0.1.0


### PR DESCRIPTION
## Summary
- updates release metadata from pre-tag readiness to v0.1.0 released as Protocol Alpha
- adds the release date to CHANGELOG.md and CITATION.cff
- keeps certification, official host, production adoption, foundation governance, and long-term support claims out of the release

## Boundary
- metadata/status only
- no protocol semantics change
- no OpenAPI, fixture, validator, SDK, adapter, host runtime, UI, auth, storage, model, tool execution, scoring, or payment change

## Reviewer agents
- Beauvoir: release-status consistency
- Descartes: protocol boundary
- Ohm: validation and link consistency

## Validation
- YAML parse for .github/*.yml and CITATION.cff
- python3 scripts/check_conformance_fixtures.py
- python3 scripts/check_openapi_contract.py
- python3 scripts/check_markdown_links.py
- python3 scripts/check_protocol_wording.py
- git diff --check
- node --check demo/assets/app.js