### PR TITLE
[codex] Plan post-v0.1 SDK helper tooling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,7 +226,8 @@ and shared learning.
 
 ## Current Execution Focus
 
-The active focus is next-phase protocol specification after the v0.1.0 release.
+The active focus is post-v0.1 SDK helper tooling planning and public docs site
+work.
 
 Protocol lock is complete. Week 2 OpenAPI contract and conformance entry work
 is complete. Week 3 protocol compatibility mapping and conformance fixtures
@@ -241,12 +242,20 @@ create long-term support.
 Work on:
 
 - next-phase protocol specification
+- post-v0.1 SDK helper tooling plan
+- SDK helper boundary and package plan
+- TypeScript protocol types and validators
+- Python protocol types and validators
+- conformance runner and protocol helper CLI
 - additional conformance evidence only when it preserves the protocol boundary
 
 The v0.1 acceptance review record starts from
 [docs/planning/v0.1-acceptance-review/README.md](./docs/planning/v0.1-acceptance-review/README.md)
 and
 [docs/planning/v0.1-acceptance-review/acceptance-spec.md](./docs/planning/v0.1-acceptance-review/acceptance-spec.md).
+
+The post-v0.1 SDK helper tooling plan starts from
+[docs/planning/post-v0.1-sdk-helper-tooling/README.md](./docs/planning/post-v0.1-sdk-helper-tooling/README.md).
 
 Do not build host implementations in this repo.
 Do not build runtime features in this repo.

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,13 @@ stable.
 - [15-openapi-communication-binding.md](./protocol/15-openapi-communication-binding.md)
 - [16-positioning-adoption-lock.md](./protocol/16-positioning-adoption-lock.md)
 
+## Active Planning
+
+Active planning docs define current post-v0.1 execution without changing
+normative protocol rules.
+
+- [post-v0.1-sdk-helper-tooling/README.md](./planning/post-v0.1-sdk-helper-tooling/README.md)
+
 ## Planning Archive
 
 Planning docs record historical v0.1 release execution and are non-normative.

--- a/docs/planning/ROADMAP.md
+++ b/docs/planning/ROADMAP.md
@@ -12,13 +12,17 @@ For the immediate execution plan, see
 For the OpenAPI entry gate, see
 [14-protocol-lock.md](../protocol/14-protocol-lock.md).
 
+For the post-v0.1 SDK helper tooling plan, see
+[post-v0.1-sdk-helper-tooling/README.md](./post-v0.1-sdk-helper-tooling/README.md).
+
 ## Current Status
 
 Week 1 protocol lock is complete.
 
 Current protocol status: Jarvis v0.1.0 is released as Protocol Alpha.
 
-Current active work: next-phase specification after acceptance review.
+Current active work: post-v0.1 SDK helper tooling planning and public docs
+site work.
 
 Release-readiness work for the v0.1.0 tag is complete:
 
@@ -393,6 +397,38 @@ v0.1 is accepted because:
 - public version labels, conformance claims, release-readiness gaps, and
   extension rules pass protocol-publication discipline review
 
+## Post-v0.1 SDK Helper Tooling
+
+Status: planned.
+
+Owner: Developer Experience
+
+Issue scope:
+
+- #64 SDK boundary and package plan
+- #65 TypeScript protocol types and validators
+- #66 Python protocol types and validators
+- #67 conformance runner and protocol helper CLI
+
+Output:
+
+- SDK boundary document
+- package plan
+- TypeScript helper package plan
+- Python helper package plan
+- conformance runner and CLI plan
+- validator and fixture reuse plan
+
+Done when:
+
+- SDK helper surfaces stay limited to protocol implementation helpers
+- TypeScript and Python helper scopes match the OpenAPI contract
+- conformance runner scope matches the fixture contract
+- package plans reject runtime, adapter, wrapper, model orchestration, tool
+  execution, auth, storage, UI, billing, scoring, payment, and deployment
+  behavior
+- local validation passes
+
 ## v0.2 Evidence And Learning Beta
 
 Goal: strengthen the compounding loop.
@@ -508,5 +544,7 @@ and example record mappers.
 5. Run local validation and GitHub validation CI before every protocol change.
 6. Keep adapter code, wrappers, host behavior, and integration code outside
    Jarvis.
-7. Keep every Jarvis SDK discussion limited to protocol implementation helpers.
-8. Start next-phase specification only inside protocol-owned scope.
+7. Execute the post-v0.1 SDK helper tooling plan through #64, #65, #66, and
+   #67.
+8. Keep every Jarvis SDK discussion limited to protocol implementation helpers.
+9. Start next-phase specification only inside protocol-owned scope.

--- a/docs/planning/ROADMAP.md
+++ b/docs/planning/ROADMAP.md
@@ -426,7 +426,7 @@ Done when:
 - conformance runner scope matches the fixture contract
 - package plans reject runtime, adapter, wrapper, model orchestration, tool
   execution, auth, storage, UI, billing, scoring, payment, and deployment
-  behavior
+  behavior, monitoring, observability, host integration, and host workflow
 - local validation passes
 
 ## v0.2 Evidence And Learning Beta

--- a/docs/planning/post-v0.1-sdk-helper-tooling/README.md
+++ b/docs/planning/post-v0.1-sdk-helper-tooling/README.md
@@ -97,7 +97,8 @@ The conformance review verifies fixture compatibility and rejection ids.
 
 The security and zero-trust review verifies mutation headers, Actor headers,
 Actor authority, WorkSession revision, previous event hash, idempotency,
-timestamp, and host-private field rejection.
+timestamp, the PolicyDecision precondition for every AgentWorker action that
+affects a WorkSession, and host-private field rejection.
 
 The developer-experience review verifies that helpers are small, direct, and
 usable by compatible implementations.

--- a/docs/planning/post-v0.1-sdk-helper-tooling/README.md
+++ b/docs/planning/post-v0.1-sdk-helper-tooling/README.md
@@ -1,0 +1,145 @@
+# Post-v0.1 SDK Helper Tooling Plan
+
+Status: planned.
+
+Jarvis v0.1.0 is released as Protocol Alpha. Post-v0.1 SDK helper tooling
+starts after the protocol contract, OpenAPI binding, conformance fixtures,
+examples, and release boundary are locked.
+
+This plan covers GitHub issues #64 through #67.
+
+Jarvis SDK work is protocol implementation helper work. It is not runtime
+work, adapter work, wrapper work, host UI work, model orchestration work, tool
+execution work, storage work, auth work, billing work, scoring work, payment
+work, or deployment work.
+
+## Goal
+
+Make Jarvis v0.1.0 easier to implement without weakening the protocol
+boundary.
+
+SDK helper tooling must help compatible implementations:
+
+- create protocol records
+- validate protocol records
+- prepare required protocol headers
+- verify event envelope and hash-chain rules
+- export EvidenceManifest records
+- validate Request, Review, Takeover, LearningRecord, MemoryProposal, and
+  SkillProposal records
+- run conformance fixtures
+- produce precise protocol errors
+
+## Inputs
+
+SDK helper tooling starts from:
+
+- [../../openapi/jarvis-openapi.yaml](../../openapi/jarvis-openapi.yaml)
+- [../../protocol/11-core-protocol-objects.md](../../protocol/11-core-protocol-objects.md)
+- [../../protocol/12-request-protocol.md](../../protocol/12-request-protocol.md)
+- [../../protocol/13-contribution-evidence-learning.md](../../protocol/13-contribution-evidence-learning.md)
+- [../../protocol/14-protocol-lock.md](../../protocol/14-protocol-lock.md)
+- [../../protocol/15-openapi-communication-binding.md](../../protocol/15-openapi-communication-binding.md)
+- [../../conformance/checklist.md](../../conformance/checklist.md)
+- [../../conformance/fixtures/README.md](../../conformance/fixtures/README.md)
+- [../../releases/v0.1.0.md](../../releases/v0.1.0.md)
+
+## Issue Mapping
+
+| Issue | Chunk | Purpose |
+| --- | --- | --- |
+| #64 | [chunk-1-sdk-boundary-package-plan.md](./chunk-1-sdk-boundary-package-plan.md) | Lock SDK boundary, package shape, generator policy, and release gates. |
+| #65 | [chunk-2-typescript-types-validators.md](./chunk-2-typescript-types-validators.md) | Define TypeScript protocol types, validators, helpers, and tests. |
+| #66 | [chunk-3-python-types-validators.md](./chunk-3-python-types-validators.md) | Define Python protocol models, validators, helpers, and tests. |
+| #67 | [chunk-4-conformance-runner-cli.md](./chunk-4-conformance-runner-cli.md) | Define conformance runner and protocol helper CLI. |
+
+## Chunk Order
+
+SDK helper tooling proceeds in this order:
+
+```txt
+1. SDK boundary and package plan
+2. TypeScript protocol types and validators
+3. Python protocol types and validators
+4. conformance runner and protocol helper CLI
+```
+
+Chunk 1 must land before implementation work starts.
+
+Chunks 2 and 3 start only after Chunk 1 locks the package boundary.
+
+Chunk 4 starts after at least one validator surface proves the shared
+validation shape.
+
+## Review Lanes
+
+Every SDK helper tooling chunk requires:
+
+```txt
+protocol-boundary review
+OpenAPI contract review
+conformance review
+security and zero-trust review
+developer-experience review
+test review
+wording review
+```
+
+The protocol-boundary review verifies that helper tooling does not become an
+agent framework, runtime, adapter, wrapper, host SDK, model router, tool
+executor, memory engine, UI kit, auth provider, storage backend, sandbox, or
+workflow engine.
+
+The OpenAPI contract review verifies exact alignment with
+`docs/openapi/jarvis-openapi.yaml`.
+
+The conformance review verifies fixture compatibility and rejection ids.
+
+The security and zero-trust review verifies mutation headers, Actor headers,
+Actor authority, WorkSession revision, previous event hash, idempotency,
+timestamp, and host-private field rejection.
+
+The developer-experience review verifies that helpers are small, direct, and
+usable by compatible implementations.
+
+The test review verifies that valid and invalid protocol records are covered.
+
+The wording review verifies direct protocol language.
+
+## Required Checks
+
+Every SDK helper tooling PR runs:
+
+```txt
+python3 scripts/check_conformance_fixtures.py
+python3 scripts/check_openapi_contract.py
+python3 scripts/check_markdown_links.py
+python3 scripts/check_protocol_wording.py
+git diff --check
+```
+
+SDK package work also runs the package test command introduced by that package
+before PR ready.
+
+## Done State
+
+SDK helper tooling planning is complete when:
+
+- Chunk 1 locks allowed and rejected SDK surfaces.
+- Chunk 2 defines TypeScript helper scope without runtime behavior.
+- Chunk 3 defines Python helper scope without runtime behavior.
+- Chunk 4 defines the conformance runner and helper CLI without host mutation.
+- Roadmap entries point contributors to this plan.
+- Local validation passes.
+
+## Boundary
+
+Jarvis owns protocol helper contracts, validation helpers, conformance runners,
+protocol error helpers, EvidenceManifest helpers, event envelope helpers, and
+hash-chain helpers.
+
+Hosts own execution, storage, auth, UI, model calls, tool execution, memory
+engines, queues, billing, monitoring, deployment, and host workflow.
+
+Existing agents participate through protocol records without being rewritten as
+Jarvis agents.

--- a/docs/planning/post-v0.1-sdk-helper-tooling/chunk-1-sdk-boundary-package-plan.md
+++ b/docs/planning/post-v0.1-sdk-helper-tooling/chunk-1-sdk-boundary-package-plan.md
@@ -1,0 +1,211 @@
+# Chunk 1: SDK Boundary And Package Plan
+
+Issue: #64.
+
+Chunk 1 locks the SDK helper boundary before TypeScript, Python, or CLI
+implementation starts.
+
+## Scope
+
+This chunk defines:
+
+- SDK purpose
+- SDK non-goals
+- allowed helper surfaces
+- rejected helper surfaces
+- TypeScript package scope
+- Python package scope
+- OpenAPI generation policy
+- validator policy
+- conformance runner policy
+- versioning policy
+- release checklist
+
+This chunk does not create SDK implementation code.
+
+## Required Output
+
+Chunk 1 produces:
+
+```txt
+SDK boundary document
+package plan
+versioning plan
+release checklist
+implementation chunk gates
+```
+
+The output becomes the entry gate for #65, #66, and #67.
+
+## SDK Purpose
+
+A Jarvis SDK is a protocol implementation kit.
+
+It helps compatible implementations create, validate, hash, export, and test
+Jarvis protocol records.
+
+## Accepted SDK Surfaces
+
+SDK work is accepted only for:
+
+- generated OpenAPI clients
+- protocol types
+- protocol record validators
+- event envelope helpers
+- event hash-chain helpers
+- idempotency helpers
+- mutation-header helpers
+- read-header helpers
+- EvidenceManifest helpers
+- Request validators
+- Review validators
+- Takeover validators
+- LearningRecord validators
+- MemoryProposal validators
+- SkillProposal validators
+- conformance fixture runners
+- protocol error helpers
+- example record mappers
+
+## Rejected SDK Surfaces
+
+SDK work is rejected when it adds:
+
+- agent runtime
+- agent planner
+- model router
+- model orchestration
+- tool executor
+- memory engine
+- host adapter
+- wrapper
+- host UI kit
+- auth provider
+- storage backend
+- queue backend
+- sandbox
+- billing system
+- scoring system
+- payment system
+- deployment system
+- workflow engine
+
+## Package Plan Requirements
+
+The package plan MUST define:
+
+- package names
+- source layout
+- generated-code policy
+- hand-written helper policy
+- test layout
+- fixture import strategy
+- release artifact names
+- version labels
+- compatibility statement
+- deprecation policy
+
+## Locked Package Decisions
+
+Initial package names:
+
+```txt
+TypeScript package: @jarvis-protocol/sdk
+Python package: jarvis-protocol
+CLI package: @jarvis-protocol/cli
+CLI command: jarvis
+```
+
+Initial source layout:
+
+```txt
+packages/typescript/src/generated
+packages/typescript/src/validators
+packages/typescript/src/headers
+packages/typescript/src/events
+packages/typescript/src/evidence
+packages/typescript/tests
+packages/python/src/jarvis_protocol/generated
+packages/python/src/jarvis_protocol/validators
+packages/python/src/jarvis_protocol/headers
+packages/python/src/jarvis_protocol/events
+packages/python/src/jarvis_protocol/evidence
+packages/python/tests
+packages/cli/src
+packages/cli/tests
+```
+
+Generated-code policy:
+
+- generated OpenAPI output lives only under `generated`
+- generated files are not hand-edited
+- hand-written helpers import generated types or models
+- generator output changes require OpenAPI contract validation
+- helper changes require package tests
+
+Fixture import strategy:
+
+- package tests read canonical fixtures from `docs/conformance/fixtures`
+- release packages include fixture snapshots under `fixtures/v0.1`
+- fixture snapshots preserve source refs to the canonical repository fixtures
+- fixture updates require `python3 scripts/check_conformance_fixtures.py`
+
+Release artifact names:
+
+```txt
+NPM: @jarvis-protocol/sdk
+NPM: @jarvis-protocol/cli
+PyPI: jarvis-protocol
+CLI binary: jarvis
+```
+
+Version labels:
+
+```txt
+package release line: 0.1.x
+supported protocol line: v0.1
+supported OpenAPI artifact version: 0.1.0
+supported fixture set: v0.1
+release status: Protocol Alpha helper tooling
+```
+
+## Versioning Rules
+
+SDK package versions MUST identify:
+
+```txt
+package version
+supported Jarvis protocol version
+supported OpenAPI artifact version
+fixture set version
+```
+
+The first helper packages target:
+
+```txt
+Jarvis protocol line: v0.1
+OpenAPI artifact version: 0.1.0
+release status: Protocol Alpha
+```
+
+## Acceptance Criteria
+
+Chunk 1 is complete when:
+
+- SDK non-goals are explicit.
+- accepted helper surfaces are explicit.
+- rejected helper surfaces are explicit.
+- TypeScript package scope is ready for #65.
+- Python package scope is ready for #66.
+- conformance runner scope is ready for #67.
+- package versioning ties helpers to Jarvis v0.1 and OpenAPI 0.1.0.
+- local validation passes.
+- review lanes have no valid unresolved findings.
+
+## Boundary
+
+The SDK plan strengthens protocol implementation only.
+
+The SDK plan does not authorize runtime, adapter, wrapper, host behavior,
+model calls, tool execution, memory engines, UI, auth, storage, queues,
+billing, scoring, payment, or deployment work inside Jarvis.

--- a/docs/planning/post-v0.1-sdk-helper-tooling/chunk-1-sdk-boundary-package-plan.md
+++ b/docs/planning/post-v0.1-sdk-helper-tooling/chunk-1-sdk-boundary-package-plan.md
@@ -125,14 +125,17 @@ packages/typescript/src/headers
 packages/typescript/src/events
 packages/typescript/src/evidence
 packages/typescript/tests
+packages/typescript/fixtures/v0.1
 packages/python/src/jarvis_protocol/generated
 packages/python/src/jarvis_protocol/validators
 packages/python/src/jarvis_protocol/headers
 packages/python/src/jarvis_protocol/events
 packages/python/src/jarvis_protocol/evidence
 packages/python/tests
+packages/python/fixtures/v0.1
 packages/cli/src
 packages/cli/tests
+packages/cli/fixtures/v0.1
 ```
 
 Generated-code policy:
@@ -208,4 +211,5 @@ The SDK plan strengthens protocol implementation only.
 
 The SDK plan does not authorize runtime, adapter, wrapper, host behavior,
 model calls, tool execution, memory engines, UI, auth, storage, queues,
-billing, scoring, payment, or deployment work inside Jarvis.
+billing, scoring, payment, deployment, monitoring, observability, host
+integration, or host workflow work inside Jarvis.

--- a/docs/planning/post-v0.1-sdk-helper-tooling/chunk-2-typescript-types-validators.md
+++ b/docs/planning/post-v0.1-sdk-helper-tooling/chunk-2-typescript-types-validators.md
@@ -143,6 +143,7 @@ Validators MUST reject:
 - silent memory mutation
 - silent skill activation
 - OutcomeReport without LearningRecord reference
+- OutcomeReport without terminal source
 
 ## Test Requirements
 

--- a/docs/planning/post-v0.1-sdk-helper-tooling/chunk-2-typescript-types-validators.md
+++ b/docs/planning/post-v0.1-sdk-helper-tooling/chunk-2-typescript-types-validators.md
@@ -1,0 +1,178 @@
+# Chunk 2: TypeScript Protocol Types And Validators
+
+Issue: #65.
+
+Chunk 2 defines the TypeScript helper package for Jarvis v0.1 protocol records.
+
+## Scope
+
+This chunk creates TypeScript helper tooling for protocol records only.
+
+It includes:
+
+- generated or maintained protocol types
+- protocol error types
+- mutation header helpers
+- read header helpers
+- WorkSession event envelope validator
+- event hash-chain helpers
+- Request validator
+- Review validator
+- Takeover validator
+- Contribution validator
+- EvidenceManifest validator
+- LearningRecord validator
+- MemoryProposal validator
+- SkillProposal validator
+- OutcomeReport validator
+- fixture-backed tests
+
+It does not create an agent runtime, model router, tool executor, host adapter,
+wrapper, UI kit, auth provider, storage backend, queue backend, memory engine,
+sandbox, billing system, scoring system, payment system, deployment system, or
+workflow engine.
+
+## Required Inputs
+
+Chunk 2 starts after Chunk 1 locks the SDK boundary.
+
+Required inputs:
+
+- [chunk-1-sdk-boundary-package-plan.md](./chunk-1-sdk-boundary-package-plan.md)
+- [../../openapi/jarvis-openapi.yaml](../../openapi/jarvis-openapi.yaml)
+- [../../conformance/fixtures/valid/golden-path.json](../../conformance/fixtures/valid/golden-path.json)
+- [../../conformance/fixtures/invalid/](../../conformance/fixtures/invalid/)
+- [../../protocol/15-openapi-communication-binding.md](../../protocol/15-openapi-communication-binding.md)
+
+## Type Surface
+
+The TypeScript package MUST expose every OpenAPI component schema from
+`docs/openapi/jarvis-openapi.yaml`.
+
+The v0.1.0 type surface includes:
+
+- AccountabilityScope
+- Actor
+- ActorType
+- Worker
+- WorkerType
+- HumanWorker
+- AgentWorker
+- ApprovalBoundary
+- ApprovalScope
+- AuthorityScope
+- AutonomyLevel
+- BlockingScope
+- CanonicalizationProfile
+- CapabilityRef
+- ContributionRole
+- ContributionScope
+- ContributionType
+- ContributorRef
+- ContributorType
+- DataSensitivity
+- EscalationRule
+- EventAuthority
+- EvidenceItemRef
+- ExportProfile
+- WorkSession
+- WorkSessionStatus
+- JarvisEvent
+- JarvisEventPayload
+- JarvisId
+- Policy
+- PolicyActionRequest
+- PolicyActionRule
+- PolicyConstraint
+- PolicyDecision
+- PolicyDecisionResult
+- PolicyRequestLimits
+- Request
+- RequestOption
+- RequestStatus
+- RequestType
+- Review
+- ReviewDecision
+- RiskClass
+- SafeFallback
+- Takeover
+- TakeoverScope
+- TakeoverState
+- Contribution
+- EvidenceManifest
+- LearningRecord
+- LearningReviewState
+- LearningSubjectType
+- MemoryProposal
+- MemoryProposalStatus
+- NamespacedExtensions
+- OpaqueRef
+- SkillProposal
+- SkillProposalStatus
+- OutcomeReport
+- PortableValue
+- ProposalTargetType
+- ProtocolError
+- ProtocolErrorId
+- ProtocolTraceContext
+- Timestamp
+- protocol error envelope
+- mutation headers
+- read headers
+
+## Validator Surface
+
+Validators MUST reject:
+
+- missing required fields
+- invalid protocol version
+- missing Actor identity
+- unauthorized Actor
+- missing idempotency key on mutation
+- stale request timestamp
+- missing expected WorkSession revision on WorkSession-scoped mutation
+- missing previous event hash on WorkSession-scoped mutation
+- actor mismatch between body and `Jarvis-Actor-Id`
+- missing PolicyDecision before accepted AgentWorker action state
+- Request resolution without Review or Takeover
+- invalid ApprovalScope
+- stale Takeover continuation
+- forbidden host-private export fields
+- sealed WorkSession mutation
+- sealed EvidenceManifest mutation
+- silent memory mutation
+- silent skill activation
+- OutcomeReport without LearningRecord reference
+
+## Test Requirements
+
+Chunk 2 tests MUST include:
+
+- valid golden-path fixture
+- invalid fixture set
+- header helper tests
+- event hash-chain tests
+- EvidenceManifest export tests
+- Request/Review/Takeover tests
+- LearningRecord, MemoryProposal, and SkillProposal governance tests
+- protocol error helper tests
+
+## Acceptance Criteria
+
+Chunk 2 is complete when:
+
+- TypeScript types match the OpenAPI contract.
+- TypeScript validators reject every required v0.1 fixture failure class.
+- package docs state Protocol Alpha support.
+- package docs state SDK boundary and non-goals.
+- local protocol validation passes.
+- package tests pass.
+- review lanes have no valid unresolved findings.
+
+## Boundary
+
+The TypeScript package helps compatible implementations create and validate
+Jarvis records.
+
+The TypeScript package does not run agents, call models, execute tools, store
+records, authenticate users, render host UI, route work, or deploy hosts.

--- a/docs/planning/post-v0.1-sdk-helper-tooling/chunk-3-python-types-validators.md
+++ b/docs/planning/post-v0.1-sdk-helper-tooling/chunk-3-python-types-validators.md
@@ -143,6 +143,7 @@ Validators MUST reject:
 - silent memory mutation
 - silent skill activation
 - OutcomeReport without LearningRecord reference
+- OutcomeReport without terminal source
 
 ## Test Requirements
 

--- a/docs/planning/post-v0.1-sdk-helper-tooling/chunk-3-python-types-validators.md
+++ b/docs/planning/post-v0.1-sdk-helper-tooling/chunk-3-python-types-validators.md
@@ -1,0 +1,178 @@
+# Chunk 3: Python Protocol Types And Validators
+
+Issue: #66.
+
+Chunk 3 defines the Python helper package for Jarvis v0.1 protocol records.
+
+## Scope
+
+This chunk creates Python helper tooling for protocol records only.
+
+It includes:
+
+- protocol models
+- protocol error models
+- mutation header helpers
+- read header helpers
+- WorkSession event envelope validator
+- event hash-chain helpers
+- Request validator
+- Review validator
+- Takeover validator
+- Contribution validator
+- EvidenceManifest validator
+- LearningRecord validator
+- MemoryProposal validator
+- SkillProposal validator
+- OutcomeReport validator
+- fixture-backed tests
+
+It does not create an agent runtime, model router, tool executor, host adapter,
+wrapper, UI kit, auth provider, storage backend, queue backend, memory engine,
+sandbox, billing system, scoring system, payment system, deployment system, or
+workflow engine.
+
+## Required Inputs
+
+Chunk 3 starts after Chunk 1 locks the SDK boundary.
+
+Required inputs:
+
+- [chunk-1-sdk-boundary-package-plan.md](./chunk-1-sdk-boundary-package-plan.md)
+- [../../openapi/jarvis-openapi.yaml](../../openapi/jarvis-openapi.yaml)
+- [../../conformance/fixtures/valid/golden-path.json](../../conformance/fixtures/valid/golden-path.json)
+- [../../conformance/fixtures/invalid/](../../conformance/fixtures/invalid/)
+- [../../protocol/15-openapi-communication-binding.md](../../protocol/15-openapi-communication-binding.md)
+
+## Model Surface
+
+The Python package MUST expose every OpenAPI component schema from
+`docs/openapi/jarvis-openapi.yaml`.
+
+The v0.1.0 model surface includes:
+
+- AccountabilityScope
+- Actor
+- ActorType
+- Worker
+- WorkerType
+- HumanWorker
+- AgentWorker
+- ApprovalBoundary
+- ApprovalScope
+- AuthorityScope
+- AutonomyLevel
+- BlockingScope
+- CanonicalizationProfile
+- CapabilityRef
+- ContributionRole
+- ContributionScope
+- ContributionType
+- ContributorRef
+- ContributorType
+- DataSensitivity
+- EscalationRule
+- EventAuthority
+- EvidenceItemRef
+- ExportProfile
+- WorkSession
+- WorkSessionStatus
+- JarvisEvent
+- JarvisEventPayload
+- JarvisId
+- Policy
+- PolicyActionRequest
+- PolicyActionRule
+- PolicyConstraint
+- PolicyDecision
+- PolicyDecisionResult
+- PolicyRequestLimits
+- Request
+- RequestOption
+- RequestStatus
+- RequestType
+- Review
+- ReviewDecision
+- RiskClass
+- SafeFallback
+- Takeover
+- TakeoverScope
+- TakeoverState
+- Contribution
+- EvidenceManifest
+- LearningRecord
+- LearningReviewState
+- LearningSubjectType
+- MemoryProposal
+- MemoryProposalStatus
+- NamespacedExtensions
+- OpaqueRef
+- SkillProposal
+- SkillProposalStatus
+- OutcomeReport
+- PortableValue
+- ProposalTargetType
+- ProtocolError
+- ProtocolErrorId
+- ProtocolTraceContext
+- Timestamp
+- protocol error envelope
+- mutation headers
+- read headers
+
+## Validator Surface
+
+Validators MUST reject:
+
+- missing required fields
+- invalid protocol version
+- missing Actor identity
+- unauthorized Actor
+- missing idempotency key on mutation
+- stale request timestamp
+- missing expected WorkSession revision on WorkSession-scoped mutation
+- missing previous event hash on WorkSession-scoped mutation
+- actor mismatch between body and `Jarvis-Actor-Id`
+- missing PolicyDecision before accepted AgentWorker action state
+- Request resolution without Review or Takeover
+- invalid ApprovalScope
+- stale Takeover continuation
+- forbidden host-private export fields
+- sealed WorkSession mutation
+- sealed EvidenceManifest mutation
+- silent memory mutation
+- silent skill activation
+- OutcomeReport without LearningRecord reference
+
+## Test Requirements
+
+Chunk 3 tests MUST include:
+
+- valid golden-path fixture
+- invalid fixture set
+- header helper tests
+- event hash-chain tests
+- EvidenceManifest export tests
+- Request/Review/Takeover tests
+- LearningRecord, MemoryProposal, and SkillProposal governance tests
+- protocol error helper tests
+
+## Acceptance Criteria
+
+Chunk 3 is complete when:
+
+- Python models match the OpenAPI contract.
+- Python validators reject every required v0.1 fixture failure class.
+- package docs state Protocol Alpha support.
+- package docs state SDK boundary and non-goals.
+- local protocol validation passes.
+- package tests pass.
+- review lanes have no valid unresolved findings.
+
+## Boundary
+
+The Python package helps compatible implementations create and validate Jarvis
+records.
+
+The Python package does not run agents, call models, execute tools, store
+records, authenticate users, render host UI, route work, or deploy hosts.

--- a/docs/planning/post-v0.1-sdk-helper-tooling/chunk-4-conformance-runner-cli.md
+++ b/docs/planning/post-v0.1-sdk-helper-tooling/chunk-4-conformance-runner-cli.md
@@ -1,0 +1,153 @@
+# Chunk 4: Conformance Runner And Protocol Helper CLI
+
+Issue: #67.
+
+Chunk 4 defines the conformance runner and protocol helper CLI.
+
+## Scope
+
+This chunk creates a command-line helper for protocol record validation and
+fixture execution.
+
+It includes commands for:
+
+- validating one fixture file
+- validating a directory of fixtures
+- validating one protocol record file
+- validating an EvidenceManifest export
+- checking required mutation headers
+- checking required read headers
+- checking event hash-chain continuity
+- listing v0.1 rejection ids
+- printing a public compatibility claim template
+
+It does not connect to host storage, mutate host state, call models, run
+agents, execute tools, own auth, render UI, schedule work, score work, route
+payments, deploy services, or certify implementations.
+
+## Required Inputs
+
+Chunk 4 starts after Chunk 1 locks the SDK boundary and after at least one
+validator package proves the shared validation shape.
+
+Required inputs:
+
+- [chunk-1-sdk-boundary-package-plan.md](./chunk-1-sdk-boundary-package-plan.md)
+- [../../conformance/checklist.md](../../conformance/checklist.md)
+- [../../conformance/fixtures/README.md](../../conformance/fixtures/README.md)
+- [../../conformance/fixtures/valid/golden-path.json](../../conformance/fixtures/valid/golden-path.json)
+- [../../conformance/fixtures/invalid/](../../conformance/fixtures/invalid/)
+- [../../openapi/jarvis-openapi.yaml](../../openapi/jarvis-openapi.yaml)
+
+## Command Surface
+
+The CLI MUST expose:
+
+```txt
+jarvis validate fixture <file>
+jarvis validate fixtures <directory>
+jarvis validate record <file>
+jarvis validate evidence-manifest <file>
+jarvis check headers <file> --operation-id <operation_id>
+jarvis check headers <file> --operation-class <operation_class>
+jarvis check hash-chain <file>
+jarvis list rejection-ids
+jarvis print compatibility-claim
+```
+
+Command names remain final only after Chunk 4 implementation review.
+
+## Header Check Input
+
+`jarvis check headers` requires operation context because Jarvis header
+requirements differ by operation class.
+
+The command MUST receive either:
+
+```txt
+--operation-id <operation_id>
+```
+
+or:
+
+```txt
+--operation-class <operation_class>
+```
+
+Accepted operation classes:
+
+```txt
+worksession_scoped_mutation
+worksession_genesis_mutation
+non_worksession_mutation
+worksession_scoped_read
+export_read
+```
+
+Header input files MUST contain:
+
+```txt
+headers
+body_ref or body
+operation_id or operation_class
+```
+
+The CLI maps operation id to header requirements through
+`docs/openapi/jarvis-openapi.yaml` and
+`docs/protocol/15-openapi-communication-binding.md`.
+
+## Error Surface
+
+CLI errors MUST include:
+
+- error id
+- protocol version
+- object type
+- field
+- reason
+- remediation
+- trace id
+
+The CLI MUST NOT expose credentials, provider secrets, raw auth tokens, session
+cookies, private keys, deployment details, billing data, private scores, host
+database ids, raw runtime state, or UI state.
+
+## Test Requirements
+
+Chunk 4 tests MUST include:
+
+- valid fixture run
+- invalid fixture run
+- WorkSession genesis mutation header check
+- missing mutation header
+- missing read header
+- unauthorized Actor
+- previous event hash mismatch
+- stale WorkSession revision
+- forbidden host-private export field
+- sealed WorkSession mutation
+- sealed EvidenceManifest mutation
+- compatibility claim output
+- machine-readable error output
+
+## Acceptance Criteria
+
+Chunk 4 is complete when:
+
+- CLI runs against the existing fixture set.
+- CLI returns stable machine-readable protocol errors.
+- CLI emits non-zero exit status for invalid records.
+- CLI emits zero exit status for valid records.
+- CLI docs include command examples and exit status rules.
+- CLI docs state that the CLI does not certify implementations.
+- local protocol validation passes.
+- CLI tests pass.
+- review lanes have no valid unresolved findings.
+
+## Boundary
+
+The CLI validates Jarvis protocol records.
+
+The CLI does not implement host behavior, certify implementations, run agents,
+call models, execute tools, store records, authenticate callers, render host UI,
+route tasks, score work, route payments, or deploy services.

--- a/docs/planning/post-v0.1-sdk-helper-tooling/chunk-4-conformance-runner-cli.md
+++ b/docs/planning/post-v0.1-sdk-helper-tooling/chunk-4-conformance-runner-cli.md
@@ -55,7 +55,8 @@ jarvis list rejection-ids
 jarvis print compatibility-claim
 ```
 
-Command names remain final only after Chunk 4 implementation review.
+Command names are normative for this plan and change only through a follow-up
+doc update.
 
 ## Header Check Input
 
@@ -126,7 +127,7 @@ Chunk 4 tests MUST include:
 - stale WorkSession revision
 - forbidden host-private export field
 - sealed WorkSession mutation
-- sealed EvidenceManifest mutation
+- sealed EvidenceManifest export rejection
 - compatibility claim output
 - machine-readable error output
 


### PR DESCRIPTION
## Summary

Plans the post-v0.1 SDK/helper tooling work for issues #64 through #67.

## Protocol Surface

- Adds the post-v0.1 SDK helper tooling plan.
- Defines four chunks: SDK boundary/package plan, TypeScript protocol types/validators, Python protocol models/validators, and conformance runner/helper CLI.
- Updates AGENTS, docs index, and roadmap to point contributors to the active plan.

## Boundary Check

- Keeps SDK work limited to protocol implementation helpers.
- Rejects runtime, adapter, wrapper, host UI, model orchestration, tool execution, auth, storage, billing, scoring, payment, deployment, and host workflow work.

## Internal Review

Sub-agent reviews passed for protocol boundary, docs/wording, security/zero-trust, and SDK developer experience. Findings fixed before PR:

- added Actor authority and unauthorized Actor coverage;
- required protocol error trace id;
- locked package names, source layout, generated-code policy, fixture import strategy, artifact names, and version labels;
- verified TypeScript/Python surfaces include all 65 OpenAPI component schemas;
- added operation-aware header checks, including worksession_genesis_mutation.

## Validation

- python3 scripts/check_conformance_fixtures.py
- python3 scripts/check_openapi_contract.py
- python3 scripts/check_markdown_links.py
- python3 scripts/check_protocol_wording.py
- git diff --check
- OpenAPI component coverage check for TypeScript/Python planned surfaces

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new active planning area for post-v0.1 SDK helper tooling and public docs work.
  * Introduced detailed planning guidance for SDK boundary, TypeScript and Python helper validation, and a conformance runner/CLI.

* **Documentation**
  * Expanded roadmap and planning docs with scope, acceptance criteria, review checkpoints, and clear boundaries for helper tooling.
  * Added new chunked planning pages to organize upcoming SDK-related work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->