### PR TITLE
[codex] Add conformance runner CLI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Test Python protocol helpers
         run: npm run test:python
 
+      - name: Test CLI protocol helpers
+        run: npm run test:cli
+
       - name: Check committed whitespace
         env:
           EVENT_NAME: ${{ github.event_name }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -324,6 +324,8 @@ TypeScript helper changes MUST run
 
 Python helper changes MUST run `npm run test:python`.
 
+CLI helper changes MUST run `npm run test:cli`.
+
 ## Required References
 
 Before changing protocol direction, read:

--- a/docs/planning/ROADMAP.md
+++ b/docs/planning/ROADMAP.md
@@ -21,8 +21,7 @@ Week 1 protocol lock is complete.
 
 Current protocol status: Jarvis v0.1.0 is released as Protocol Alpha.
 
-Current active work: post-v0.1 SDK helper tooling planning and public docs
-site work.
+Current active work: public docs site work and implementation proof planning.
 
 Release-readiness work for the v0.1.0 tag is complete:
 
@@ -399,7 +398,7 @@ v0.1 is accepted because:
 
 ## Post-v0.1 SDK Helper Tooling
 
-Status: planned.
+Status: implemented.
 
 Owner: Developer Experience
 
@@ -417,6 +416,7 @@ Output:
 - TypeScript helper package plan
 - Python helper package plan
 - conformance runner and CLI plan
+- conformance runner and protocol helper CLI package
 - validator and fixture reuse plan
 
 Done when:
@@ -544,7 +544,7 @@ and example record mappers.
 5. Run local validation and GitHub validation CI before every protocol change.
 6. Keep adapter code, wrappers, host behavior, and integration code outside
    Jarvis.
-7. Execute the post-v0.1 SDK helper tooling plan through #64, #65, #66, and
-   #67.
-8. Keep every Jarvis SDK discussion limited to protocol implementation helpers.
-9. Start next-phase specification only inside protocol-owned scope.
+7. Keep every Jarvis SDK discussion limited to protocol implementation helpers.
+8. Continue public documentation site work inside protocol-owned scope.
+9. Start implementation proof only through Jarvis protocol records, not host
+   runtime ownership.

--- a/docs/planning/post-v0.1-sdk-helper-tooling/README.md
+++ b/docs/planning/post-v0.1-sdk-helper-tooling/README.md
@@ -1,6 +1,6 @@
 # Post-v0.1 SDK Helper Tooling Plan
 
-Status: planned.
+Status: implemented.
 
 Jarvis v0.1.0 is released as Protocol Alpha. Post-v0.1 SDK helper tooling
 starts after the protocol contract, OpenAPI binding, conformance fixtures,
@@ -125,7 +125,7 @@ before PR ready.
 
 ## Done State
 
-SDK helper tooling planning is complete when:
+SDK helper tooling implementation is complete when:
 
 - Chunk 1 locks allowed and rejected SDK surfaces.
 - Chunk 2 defines TypeScript helper scope without runtime behavior.

--- a/docs/planning/post-v0.1-sdk-helper-tooling/chunk-4-conformance-runner-cli.md
+++ b/docs/planning/post-v0.1-sdk-helper-tooling/chunk-4-conformance-runner-cli.md
@@ -2,6 +2,8 @@
 
 Issue: #67.
 
+Status: implemented.
+
 Chunk 4 defines the conformance runner and protocol helper CLI.
 
 ## Scope

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "check:protocol": "python3 scripts/check_conformance_fixtures.py && python3 scripts/check_openapi_contract.py && python3 scripts/check_markdown_links.py && python3 scripts/check_protocol_wording.py && git diff --check",
     "check:sdk-boundary": "python3 scripts/check_sdk_boundary.py",
+    "test:cli": "npm --workspace @jarvis-protocol/cli test",
     "test:python": "node scripts/run_python_package_tests.mjs",
     "test:typescript": "npm --workspace @jarvis-protocol/sdk test"
   }

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,7 +1,6 @@
 # Jarvis SDK Helper Packages
 
-This directory contains package foundations for Jarvis protocol helper
-tooling.
+This directory contains Jarvis protocol helper packages.
 
 The packages help compatible implementations create, validate, hash, export,
 and test Jarvis protocol records.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 # @jarvis-protocol/cli
 
-Status: package foundation.
+Status: Protocol Alpha helper tooling.
 
 This package provides a command-line helper for Jarvis v0.1 protocol record
 validation and conformance fixture execution.
@@ -16,6 +16,86 @@ Accepted command surfaces:
 - `jarvis check hash-chain <file>`
 - `jarvis list rejection-ids`
 - `jarvis print compatibility-claim`
+
+## Examples
+
+From the repository root, run one fixture expectation:
+
+```bash
+jarvis validate fixture packages/cli/fixtures/v0.1/valid/golden-path.json
+```
+
+From the repository root, run the full fixture snapshot:
+
+```bash
+jarvis validate fixtures packages/cli/fixtures/v0.1
+```
+
+Installed package consumers pass the path to the installed
+`@jarvis-protocol/cli/fixtures/v0.1` directory.
+
+Validate one protocol record file:
+
+```bash
+jarvis validate record record.json
+```
+
+The record file MUST use this envelope:
+
+```json
+{
+  "object_type": "Request",
+  "record": {}
+}
+```
+
+Validate an EvidenceManifest export:
+
+```bash
+jarvis validate evidence-manifest evidence-manifest.json
+```
+
+Check operation headers:
+
+```bash
+jarvis check headers headers.json --operation-id createWorkSession
+jarvis check headers headers.json --operation-class non_worksession_mutation
+```
+
+Check an event hash chain:
+
+```bash
+jarvis check hash-chain events.json
+```
+
+List protocol rejection ids:
+
+```bash
+jarvis list rejection-ids
+```
+
+Print a compatibility claim template:
+
+```bash
+jarvis print compatibility-claim
+```
+
+## Exit Status
+
+Validation commands return `0` when the requested protocol check passes.
+
+Record, header, EvidenceManifest, and hash-chain commands return non-zero when
+the protocol record is invalid.
+
+Fixture commands return `0` when the fixture outcome matches its
+`expected_result`. Invalid fixtures pass the command when they reject with the
+expected protocol error id.
+
+All validation and error output is JSON. Error output uses the Jarvis
+`ProtocolError` envelope.
+
+The compatibility claim output is an implementation claim template. It is not a
+Jarvis certification.
 
 Rejected surfaces:
 
@@ -37,3 +117,11 @@ Rejected surfaces:
 
 The CLI validates Jarvis protocol records. The CLI does not certify
 implementations.
+
+## Local Validation
+
+Run CLI tests from the repository root:
+
+```bash
+npm --workspace @jarvis-protocol/cli test
+```

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -55,6 +55,17 @@ Validate an EvidenceManifest export:
 jarvis validate evidence-manifest evidence-manifest.json
 ```
 
+The EvidenceManifest file MUST use this envelope:
+
+```json
+{
+  "evidence_manifest": {},
+  "work_session": {}
+}
+```
+
+`work_session` is required when enforcing terminal-source export validation.
+
 Check operation headers:
 
 ```bash

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,14 +5,17 @@
   "license": "MIT",
   "type": "module",
   "bin": {
-    "jarvis": "./dist/index.js"
+    "jarvis": "./src/index.js"
   },
   "files": [
-    "dist/",
+    "src/",
     "fixtures/v0.1/",
     "README.md",
     "package.json"
   ],
+  "dependencies": {
+    "@jarvis-protocol/sdk": "0.1.0-alpha.0"
+  },
   "jarvis": {
     "packageStatus": "Protocol Alpha helper tooling",
     "protocolVersion": "v0.1",
@@ -20,6 +23,7 @@
     "fixtureSet": "v0.1"
   },
   "scripts": {
-    "check:boundary": "python3 ../../scripts/check_sdk_boundary.py"
+    "check:boundary": "python3 ../../scripts/check_sdk_boundary.py",
+    "test": "node --test tests/*.test.js"
   }
 }

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -1,0 +1,546 @@
+#!/usr/bin/env node
+
+import { readFileSync, readdirSync, realpathSync, statSync } from "node:fs";
+import { dirname, relative, resolve, sep } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const CLI_PROTOCOL_VERSION = "v0.1";
+
+const OPERATION_CONTEXT = Object.freeze({
+  registerWorker: {
+    method: "PUT",
+    path: "/workers/{worker_id}",
+    operationClass: "non_worksession_mutation",
+  },
+  registerActor: {
+    method: "PUT",
+    path: "/actors/{actor_id}",
+    operationClass: "non_worksession_mutation",
+  },
+  createWorkSession: {
+    method: "POST",
+    path: "/work-sessions",
+    operationClass: "worksession_genesis_mutation",
+  },
+  getWorkSession: {
+    method: "GET",
+    path: "/work-sessions/{work_session_id}",
+    operationClass: "worksession_scoped_read",
+  },
+  appendJarvisEvent: {
+    method: "POST",
+    path: "/work-sessions/{work_session_id}/events",
+    operationClass: "worksession_scoped_mutation",
+  },
+  recordPolicyDecision: {
+    method: "POST",
+    path: "/work-sessions/{work_session_id}/policy-decisions",
+    operationClass: "worksession_scoped_mutation",
+  },
+  createRequest: {
+    method: "POST",
+    path: "/work-sessions/{work_session_id}/requests",
+    operationClass: "worksession_scoped_mutation",
+  },
+  recordReview: {
+    method: "POST",
+    path: "/work-sessions/{work_session_id}/reviews",
+    operationClass: "worksession_scoped_mutation",
+  },
+  recordTakeover: {
+    method: "POST",
+    path: "/work-sessions/{work_session_id}/takeovers",
+    operationClass: "worksession_scoped_mutation",
+  },
+  recordContribution: {
+    method: "POST",
+    path: "/work-sessions/{work_session_id}/contributions",
+    operationClass: "worksession_scoped_mutation",
+  },
+  createLearningRecord: {
+    method: "POST",
+    path: "/work-sessions/{work_session_id}/learning-records",
+    operationClass: "worksession_scoped_mutation",
+  },
+  createMemoryProposal: {
+    method: "POST",
+    path: "/work-sessions/{work_session_id}/memory-proposals",
+    operationClass: "worksession_scoped_mutation",
+  },
+  createSkillProposal: {
+    method: "POST",
+    path: "/work-sessions/{work_session_id}/skill-proposals",
+    operationClass: "worksession_scoped_mutation",
+  },
+  exportEvidenceManifest: {
+    method: "GET",
+    path: "/work-sessions/{work_session_id}/export",
+    operationClass: "export_read",
+  },
+  submitOutcomeReport: {
+    method: "POST",
+    path: "/outcome-reports",
+    operationClass: "non_worksession_mutation",
+  },
+});
+
+const ACCEPTED_OPERATION_CLASSES = new Set([
+  "worksession_scoped_mutation",
+  "worksession_genesis_mutation",
+  "non_worksession_mutation",
+  "worksession_scoped_read",
+  "export_read",
+]);
+
+const REQUIRED_FIXTURE_PATHS = Object.freeze([
+  "valid/golden-path.json",
+  "invalid/forbidden-host-private-export-field.json",
+  "invalid/invalid-approval-scope.json",
+  "invalid/invalid-evidence-export-state.json",
+  "invalid/invalid-previous-event-hash.json",
+  "invalid/missing-actor.json",
+  "invalid/missing-expected-work-session-revision.json",
+  "invalid/missing-idempotency-key.json",
+  "invalid/missing-policy-decision.json",
+  "invalid/missing-policy.json",
+  "invalid/missing-previous-event-hash.json",
+  "invalid/missing-protocol-version.json",
+  "invalid/missing-request-timestamp.json",
+  "invalid/missing-review-resolution.json",
+  "invalid/missing-takeover-resolution.json",
+  "invalid/outcome-report-without-learning-record.json",
+  "invalid/outcome-report-requires-terminal-source.json",
+  "invalid/sealed-evidence-mutation.json",
+  "invalid/sealed-work-session-mutation.json",
+  "invalid/silent-memory-mutation.json",
+  "invalid/silent-skill-activation.json",
+  "invalid/stale-request-timestamp.json",
+  "invalid/stale-takeover-continuation.json",
+  "invalid/stale-work-session-revision.json",
+  "invalid/unauthorized-actor.json",
+  "invalid/unresolved-request.json",
+]);
+
+export async function runCli(args, io = defaultIo()) {
+  const sdk = await loadSdk();
+  try {
+    const parsed = parseArgs(args);
+    const outcome = await dispatch(sdk, parsed);
+    writeJson(io.stdout, outcome.payload);
+    return outcome.code;
+  } catch (error) {
+    writeJson(io.stdout, {
+      protocol_version: sdk.PROTOCOL_VERSION ?? CLI_PROTOCOL_VERSION,
+      command: "jarvis",
+      passed: false,
+      valid: false,
+      errors: [
+        sdk.protocolError("invalid_export", {
+          objectType: "CLI",
+          field: "argv",
+          reason: error instanceof Error ? error.message : String(error),
+          remediation: "Run a supported Jarvis CLI command with the required input file.",
+          traceId: "trace:jarvis-cli",
+        }),
+      ],
+    });
+    return 1;
+  }
+}
+
+async function loadSdk() {
+  try {
+    return await import("@jarvis-protocol/sdk");
+  } catch (error) {
+    if (
+      error?.code !== "ERR_MODULE_NOT_FOUND"
+      || !String(error?.message ?? "").includes("@jarvis-protocol/sdk")
+    ) {
+      throw error;
+    }
+    const here = dirname(fileURLToPath(import.meta.url));
+    const localSdk = resolve(here, "../../typescript/src/index.js");
+    return import(pathToFileURL(localSdk).href);
+  }
+}
+
+function defaultIo() {
+  return {
+    stdout: process.stdout,
+    stderr: process.stderr,
+  };
+}
+
+function parseArgs(args) {
+  const positionals = [];
+  const flags = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg.startsWith("--")) {
+      const key = arg.slice(2);
+      const value = args[index + 1];
+      if (!value || value.startsWith("--")) {
+        throw new Error(`--${key} requires a value.`);
+      }
+      flags[key] = value;
+      index += 1;
+    } else {
+      positionals.push(arg);
+    }
+  }
+  return { positionals, flags };
+}
+
+async function dispatch(sdk, parsed) {
+  const [group, action, target] = parsed.positionals;
+  if (group === "validate" && action === "fixture") {
+    return validateFixtureCommand(sdk, requiredPath(target));
+  }
+  if (group === "validate" && action === "fixtures") {
+    return validateFixturesCommand(sdk, requiredPath(target));
+  }
+  if (group === "validate" && action === "record") {
+    return validateRecordCommand(sdk, requiredPath(target));
+  }
+  if (group === "validate" && action === "evidence-manifest") {
+    return validateEvidenceManifestCommand(sdk, requiredPath(target));
+  }
+  if (group === "check" && action === "headers") {
+    return checkHeadersCommand(sdk, requiredPath(target), parsed.flags);
+  }
+  if (group === "check" && action === "hash-chain") {
+    return checkHashChainCommand(sdk, requiredPath(target));
+  }
+  if (group === "list" && action === "rejection-ids") {
+    return listRejectionIdsCommand(sdk);
+  }
+  if (group === "print" && action === "compatibility-claim") {
+    return compatibilityClaimCommand(sdk);
+  }
+  throw new Error(`Unsupported command: ${parsed.positionals.join(" ")}`);
+}
+
+function requiredPath(value) {
+  if (!value) {
+    throw new Error("Input path is required.");
+  }
+  return value;
+}
+
+function validateFixtureCommand(sdk, file) {
+  const fixture = readJsonFile(file);
+  const result = fixtureRunResult(sdk, fixture, file);
+  return {
+    code: result.passed ? 0 : 1,
+    payload: result,
+  };
+}
+
+function validateFixturesCommand(sdk, directory) {
+  const root = resolve(directory);
+  const files = collectJsonFiles(root);
+  const results = files.map((file) => fixtureRunResult(sdk, readJsonFile(file), file));
+  const fixtureSetError = fixtureSetCompletenessError(sdk, root, files);
+  const passed = !fixtureSetError && results.every((result) => result.passed);
+  return {
+    code: passed ? 0 : 1,
+    payload: {
+      protocol_version: sdk.PROTOCOL_VERSION,
+      command: "validate fixtures",
+      directory,
+      passed,
+      fixture_count: results.length,
+      errors: fixtureSetError ? [fixtureSetError] : [],
+      results,
+    },
+  };
+}
+
+function validateRecordCommand(sdk, file) {
+  const input = readJsonFile(file);
+  const objectType = input.object_type ?? input.objectType;
+  if (!objectType) {
+    return failureOutcome(sdk, "validate record", "record.object_type", "Record input MUST include object_type.");
+  }
+  const record = input.record ?? input.body;
+  if (record === undefined) {
+    return failureOutcome(sdk, "validate record", "record", "Record input MUST include record.");
+  }
+  const result = sdk.validateProtocolRecord(objectType, record, input.context ?? input.options ?? {});
+  return validationOutcome(sdk, "validate record", result, { file, object_type: objectType });
+}
+
+function validateEvidenceManifestCommand(sdk, file) {
+  const input = readJsonFile(file);
+  const manifest = input.evidence_manifest ?? input.evidenceManifest ?? input.record ?? input;
+  const workSession = input.work_session ?? input.workSession;
+  const result = sdk.validateEvidenceManifest(manifest, { workSession });
+  return validationOutcome(sdk, "validate evidence-manifest", result, { file });
+}
+
+function checkHeadersCommand(sdk, file, flags) {
+  const input = readJsonFile(file);
+  const headers = input.headers ?? input;
+  const operationId = flags["operation-id"] ?? input.operation_id;
+  const operationClass = flags["operation-class"] ?? input.operation_class;
+  if (operationId) {
+    const context = OPERATION_CONTEXT[operationId];
+    if (!context) {
+      return failureOutcome(sdk, "check headers", "operation_id", `Unsupported operation_id: ${operationId}`);
+    }
+    const operation = {
+      ...input,
+      operation_id: operationId,
+      method: context.method,
+      path: context.path,
+      actor_id: input.actor_id ?? input.actorId ?? headers["Jarvis-Actor-Id"],
+      expected_status: input.expected_status ?? 200,
+      headers,
+    };
+    const result = sdk.validateOperationHeaders(operation);
+    return validationOutcome(sdk, "check headers", result, {
+      file,
+      operation_id: operationId,
+      operation_class: context.operationClass,
+    });
+  }
+  if (!operationClass) {
+    return failureOutcome(
+      sdk,
+      "check headers",
+      "operation_class",
+      "Header checks MUST include --operation-id or --operation-class.",
+    );
+  }
+  if (!ACCEPTED_OPERATION_CLASSES.has(operationClass)) {
+    return failureOutcome(sdk, "check headers", "operation_class", `Unsupported operation_class: ${operationClass}`);
+  }
+  const result = validateHeadersByOperationClass(sdk, headers, operationClass);
+  return validationOutcome(sdk, "check headers", result, {
+    file,
+    operation_class: operationClass,
+  });
+}
+
+function validateHeadersByOperationClass(sdk, headers, operationClass) {
+  if (operationClass === "worksession_scoped_mutation") {
+    return sdk.validateMutationHeaders(headers, { workSessionScoped: true });
+  }
+  if (operationClass === "non_worksession_mutation") {
+    return sdk.validateMutationHeaders(headers, { workSessionScoped: false });
+  }
+  if (operationClass === "worksession_scoped_read" || operationClass === "export_read") {
+    return sdk.validateReadHeaders(headers);
+  }
+  const mutationResult = sdk.validateMutationHeaders(headers, { workSessionScoped: true });
+  if (!mutationResult.valid) {
+    return mutationResult;
+  }
+  if (headers["Jarvis-Expected-WorkSession-Revision"] !== 0) {
+    return {
+      valid: false,
+      errors: [
+        sdk.protocolError("stale_work_session_revision", {
+          objectType: "headers",
+          field: "headers.Jarvis-Expected-WorkSession-Revision",
+          reason: "WorkSession genesis mutation MUST use expected revision 0.",
+          traceId: "trace:jarvis-cli",
+        }),
+      ],
+    };
+  }
+  if (headers["Jarvis-Previous-Event-Hash"] !== "hash:protocol-genesis") {
+    return {
+      valid: false,
+      errors: [
+        sdk.protocolError("invalid_previous_event_hash", {
+          objectType: "headers",
+          field: "headers.Jarvis-Previous-Event-Hash",
+          reason: "WorkSession genesis mutation MUST use hash:protocol-genesis.",
+          traceId: "trace:jarvis-cli",
+        }),
+      ],
+    };
+  }
+  return mutationResult;
+}
+
+function checkHashChainCommand(sdk, file) {
+  const input = readJsonFile(file);
+  const events = extractEvents(input);
+  const result = sdk.validateEventHashChain(events);
+  return validationOutcome(sdk, "check hash-chain", result, { file });
+}
+
+function listRejectionIdsCommand(sdk) {
+  return {
+    code: 0,
+    payload: {
+      protocol_version: sdk.PROTOCOL_VERSION,
+      command: "list rejection-ids",
+      passed: true,
+      rejection_ids: sdk.SCHEMA_ENUMS.ProtocolErrorId ?? [],
+    },
+  };
+}
+
+function compatibilityClaimCommand(sdk) {
+  return {
+    code: 0,
+    payload: {
+      protocol_version: sdk.PROTOCOL_VERSION,
+      command: "print compatibility-claim",
+      passed: true,
+      compatibility_claim: {
+        implementation: "<name> <implementation-version>",
+        "protocol compatibility": `Jarvis ${sdk.PROTOCOL_VERSION}`,
+        "conformance surface": "<conformance-surface>",
+        "verification date": "<YYYY-MM-DD>",
+        verifier: "self-attested",
+        evidence: "<evidence-ref-or-artifact-hash>",
+        "fixture or checklist basis": "Jarvis v0.1 conformance fixtures and checklist",
+        implementation_version: "<implementation-version>",
+        status: "implementation claim, not certification",
+        statement: "This implementation claims Jarvis v0.1 compatibility for the listed protocol surfaces.",
+        required_evidence: [
+          "valid fixture run",
+          "invalid fixture run with expected rejection ids",
+          "mutation-header validation",
+          "read-header validation",
+          "event hash-chain validation",
+          "EvidenceManifest export validation",
+        ],
+        boundary: "Jarvis compatibility does not certify host runtime, storage, auth, UI, model, tool, billing, deployment, or workflow behavior.",
+      },
+    },
+  };
+}
+
+function validationOutcome(sdk, command, result, extra = {}) {
+  return {
+    code: result.valid ? 0 : 1,
+    payload: {
+      protocol_version: sdk.PROTOCOL_VERSION,
+      command,
+      passed: result.valid,
+      valid: result.valid,
+      errors: result.errors,
+      ...extra,
+    },
+  };
+}
+
+function failureOutcome(sdk, command, field, reason) {
+  return {
+    code: 1,
+    payload: {
+      protocol_version: sdk.PROTOCOL_VERSION,
+      command,
+      passed: false,
+      valid: false,
+      errors: [
+        sdk.protocolError("invalid_export", {
+          objectType: "CLI",
+          field,
+          reason,
+          traceId: "trace:jarvis-cli",
+        }),
+      ],
+    },
+  };
+}
+
+function fixtureRunResult(sdk, fixture, file) {
+  const result = sdk.validateFixture(fixture);
+  const expectedResult = fixture.expected_result;
+  const expectedErrorId = fixture.expected_error_id;
+  const errorId = result.errors[0]?.error_id;
+  const rejectedExpected = expectedResult === "reject";
+  const acceptedExpected = expectedResult === "pass";
+  const passed = rejectedExpected
+    ? Boolean(expectedErrorId) && result.valid === false && errorId === expectedErrorId
+    : acceptedExpected && result.valid === true;
+  return {
+    protocol_version: sdk.PROTOCOL_VERSION,
+    command: "validate fixture",
+    file,
+    fixture_id: fixture.fixture_id,
+    expected_result: expectedResult,
+    expected_error_id: expectedErrorId,
+    passed,
+    valid: result.valid,
+    errors: result.errors,
+  };
+}
+
+function fixtureSetCompletenessError(sdk, root, files) {
+  const observed = new Set(files.map((file) => relative(root, file).split(sep).join("/")));
+  const required = new Set(REQUIRED_FIXTURE_PATHS);
+  const missing = REQUIRED_FIXTURE_PATHS.filter((path) => !observed.has(path));
+  const extra = [...observed].filter((path) => !required.has(path)).sort();
+  if (missing.length === 0 && extra.length === 0) {
+    return null;
+  }
+  return sdk.protocolError("invalid_export", {
+    objectType: "FixtureSet",
+    field: "fixtures",
+    reason: "Fixture directory MUST contain the complete Jarvis v0.1 fixture snapshot.",
+    remediation: `Missing: ${missing.join(", ") || "none"}. Extra: ${extra.join(", ") || "none"}.`,
+    traceId: "trace:jarvis-cli",
+  });
+}
+
+function readJsonFile(path) {
+  const text = readFileSync(resolve(path), "utf8");
+  return JSON.parse(text);
+}
+
+function collectJsonFiles(directory) {
+  const root = resolve(directory);
+  const entries = [];
+  function visit(path) {
+    const stat = statSync(path);
+    if (stat.isDirectory()) {
+      for (const entry of readdirSync(path).sort()) {
+        visit(resolve(path, entry));
+      }
+      return;
+    }
+    if (path.endsWith(".json")) {
+      entries.push(path);
+    }
+  }
+  visit(root);
+  return entries;
+}
+
+function extractEvents(input) {
+  if (Array.isArray(input)) {
+    return input;
+  }
+  if (Array.isArray(input.events)) {
+    return input.events;
+  }
+  if (input.records?.jarvis_events && typeof input.records.jarvis_events === "object") {
+    return Object.values(input.records.jarvis_events);
+  }
+  if (input.jarvis_events && typeof input.jarvis_events === "object") {
+    return Object.values(input.jarvis_events);
+  }
+  throw new Error("Hash-chain input MUST be an event array or contain events.");
+}
+
+function writeJson(stream, value) {
+  stream.write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+function isDirectRun() {
+  return process.argv[1]
+    && realpathSync(resolve(process.argv[1])) === realpathSync(fileURLToPath(import.meta.url));
+}
+
+if (isDirectRun()) {
+  runCli(process.argv.slice(2)).then((code) => {
+    process.exitCode = code;
+  });
+}

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -122,30 +122,45 @@ const REQUIRED_FIXTURE_PATHS = Object.freeze([
 ]);
 
 export async function runCli(args, io = defaultIo()) {
-  const sdk = await loadSdk();
+  let sdk;
   try {
+    sdk = await loadSdk();
     const parsed = parseArgs(args);
     const outcome = await dispatch(sdk, parsed);
     writeJson(io.stdout, outcome.payload);
     return outcome.code;
   } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
     writeJson(io.stdout, {
-      protocol_version: sdk.PROTOCOL_VERSION ?? CLI_PROTOCOL_VERSION,
+      protocol_version: sdk?.PROTOCOL_VERSION ?? CLI_PROTOCOL_VERSION,
       command: "jarvis",
       passed: false,
       valid: false,
-      errors: [
-        sdk.protocolError("invalid_export", {
-          objectType: "CLI",
-          field: "argv",
-          reason: error instanceof Error ? error.message : String(error),
-          remediation: "Run a supported Jarvis CLI command with the required input file.",
-          traceId: "trace:jarvis-cli",
-        }),
-      ],
+      errors: [cliProtocolError(sdk, "argv", reason)],
     });
     return 1;
   }
+}
+
+function cliProtocolError(sdk, field, reason) {
+  if (sdk?.protocolError) {
+    return sdk.protocolError("invalid_export", {
+      objectType: "CLI",
+      field,
+      reason,
+      remediation: "Run a supported Jarvis CLI command with the required input file.",
+      traceId: "trace:jarvis-cli",
+    });
+  }
+  return {
+    error_id: "invalid_export",
+    protocol_version: CLI_PROTOCOL_VERSION,
+    object_type: "CLI",
+    field,
+    reason,
+    remediation: "Run a supported Jarvis CLI command with the required input file.",
+    trace_id: "trace:jarvis-cli",
+  };
 }
 
 async function loadSdk() {
@@ -272,7 +287,15 @@ function validateRecordCommand(sdk, file) {
 
 function validateEvidenceManifestCommand(sdk, file) {
   const input = readJsonFile(file);
-  const manifest = input.evidence_manifest ?? input.evidenceManifest ?? input.record ?? input;
+  const manifest = input.evidence_manifest ?? input.evidenceManifest ?? input.record;
+  if (manifest === undefined) {
+    return failureOutcome(
+      sdk,
+      "validate evidence-manifest",
+      "evidence_manifest",
+      "EvidenceManifest input MUST include evidence_manifest, evidenceManifest, or record.",
+    );
+  }
   const workSession = input.work_session ?? input.workSession;
   const result = sdk.validateEvidenceManifest(manifest, { workSession });
   return validationOutcome(sdk, "validate evidence-manifest", result, { file });

--- a/packages/cli/tests/cli.test.js
+++ b/packages/cli/tests/cli.test.js
@@ -1,0 +1,526 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import { runCli } from "../src/index.js";
+
+const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const fixtureRoot = join(packageRoot, "fixtures/v0.1");
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function memoryIo() {
+  let stdout = "";
+  let stderr = "";
+  return {
+    io: {
+      stdout: {
+        write(chunk) {
+          stdout += chunk;
+        },
+      },
+      stderr: {
+        write(chunk) {
+          stderr += chunk;
+        },
+      },
+    },
+    output() {
+      return JSON.parse(stdout);
+    },
+    stderr() {
+      return stderr;
+    },
+  };
+}
+
+async function run(args) {
+  const capture = memoryIo();
+  const code = await runCli(args, capture.io);
+  return {
+    code,
+    payload: capture.output(),
+    stderr: capture.stderr(),
+  };
+}
+
+function writeJsonTemp(value) {
+  const dir = mkdtempSync(join(tmpdir(), "jarvis-cli-"));
+  const file = join(dir, "input.json");
+  writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+  return {
+    file,
+    cleanup() {
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+test("validate fixture accepts golden-path fixture expectation", async () => {
+  const result = await run([
+    "validate",
+    "fixture",
+    join(fixtureRoot, "valid/golden-path.json"),
+  ]);
+  assert.equal(result.code, 0);
+  assert.equal(result.payload.command, "validate fixture");
+  assert.equal(result.payload.passed, true);
+  assert.equal(result.payload.valid, true);
+});
+
+test("validate fixture passes when invalid fixture rejects as expected", async () => {
+  const result = await run([
+    "validate",
+    "fixture",
+    join(fixtureRoot, "invalid/missing-actor.json"),
+  ]);
+  assert.equal(result.code, 0);
+  assert.equal(result.payload.passed, true);
+  assert.equal(result.payload.valid, false);
+  assert.equal(result.payload.expected_error_id, "missing_actor");
+  assert.equal(result.payload.errors[0].error_id, "missing_actor");
+});
+
+test("validate fixtures runs fixture directory expectations", async () => {
+  const result = await run(["validate", "fixtures", fixtureRoot]);
+  assert.equal(result.code, 0);
+  assert.equal(result.payload.command, "validate fixtures");
+  assert.equal(result.payload.passed, true);
+  assert.ok(result.payload.fixture_count > 1);
+});
+
+test("validate fixtures rejects incomplete fixture directory", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "jarvis-cli-fixtures-"));
+  const validDir = join(dir, "valid");
+  const file = join(validDir, "golden-path.json");
+  try {
+    symlinkSync(join(fixtureRoot, "valid"), validDir);
+    const result = await run(["validate", "fixtures", dir]);
+    assert.equal(readJson(file).fixture_id, "valid-golden-path-v01");
+    assert.equal(result.code, 1);
+    assert.equal(result.payload.passed, false);
+    assert.equal(result.payload.errors[0].error_id, "invalid_export");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("validate fixture rejects non-canonical expected_result aliases", async () => {
+  const fixture = readJson(join(fixtureRoot, "invalid/missing-actor.json"));
+  fixture.expected_result = "rejected";
+  const input = writeJsonTemp(fixture);
+  try {
+    const result = await run(["validate", "fixture", input.file]);
+    assert.equal(result.code, 1);
+    assert.equal(result.payload.passed, false);
+  } finally {
+    input.cleanup();
+  }
+});
+
+test("validate record rejects malformed protocol record", async () => {
+  const input = writeJsonTemp({
+    object_type: "OutcomeReport",
+    record: {
+      id: "outcome-test",
+      unexpected_host_field: "host",
+    },
+  });
+  try {
+    const result = await run(["validate", "record", input.file]);
+    assert.equal(result.code, 1);
+    assert.equal(result.payload.passed, false);
+    assert.equal(result.payload.errors[0].error_id, "invalid_export");
+  } finally {
+    input.cleanup();
+  }
+});
+
+test("validate record rejects unknown protocol object type", async () => {
+  const input = writeJsonTemp({
+    object_type: "NotAProtocolObject",
+    record: {},
+  });
+  try {
+    const result = await run(["validate", "record", input.file]);
+    assert.equal(result.code, 1);
+    assert.equal(result.payload.errors[0].error_id, "invalid_export");
+    assert.equal(result.payload.errors[0].field, "object_type");
+  } finally {
+    input.cleanup();
+  }
+});
+
+test("validate record rejects nested host-private protocol fields", async () => {
+  const golden = readJson(join(fixtureRoot, "valid/golden-path.json"));
+  const event = structuredClone(golden.records.jarvis_events.worksession_created);
+  event.payload.raw_runtime_state = "host-only";
+  const input = writeJsonTemp({
+    object_type: "JarvisEvent",
+    record: event,
+  });
+  try {
+    const result = await run(["validate", "record", input.file]);
+    assert.equal(result.code, 1);
+    assert.equal(result.payload.errors[0].error_id, "forbidden_host_private_field");
+    assert.equal(result.payload.errors[0].field, "payload.raw_runtime_state");
+  } finally {
+    input.cleanup();
+  }
+});
+
+test("validate evidence-manifest rejects host-private export field", async () => {
+  const golden = readJson(join(fixtureRoot, "valid/golden-path.json"));
+  const evidenceManifest = structuredClone(golden.records.evidence_manifests.portable_export);
+  evidenceManifest.raw_runtime_state = "secret";
+  const input = writeJsonTemp({
+    evidence_manifest: evidenceManifest,
+    work_session: golden.records.work_sessions.completed,
+  });
+  try {
+    const result = await run(["validate", "evidence-manifest", input.file]);
+    assert.equal(result.code, 1);
+    assert.equal(result.payload.errors[0].error_id, "forbidden_host_private_field");
+  } finally {
+    input.cleanup();
+  }
+});
+
+test("validate evidence-manifest rejects host-private separator variants", async () => {
+  const golden = readJson(join(fixtureRoot, "valid/golden-path.json"));
+  const evidenceManifest = structuredClone(golden.records.evidence_manifests.portable_export);
+  evidenceManifest.evidence_item_refs[0]["private-key"] = "secret";
+  const input = writeJsonTemp({
+    evidence_manifest: evidenceManifest,
+    work_session: golden.records.work_sessions.completed,
+  });
+  try {
+    const result = await run(["validate", "evidence-manifest", input.file]);
+    assert.equal(result.code, 1);
+    assert.equal(result.payload.errors[0].error_id, "forbidden_host_private_field");
+    assert.equal(result.payload.errors[0].field, "evidence_item_refs[0].private-key");
+  } finally {
+    input.cleanup();
+  }
+});
+
+test("validate evidence-manifest rejects missing terminal WorkSession source", async () => {
+  const golden = readJson(join(fixtureRoot, "valid/golden-path.json"));
+  const input = writeJsonTemp({
+    evidence_manifest: golden.records.evidence_manifests.portable_export,
+  });
+  try {
+    const result = await run(["validate", "evidence-manifest", input.file]);
+    assert.equal(result.code, 1);
+    assert.equal(result.payload.errors[0].error_id, "invalid_evidence_export_state");
+    assert.equal(result.payload.errors[0].field, "work_session.status");
+  } finally {
+    input.cleanup();
+  }
+});
+
+test("validate evidence-manifest rejects mismatched WorkSession source", async () => {
+  const golden = readJson(join(fixtureRoot, "valid/golden-path.json"));
+  const input = writeJsonTemp({
+    evidence_manifest: golden.records.evidence_manifests.portable_export,
+    work_session: {
+      ...golden.records.work_sessions.completed,
+      id: "ws-other",
+    },
+  });
+  try {
+    const result = await run(["validate", "evidence-manifest", input.file]);
+    assert.equal(result.code, 1);
+    assert.equal(result.payload.errors[0].error_id, "invalid_evidence_export_state");
+    assert.equal(result.payload.errors[0].field, "work_session_id");
+  } finally {
+    input.cleanup();
+  }
+});
+
+test("check headers validates WorkSession genesis mutation headers", async () => {
+  const input = writeJsonTemp({
+    headers: {
+      Authorization: "HostAuth test",
+      "Jarvis-Protocol-Version": "v0.1",
+      "Jarvis-Actor-Id": "actor-test",
+      "Jarvis-Idempotency-Key": "idem-test",
+      "Jarvis-Request-Timestamp": "2026-06-16T10:00:00Z",
+      "Jarvis-Expected-WorkSession-Revision": 0,
+      "Jarvis-Previous-Event-Hash": "hash:protocol-genesis",
+    },
+  });
+  try {
+    const result = await run([
+      "check",
+      "headers",
+      input.file,
+      "--operation-class",
+      "worksession_genesis_mutation",
+    ]);
+    assert.equal(result.code, 0);
+    assert.equal(result.payload.passed, true);
+  } finally {
+    input.cleanup();
+  }
+});
+
+test("check headers rejects missing read header", async () => {
+  const input = writeJsonTemp({
+    headers: {
+      Authorization: "HostAuth test",
+      "Jarvis-Protocol-Version": "v0.1",
+    },
+  });
+  try {
+    const result = await run([
+      "check",
+      "headers",
+      input.file,
+      "--operation-id",
+      "exportEvidenceManifest",
+    ]);
+    assert.equal(result.code, 1);
+    assert.equal(result.payload.errors[0].error_id, "missing_actor");
+  } finally {
+    input.cleanup();
+  }
+});
+
+test("check headers rejects operation-id downgrade attempts", async () => {
+  const input = writeJsonTemp({
+    method: "GET",
+    path: "/work-sessions/ws-test/export",
+    headers: {
+      Authorization: "HostAuth test",
+      "Jarvis-Protocol-Version": "v0.1",
+      "Jarvis-Actor-Id": "actor-test",
+    },
+  });
+  try {
+    const result = await run([
+      "check",
+      "headers",
+      input.file,
+      "--operation-id",
+      "createRequest",
+    ]);
+    assert.equal(result.code, 1);
+    assert.equal(result.payload.errors[0].error_id, "missing_idempotency_key");
+  } finally {
+    input.cleanup();
+  }
+});
+
+test("check headers rejects mutation-only headers on read operations", async () => {
+  const input = writeJsonTemp({
+    headers: {
+      Authorization: "HostAuth test",
+      "Jarvis-Protocol-Version": "v0.1",
+      "Jarvis-Actor-Id": "actor-test",
+      "Jarvis-Idempotency-Key": "idem-test",
+    },
+  });
+  try {
+    const result = await run([
+      "check",
+      "headers",
+      input.file,
+      "--operation-id",
+      "exportEvidenceManifest",
+    ]);
+    assert.equal(result.code, 1);
+    assert.equal(result.payload.errors[0].error_id, "invalid_export");
+    assert.equal(result.payload.errors[0].field, "headers.Jarvis-Idempotency-Key");
+  } finally {
+    input.cleanup();
+  }
+});
+
+test("check headers rejects missing mutation header", async () => {
+  const input = writeJsonTemp({
+    headers: {
+      Authorization: "HostAuth test",
+      "Jarvis-Protocol-Version": "v0.1",
+      "Jarvis-Actor-Id": "actor-test",
+      "Jarvis-Request-Timestamp": "2026-06-16T10:00:00Z",
+      "Jarvis-Expected-WorkSession-Revision": 0,
+      "Jarvis-Previous-Event-Hash": "hash:protocol-genesis",
+    },
+  });
+  try {
+    const result = await run([
+      "check",
+      "headers",
+      input.file,
+      "--operation-class",
+      "worksession_scoped_mutation",
+    ]);
+    assert.equal(result.code, 1);
+    assert.equal(result.payload.errors[0].error_id, "missing_idempotency_key");
+  } finally {
+    input.cleanup();
+  }
+});
+
+test("check headers rejects unauthorized Actor header", async () => {
+  const input = writeJsonTemp({
+    headers: {
+      Authorization: "",
+      "Jarvis-Protocol-Version": "v0.1",
+      "Jarvis-Actor-Id": "actor-test",
+      "Jarvis-Idempotency-Key": "idem-test",
+      "Jarvis-Request-Timestamp": "2026-06-16T10:00:00Z",
+      "Jarvis-Expected-WorkSession-Revision": 0,
+      "Jarvis-Previous-Event-Hash": "hash:protocol-genesis",
+    },
+  });
+  try {
+    const result = await run([
+      "check",
+      "headers",
+      input.file,
+      "--operation-class",
+      "worksession_scoped_mutation",
+    ]);
+    assert.equal(result.code, 1);
+    assert.equal(result.payload.errors[0].error_id, "unauthorized_actor");
+  } finally {
+    input.cleanup();
+  }
+});
+
+test("check headers rejects stale WorkSession genesis revision", async () => {
+  const input = writeJsonTemp({
+    headers: {
+      Authorization: "HostAuth test",
+      "Jarvis-Protocol-Version": "v0.1",
+      "Jarvis-Actor-Id": "actor-test",
+      "Jarvis-Idempotency-Key": "idem-test",
+      "Jarvis-Request-Timestamp": "2026-06-16T10:00:00Z",
+      "Jarvis-Expected-WorkSession-Revision": 1,
+      "Jarvis-Previous-Event-Hash": "hash:protocol-genesis",
+    },
+  });
+  try {
+    const result = await run([
+      "check",
+      "headers",
+      input.file,
+      "--operation-class",
+      "worksession_genesis_mutation",
+    ]);
+    assert.equal(result.code, 1);
+    assert.equal(result.payload.errors[0].error_id, "stale_work_session_revision");
+  } finally {
+    input.cleanup();
+  }
+});
+
+test("check hash-chain rejects previous hash mismatch", async () => {
+  const input = writeJsonTemp({
+    events: [
+      {
+        sequence: 1,
+        previous_hash: "hash:protocol-genesis",
+        event_hash: "hash:first",
+      },
+      {
+        sequence: 2,
+        previous_hash: "hash:wrong",
+        event_hash: "hash:second",
+      },
+    ],
+  });
+  try {
+    const result = await run(["check", "hash-chain", input.file]);
+    assert.equal(result.code, 1);
+    assert.equal(result.payload.errors[0].error_id, "invalid_previous_event_hash");
+  } finally {
+    input.cleanup();
+  }
+});
+
+test("list rejection-ids emits OpenAPI rejection ids", async () => {
+  const result = await run(["list", "rejection-ids"]);
+  assert.equal(result.code, 0);
+  assert.equal(result.payload.passed, true);
+  assert.ok(result.payload.rejection_ids.includes("missing_actor"));
+  assert.ok(result.payload.rejection_ids.includes("outcome_report_requires_terminal_source"));
+});
+
+test("validate fixture covers sealed WorkSession and EvidenceManifest rejection paths", async () => {
+  const sealedWorkSession = await run([
+    "validate",
+    "fixture",
+    join(fixtureRoot, "invalid/sealed-work-session-mutation.json"),
+  ]);
+  assert.equal(sealedWorkSession.code, 0);
+  assert.equal(sealedWorkSession.payload.errors[0].error_id, "sealed_work_session_mutation");
+
+  const sealedEvidence = await run([
+    "validate",
+    "fixture",
+    join(fixtureRoot, "invalid/sealed-evidence-mutation.json"),
+  ]);
+  assert.equal(sealedEvidence.code, 0);
+  assert.equal(sealedEvidence.payload.errors[0].error_id, "sealed_evidence_mutation");
+});
+
+test("validate fixture rejects invalid fixture without expected error id", async () => {
+  const fixture = readJson(join(fixtureRoot, "invalid/missing-actor.json"));
+  delete fixture.expected_error_id;
+  const input = writeJsonTemp(fixture);
+  try {
+    const result = await run(["validate", "fixture", input.file]);
+    assert.equal(result.code, 1);
+    assert.equal(result.payload.passed, false);
+    assert.equal(result.payload.valid, false);
+    assert.equal(result.payload.expected_error_id, undefined);
+  } finally {
+    input.cleanup();
+  }
+});
+
+test("print compatibility-claim emits non-certification template", async () => {
+  const result = await run(["print", "compatibility-claim"]);
+  assert.equal(result.code, 0);
+  assert.equal(result.payload.passed, true);
+  assert.equal(result.payload.compatibility_claim.status, "implementation claim, not certification");
+  assert.equal(result.payload.compatibility_claim.verifier, "self-attested");
+  assert.ok(result.payload.compatibility_claim.evidence);
+  assert.ok(result.payload.compatibility_claim["conformance surface"]);
+});
+
+test("unsupported command emits machine-readable protocol error", async () => {
+  const result = await run(["run", "agent"]);
+  assert.equal(result.code, 1);
+  assert.equal(result.payload.valid, false);
+  assert.equal(result.payload.errors[0].error_id, "invalid_export");
+  assert.equal(result.payload.errors[0].object_type, "CLI");
+});
+
+test("installed bin symlink executes CLI", () => {
+  const dir = mkdtempSync(join(tmpdir(), "jarvis-cli-bin-"));
+  const link = join(dir, "jarvis");
+  try {
+    symlinkSync(join(packageRoot, "src/index.js"), link);
+    const result = spawnSync(process.execPath, [link, "list", "rejection-ids"], {
+      cwd: packageRoot,
+      encoding: "utf8",
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.ok(result.stdout.length > 0);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.command, "list rejection-ids");
+    assert.equal(payload.passed, true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/cli/tests/cli.test.js
+++ b/packages/cli/tests/cli.test.js
@@ -192,6 +192,19 @@ test("validate evidence-manifest rejects host-private export field", async () =>
   }
 });
 
+test("validate evidence-manifest rejects malformed input envelope", async () => {
+  const golden = readJson(join(fixtureRoot, "valid/golden-path.json"));
+  const input = writeJsonTemp(golden.records.evidence_manifests.portable_export);
+  try {
+    const result = await run(["validate", "evidence-manifest", input.file]);
+    assert.equal(result.code, 1);
+    assert.equal(result.payload.errors[0].error_id, "invalid_export");
+    assert.equal(result.payload.errors[0].field, "evidence_manifest");
+  } finally {
+    input.cleanup();
+  }
+});
+
 test("validate evidence-manifest rejects host-private separator variants", async () => {
   const golden = readJson(join(fixtureRoot, "valid/golden-path.json"));
   const evidenceManifest = structuredClone(golden.records.evidence_manifests.portable_export);

--- a/packages/python/src/jarvis_protocol/__init__.py
+++ b/packages/python/src/jarvis_protocol/__init__.py
@@ -122,58 +122,62 @@ OBJECT_BY_OPERATION = {
     "exportEvidenceManifest": "EvidenceManifest",
 }
 
-OPERATION_METHOD_BY_ID = {
-    "registerWorker": "PUT",
-    "registerActor": "PUT",
-    "createWorkSession": "POST",
-    "getWorkSession": "GET",
-    "appendJarvisEvent": "POST",
-    "recordPolicyDecision": "POST",
-    "createRequest": "POST",
-    "recordReview": "POST",
-    "recordTakeover": "POST",
-    "recordContribution": "POST",
-    "createLearningRecord": "POST",
-    "createMemoryProposal": "POST",
-    "createSkillProposal": "POST",
-    "exportEvidenceManifest": "GET",
-    "submitOutcomeReport": "POST",
-}
-
-OPERATION_PATH_BY_ID = {
-    "registerWorker": "/workers/{worker_id}",
-    "registerActor": "/actors/{actor_id}",
-    "createWorkSession": "/work-sessions",
-    "getWorkSession": "/work-sessions/{work_session_id}",
-    "appendJarvisEvent": "/work-sessions/{work_session_id}/events",
-    "recordPolicyDecision": "/work-sessions/{work_session_id}/policy-decisions",
-    "createRequest": "/work-sessions/{work_session_id}/requests",
-    "recordReview": "/work-sessions/{work_session_id}/reviews",
-    "recordTakeover": "/work-sessions/{work_session_id}/takeovers",
-    "recordContribution": "/work-sessions/{work_session_id}/contributions",
-    "createLearningRecord": "/work-sessions/{work_session_id}/learning-records",
-    "createMemoryProposal": "/work-sessions/{work_session_id}/memory-proposals",
-    "createSkillProposal": "/work-sessions/{work_session_id}/skill-proposals",
-    "exportEvidenceManifest": "/work-sessions/{work_session_id}/export",
-    "submitOutcomeReport": "/outcome-reports",
-}
-
-OPERATION_STATUS_BY_ID = {
-    "registerWorker": {200, 400},
-    "registerActor": {200, 400},
-    "createWorkSession": {201, 400},
-    "getWorkSession": {200, 400},
-    "appendJarvisEvent": {201, 400},
-    "recordPolicyDecision": {201, 400},
-    "createRequest": {201, 400},
-    "recordReview": {201, 400},
-    "recordTakeover": {201, 400},
-    "recordContribution": {201, 400},
-    "createLearningRecord": {201, 400},
-    "createMemoryProposal": {201, 400},
-    "createSkillProposal": {201, 400},
-    "exportEvidenceManifest": {200, 400},
-    "submitOutcomeReport": {202, 400},
+OPERATION_BINDINGS_BY_ID = {
+    "registerWorker": {"method": "PUT", "path": "/workers/{worker_id}", "statuses": {200, 400}},
+    "registerActor": {"method": "PUT", "path": "/actors/{actor_id}", "statuses": {200, 400}},
+    "createWorkSession": {"method": "POST", "path": "/work-sessions", "statuses": {201, 400}},
+    "getWorkSession": {"method": "GET", "path": "/work-sessions/{work_session_id}", "statuses": {200, 400}},
+    "appendJarvisEvent": {
+        "method": "POST",
+        "path": "/work-sessions/{work_session_id}/events",
+        "statuses": {201, 400},
+    },
+    "recordPolicyDecision": {
+        "method": "POST",
+        "path": "/work-sessions/{work_session_id}/policy-decisions",
+        "statuses": {201, 400},
+    },
+    "createRequest": {
+        "method": "POST",
+        "path": "/work-sessions/{work_session_id}/requests",
+        "statuses": {201, 400},
+    },
+    "recordReview": {
+        "method": "POST",
+        "path": "/work-sessions/{work_session_id}/reviews",
+        "statuses": {201, 400},
+    },
+    "recordTakeover": {
+        "method": "POST",
+        "path": "/work-sessions/{work_session_id}/takeovers",
+        "statuses": {201, 400},
+    },
+    "recordContribution": {
+        "method": "POST",
+        "path": "/work-sessions/{work_session_id}/contributions",
+        "statuses": {201, 400},
+    },
+    "createLearningRecord": {
+        "method": "POST",
+        "path": "/work-sessions/{work_session_id}/learning-records",
+        "statuses": {201, 400},
+    },
+    "createMemoryProposal": {
+        "method": "POST",
+        "path": "/work-sessions/{work_session_id}/memory-proposals",
+        "statuses": {201, 400},
+    },
+    "createSkillProposal": {
+        "method": "POST",
+        "path": "/work-sessions/{work_session_id}/skill-proposals",
+        "statuses": {201, 400},
+    },
+    "exportEvidenceManifest": {
+        "method": "GET",
+        "path": "/work-sessions/{work_session_id}/export",
+        "statuses": {200, 400},
+    },
+    "submitOutcomeReport": {"method": "POST", "path": "/outcome-reports", "statuses": {202, 400}},
 }
 
 ACTOR_BODY_FIELD_BY_OPERATION = {
@@ -328,13 +332,15 @@ def _worker_grants(worker: Mapping[str, Any] | None) -> set[str]:
 
 def _operation_method(operation: Mapping[str, Any] | None) -> Any:
     if operation:
-        return OPERATION_METHOD_BY_ID.get(operation.get("operation_id"), operation.get("method"))
+        binding = OPERATION_BINDINGS_BY_ID.get(operation.get("operation_id"))
+        return binding["method"] if binding else operation.get("method")
     return None
 
 
 def _operation_path(operation: Mapping[str, Any] | None) -> str:
     if operation:
-        return OPERATION_PATH_BY_ID.get(operation.get("operation_id"), operation.get("path", ""))
+        binding = OPERATION_BINDINGS_BY_ID.get(operation.get("operation_id"))
+        return binding["path"] if binding else operation.get("path", "")
     return ""
 
 
@@ -352,7 +358,8 @@ def _operation_path_matches_template(template: str, path: Any) -> bool:
 
 def _operation_binding_error(operation: Mapping[str, Any] | None) -> dict[str, Any] | None:
     operation_id = operation.get("operation_id") if operation else None
-    if operation_id not in OPERATION_METHOD_BY_ID:
+    binding = OPERATION_BINDINGS_BY_ID.get(operation_id)
+    if not binding:
         return protocol_error(
             "invalid_export",
             {
@@ -361,7 +368,7 @@ def _operation_binding_error(operation: Mapping[str, Any] | None) -> dict[str, A
                 "reason": "Fixture operation_id MUST exist in the Jarvis OpenAPI binding.",
             },
         )
-    if operation.get("method") != OPERATION_METHOD_BY_ID[operation_id]:
+    if operation.get("method") != binding["method"]:
         return protocol_error(
             "invalid_export",
             {
@@ -370,7 +377,7 @@ def _operation_binding_error(operation: Mapping[str, Any] | None) -> dict[str, A
                 "reason": "Fixture operation method MUST match the Jarvis OpenAPI binding.",
             },
         )
-    if not _operation_path_matches_template(OPERATION_PATH_BY_ID[operation_id], operation.get("path")):
+    if not _operation_path_matches_template(binding["path"], operation.get("path")):
         return protocol_error(
             "invalid_export",
             {
@@ -379,7 +386,7 @@ def _operation_binding_error(operation: Mapping[str, Any] | None) -> dict[str, A
                 "reason": "Fixture operation path MUST match the Jarvis OpenAPI binding.",
             },
         )
-    if operation.get("expected_status") not in OPERATION_STATUS_BY_ID[operation_id]:
+    if operation.get("expected_status") not in binding["statuses"]:
         return protocol_error(
             "invalid_export",
             {
@@ -1443,9 +1450,10 @@ def _detect_fixture_error(
 ) -> dict[str, Any] | None:
     records = fixture.get("records", {}) if isinstance(fixture.get("records"), dict) else {}
     body = _operation_body(fixture, operation)
-    binding_shape_error = _operation_binding_error(operation)
-    if binding_shape_error:
-        return binding_shape_error
+    if operation is not None:
+        binding_shape_error = _operation_binding_error(operation)
+        if binding_shape_error:
+            return binding_shape_error
     header_result = validate_operation_headers(operation, {"skip_timestamp_skew": True})
     if not header_result.valid:
         return header_result.errors[0]

--- a/packages/python/src/jarvis_protocol/__init__.py
+++ b/packages/python/src/jarvis_protocol/__init__.py
@@ -49,6 +49,13 @@ READ_HEADERS = (
     "Jarvis-Actor-Id",
 )
 
+MUTATION_ONLY_HEADERS = (
+    "Jarvis-Idempotency-Key",
+    "Jarvis-Request-Timestamp",
+    "Jarvis-Expected-WorkSession-Revision",
+    "Jarvis-Previous-Event-Hash",
+)
+
 TERMINAL_WORK_SESSION_STATES = (
     "completed",
     "failed",
@@ -113,6 +120,60 @@ OBJECT_BY_OPERATION = {
     "createSkillProposal": "SkillProposal",
     "submitOutcomeReport": "OutcomeReport",
     "exportEvidenceManifest": "EvidenceManifest",
+}
+
+OPERATION_METHOD_BY_ID = {
+    "registerWorker": "PUT",
+    "registerActor": "PUT",
+    "createWorkSession": "POST",
+    "getWorkSession": "GET",
+    "appendJarvisEvent": "POST",
+    "recordPolicyDecision": "POST",
+    "createRequest": "POST",
+    "recordReview": "POST",
+    "recordTakeover": "POST",
+    "recordContribution": "POST",
+    "createLearningRecord": "POST",
+    "createMemoryProposal": "POST",
+    "createSkillProposal": "POST",
+    "exportEvidenceManifest": "GET",
+    "submitOutcomeReport": "POST",
+}
+
+OPERATION_PATH_BY_ID = {
+    "registerWorker": "/workers/{worker_id}",
+    "registerActor": "/actors/{actor_id}",
+    "createWorkSession": "/work-sessions",
+    "getWorkSession": "/work-sessions/{work_session_id}",
+    "appendJarvisEvent": "/work-sessions/{work_session_id}/events",
+    "recordPolicyDecision": "/work-sessions/{work_session_id}/policy-decisions",
+    "createRequest": "/work-sessions/{work_session_id}/requests",
+    "recordReview": "/work-sessions/{work_session_id}/reviews",
+    "recordTakeover": "/work-sessions/{work_session_id}/takeovers",
+    "recordContribution": "/work-sessions/{work_session_id}/contributions",
+    "createLearningRecord": "/work-sessions/{work_session_id}/learning-records",
+    "createMemoryProposal": "/work-sessions/{work_session_id}/memory-proposals",
+    "createSkillProposal": "/work-sessions/{work_session_id}/skill-proposals",
+    "exportEvidenceManifest": "/work-sessions/{work_session_id}/export",
+    "submitOutcomeReport": "/outcome-reports",
+}
+
+OPERATION_STATUS_BY_ID = {
+    "registerWorker": {200, 400},
+    "registerActor": {200, 400},
+    "createWorkSession": {201, 400},
+    "getWorkSession": {200, 400},
+    "appendJarvisEvent": {201, 400},
+    "recordPolicyDecision": {201, 400},
+    "createRequest": {201, 400},
+    "recordReview": {201, 400},
+    "recordTakeover": {201, 400},
+    "recordContribution": {201, 400},
+    "createLearningRecord": {201, 400},
+    "createMemoryProposal": {201, 400},
+    "createSkillProposal": {201, 400},
+    "exportEvidenceManifest": {200, 400},
+    "submitOutcomeReport": {202, 400},
 }
 
 ACTOR_BODY_FIELD_BY_OPERATION = {
@@ -265,6 +326,71 @@ def _worker_grants(worker: Mapping[str, Any] | None) -> set[str]:
     return {grant for grant in grants if isinstance(grant, str)} if isinstance(grants, list) else set()
 
 
+def _operation_method(operation: Mapping[str, Any] | None) -> Any:
+    if operation:
+        return OPERATION_METHOD_BY_ID.get(operation.get("operation_id"), operation.get("method"))
+    return None
+
+
+def _operation_path(operation: Mapping[str, Any] | None) -> str:
+    if operation:
+        return OPERATION_PATH_BY_ID.get(operation.get("operation_id"), operation.get("path", ""))
+    return ""
+
+
+def _operation_path_matches_template(template: str, path: Any) -> bool:
+    if not _is_nonempty_string(template) or not _is_nonempty_string(path):
+        return False
+    parts = []
+    for segment in template.split("/"):
+        if re.fullmatch(r"\{[^/]+\}", segment):
+            parts.append(r"[^/]+")
+        else:
+            parts.append(re.escape(segment))
+    return re.fullmatch("/".join(parts), path) is not None
+
+
+def _operation_binding_error(operation: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    operation_id = operation.get("operation_id") if operation else None
+    if operation_id not in OPERATION_METHOD_BY_ID:
+        return protocol_error(
+            "invalid_export",
+            {
+                "object_type": "FixtureOperation",
+                "field": "operation_id",
+                "reason": "Fixture operation_id MUST exist in the Jarvis OpenAPI binding.",
+            },
+        )
+    if operation.get("method") != OPERATION_METHOD_BY_ID[operation_id]:
+        return protocol_error(
+            "invalid_export",
+            {
+                "object_type": "FixtureOperation",
+                "field": "method",
+                "reason": "Fixture operation method MUST match the Jarvis OpenAPI binding.",
+            },
+        )
+    if not _operation_path_matches_template(OPERATION_PATH_BY_ID[operation_id], operation.get("path")):
+        return protocol_error(
+            "invalid_export",
+            {
+                "object_type": "FixtureOperation",
+                "field": "path",
+                "reason": "Fixture operation path MUST match the Jarvis OpenAPI binding.",
+            },
+        )
+    if operation.get("expected_status") not in OPERATION_STATUS_BY_ID[operation_id]:
+        return protocol_error(
+            "invalid_export",
+            {
+                "object_type": "FixtureOperation",
+                "field": "expected_status",
+                "reason": "Fixture operation expected_status MUST match the Jarvis OpenAPI binding.",
+            },
+        )
+    return None
+
+
 def _target_work_session_id(operation: Mapping[str, Any] | None, body: Mapping[str, Any] | None) -> Any:
     if operation and operation.get("work_session_id") is not None:
         return operation.get("work_session_id")
@@ -323,6 +449,34 @@ def _outcome_report_source_work_session(
         if snapshot.get("status") in TERMINAL_WORK_SESSION_STATES:
             return snapshot
     return candidates[0] if candidates else None
+
+
+def _evidence_manifest_source_work_session(
+    fixture: Mapping[str, Any],
+    evidence_manifest: Mapping[str, Any] | None,
+    operation: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    records = fixture.get("records", {}) if isinstance(fixture.get("records"), dict) else {}
+    expected_field = fixture.get("expected_error_field")
+    if (
+        fixture.get("expected_error_id") == "invalid_evidence_export_state"
+        and _is_nonempty_string(expected_field)
+        and expected_field.endswith(".status")
+    ):
+        referenced = _get_ref(fixture, expected_field.removesuffix(".status"))
+        if isinstance(referenced, dict):
+            return referenced
+    work_session_id = evidence_manifest.get("work_session_id") if isinstance(evidence_manifest, dict) else None
+    for snapshot in _all_records(records, "work_sessions"):
+        if snapshot.get("id") == work_session_id and snapshot.get("status") in TERMINAL_WORK_SESSION_STATES:
+            return snapshot
+    operation_snapshot = _work_session_snapshot_for_operation(records, operation, evidence_manifest)
+    if operation_snapshot:
+        return operation_snapshot
+    for snapshot in _all_records(records, "work_sessions"):
+        if snapshot.get("id") == work_session_id:
+            return snapshot
+    return None
 
 
 def _operation_body_binding_error(
@@ -399,7 +553,7 @@ def _operation_state_error(
 ) -> dict[str, Any] | None:
     if operation and operation.get("operation_id") == "createWorkSession":
         return _create_work_session_genesis_error(operation) or _create_work_session_body_genesis_error(body)
-    path = operation.get("path") if operation else None
+    path = _operation_path(operation)
     if not isinstance(path, str) or not path.startswith("/work-sessions"):
         return None
     headers = operation.get("headers", {}) if operation else {}
@@ -494,6 +648,15 @@ def _evidence_manifest_export_error(
             },
         )
     work_session_status = work_session.get("status") if isinstance(work_session, dict) else None
+    if not work_session_status:
+        return protocol_error(
+            "invalid_evidence_export_state",
+            {
+                "object_type": "EvidenceManifest",
+                "field": "work_session.status",
+                "reason": "EvidenceManifest export requires a terminal WorkSession source.",
+            },
+        )
     if work_session_status and work_session_status not in TERMINAL_WORK_SESSION_STATES:
         return protocol_error(
             "invalid_evidence_export_state",
@@ -501,6 +664,19 @@ def _evidence_manifest_export_error(
                 "object_type": "EvidenceManifest",
                 "field": "work_session.status",
                 "reason": "EvidenceManifest export requires a terminal WorkSession source.",
+            },
+        )
+    if (
+        not isinstance(work_session, dict)
+        or not isinstance(evidence_manifest, dict)
+        or work_session.get("id") != evidence_manifest.get("work_session_id")
+    ):
+        return protocol_error(
+            "invalid_evidence_export_state",
+            {
+                "object_type": "EvidenceManifest",
+                "field": "work_session_id",
+                "reason": "EvidenceManifest source WorkSession id MUST match EvidenceManifest.work_session_id.",
             },
         )
     return None
@@ -738,7 +914,20 @@ def validate_mutation_headers(headers: Any, options: Mapping[str, Any] | None = 
 def validate_read_headers(headers: Any, options: Mapping[str, Any] | None = None) -> ValidationResult:
     options = dict(options or {})
     options["required_headers"] = READ_HEADERS
-    return validate_headers(headers, options)
+    result = validate_headers(headers, options)
+    if not result.valid:
+        return result
+    forbidden_header = next((header for header in MUTATION_ONLY_HEADERS if header in headers), None)
+    if forbidden_header:
+        return _fail(
+            "invalid_export",
+            {
+                "object_type": "headers",
+                "field": f"headers.{forbidden_header}",
+                "reason": "Read operations MUST NOT include mutation-only headers.",
+            },
+        )
+    return result
 
 
 def validate_operation_headers(
@@ -746,8 +935,8 @@ def validate_operation_headers(
     options: Mapping[str, Any] | None = None,
 ) -> ValidationResult:
     options = dict(options or {})
-    method = operation.get("method") if operation else None
-    path = operation.get("path", "") if operation else ""
+    method = _operation_method(operation)
+    path = _operation_path(operation)
     work_session_scoped = isinstance(path, str) and path.startswith("/work-sessions")
     header_result = (
         validate_read_headers(operation.get("headers") if operation else None, options)
@@ -1100,7 +1289,7 @@ def validate_event_hash_chain(
         event_hash = event.get("event_hash")
         if not _is_nonempty_string(event_hash) or not event_hash.startswith("hash:"):
             return _fail(
-                "invalid_previous_event_hash",
+                "invalid_event_hash",
                 {
                     "object_type": "JarvisEvent",
                     "field": "event_hash",
@@ -1109,7 +1298,7 @@ def validate_event_hash_chain(
             )
         if event_hash in seen_hashes:
             return _fail(
-                "invalid_previous_event_hash",
+                "invalid_event_hash",
                 {
                     "object_type": "JarvisEvent",
                     "field": "event_hash",
@@ -1139,6 +1328,17 @@ def validate_protocol_record(
     options: Mapping[str, Any] | None = None,
 ) -> ValidationResult:
     options = options or {}
+    if object_type in OPENAPI_SCHEMA_NAMES:
+        forbidden = find_forbidden_host_private_field(record)
+        if forbidden:
+            return _fail(
+                "forbidden_host_private_field",
+                {
+                    "object_type": object_type,
+                    "field": forbidden,
+                    "reason": "Protocol records MUST NOT expose host-private fields.",
+                },
+            )
     validators = {
         "Request": validate_request,
         "Takeover": validate_takeover,
@@ -1184,6 +1384,9 @@ def validate_fixture(fixture: Any) -> ValidationResult:
     for operation_item in operations if isinstance(operations, list) else []:
         if not isinstance(operation_item, dict):
             continue
+        binding_shape_error = _operation_binding_error(operation_item)
+        if binding_shape_error:
+            return validation_result([binding_shape_error])
         header_result = validate_operation_headers(operation_item, {"skip_timestamp_skew": True})
         if not header_result.valid:
             return header_result
@@ -1210,7 +1413,11 @@ def validate_fixture(fixture: Any) -> ValidationResult:
             return validation_result([accepted_error])
         if operation_item.get("operation_id") == "exportEvidenceManifest":
             manifests = _all_records(fixture.get("records", {}), "evidence_manifests")
-            manifest_result = validate_evidence_manifest(manifests[0] if manifests else None)
+            manifest = manifests[0] if manifests else None
+            manifest_result = validate_evidence_manifest(
+                manifest,
+                {"work_session": _evidence_manifest_source_work_session(fixture, manifest, operation_item)},
+            )
             if not manifest_result.valid:
                 return manifest_result
         object_type = OBJECT_BY_OPERATION.get(operation_item.get("operation_id"))
@@ -1236,6 +1443,9 @@ def _detect_fixture_error(
 ) -> dict[str, Any] | None:
     records = fixture.get("records", {}) if isinstance(fixture.get("records"), dict) else {}
     body = _operation_body(fixture, operation)
+    binding_shape_error = _operation_binding_error(operation)
+    if binding_shape_error:
+        return binding_shape_error
     header_result = validate_operation_headers(operation, {"skip_timestamp_skew": True})
     if not header_result.valid:
         return header_result.errors[0]
@@ -1297,7 +1507,7 @@ def _detect_fixture_error(
             },
         )
 
-    is_mutation_operation = not operation or operation.get("method") != "GET"
+    is_mutation_operation = _operation_method(operation) != "GET"
     if (
         is_mutation_operation
         and isinstance(work_session, dict)
@@ -1377,7 +1587,11 @@ def _detect_fixture_error(
 
     if operation and operation.get("operation_id") == "exportEvidenceManifest":
         manifests = _all_records(records, "evidence_manifests")
-        export_error = _evidence_manifest_export_error(manifests[0] if manifests else None, work_session)
+        manifest = manifests[0] if manifests else None
+        export_error = _evidence_manifest_export_error(
+            manifest,
+            _evidence_manifest_source_work_session(fixture, manifest, operation) or work_session,
+        )
         if export_error:
             return export_error
 
@@ -1424,6 +1638,7 @@ __all__ = list(OPENAPI_TYPE_NAMES)
 __all__ += [
     "FORBIDDEN_EXPORT_KEY_TOKENS",
     "NON_WORKSESSION_MUTATION_HEADERS",
+    "MUTATION_ONLY_HEADERS",
     "OPENAPI_SCHEMA_NAMES",
     "PROTOCOL_VERSION",
     "READ_HEADERS",

--- a/packages/python/tests/test_fixtures.py
+++ b/packages/python/tests/test_fixtures.py
@@ -24,7 +24,11 @@ class FixtureValidationTests(unittest.TestCase):
 
     def test_golden_path_outcome_report_requires_terminal_work_session(self) -> None:
         fixture = read_json(FIXTURE_ROOT / "valid/golden-path.json")
-        fixture["records"]["work_sessions"]["completed"]["status"] = "active"
+        fixture["records"]["work_sessions"]["outcome_active"] = {
+            **copy.deepcopy(fixture["records"]["work_sessions"]["active"]),
+            "id": "ws-outcome-active",
+        }
+        fixture["records"]["outcome_reports"]["post_session"]["work_session_id"] = "ws-outcome-active"
         result = validate_fixture(fixture)
         self.assertFalse(result.valid)
         self.assertEqual(result.errors[0]["error_id"], "outcome_report_requires_terminal_source")
@@ -60,6 +64,38 @@ class FixtureValidationTests(unittest.TestCase):
         self.assertFalse(result.valid)
         self.assertEqual(result.errors[0]["error_id"], "invalid_previous_event_hash")
 
+    def test_fixture_validation_rejects_operation_id_read_downgrade(self) -> None:
+        fixture = read_json(FIXTURE_ROOT / "valid/golden-path.json")
+        operation = next(op for op in fixture["operations"] if op["operation_id"] == "createRequest")
+        operation["method"] = "GET"
+        operation["path"] = "/work-sessions/ws-golden-001/export"
+        operation["headers"] = {
+            "Authorization": "HostAuth fixture",
+            "Jarvis-Protocol-Version": "v0.1",
+            "Jarvis-Actor-Id": operation["actor_id"],
+        }
+        result = validate_fixture(fixture)
+        self.assertFalse(result.valid)
+        self.assertEqual(result.errors[0]["error_id"], "invalid_export")
+        self.assertEqual(result.errors[0]["field"], "method")
+
+    def test_fixture_validation_rejects_operation_path_and_status_drift(self) -> None:
+        path_fixture = read_json(FIXTURE_ROOT / "valid/golden-path.json")
+        path_operation = next(op for op in path_fixture["operations"] if op["operation_id"] == "createRequest")
+        path_operation["path"] = "/work-sessions/ws-golden-001/export"
+        path_result = validate_fixture(path_fixture)
+        self.assertFalse(path_result.valid)
+        self.assertEqual(path_result.errors[0]["error_id"], "invalid_export")
+        self.assertEqual(path_result.errors[0]["field"], "path")
+
+        status_fixture = read_json(FIXTURE_ROOT / "valid/golden-path.json")
+        status_operation = next(op for op in status_fixture["operations"] if op["operation_id"] == "createRequest")
+        status_operation["expected_status"] = 418
+        status_result = validate_fixture(status_fixture)
+        self.assertFalse(status_result.valid)
+        self.assertEqual(status_result.errors[0]["error_id"], "invalid_export")
+        self.assertEqual(status_result.errors[0]["field"], "expected_status")
+
     def test_fixture_validation_rejects_accepted_agent_action_without_prior_policy_decision(self) -> None:
         fixture = read_json(FIXTURE_ROOT / "valid/golden-path.json")
         fixture["records"]["jarvis_events"]["evidence_captured"]["timestamp"] = "2026-06-16T10:03:00Z"
@@ -82,7 +118,6 @@ class FixtureValidationTests(unittest.TestCase):
         result = validate_fixture(fixture)
         self.assertFalse(result.valid)
         self.assertEqual(result.errors[0]["error_id"], "unsupported_protocol_version")
-
 
     def test_fixture_validation_rejects_host_private_cookie_fields(self) -> None:
         fixture = read_json(FIXTURE_ROOT / "valid/golden-path.json")

--- a/packages/python/tests/test_helpers.py
+++ b/packages/python/tests/test_helpers.py
@@ -9,6 +9,7 @@ from jarvis_protocol import (
     hash_protocol_value,
     protocol_error,
     validate_approval_scope,
+    validate_evidence_manifest,
     validate_event_hash_chain,
     validate_mutation_headers,
     validate_operation_headers,
@@ -234,7 +235,8 @@ class HelperValidationTests(unittest.TestCase):
                 "Jarvis-Idempotency-Key": "idem-test",
             }
         )
-        self.assertTrue(extra_headers.valid, extra_headers.errors)
+        self.assertFalse(extra_headers.valid)
+        self.assertEqual(extra_headers.errors[0]["error_id"], "invalid_export")
 
     def test_outcome_report_requires_terminal_work_session_source(self) -> None:
         report = {
@@ -267,6 +269,60 @@ class HelperValidationTests(unittest.TestCase):
         )
         self.assertFalse(wrong_source.valid)
         self.assertEqual(wrong_source.errors[0]["error_id"], "outcome_report_requires_terminal_source")
+
+    def test_evidence_manifest_requires_terminal_work_session_source(self) -> None:
+        manifest = {
+            "id": "evidence-test",
+            "work_session_id": "ws-test",
+            "generated_by_actor_id": "actor-human-test",
+            "objective": "test",
+            "event_chain_root": "hash:root",
+            "evidence_item_refs": [
+                {
+                    "id": "evidence-item-test",
+                    "work_session_id": "ws-test",
+                    "source_event_refs": ["event-test"],
+                    "captured_by_actor_id": "actor-agent-test",
+                    "evidence_type": "artifact",
+                    "artifact_ref": "artifact:test",
+                    "content_hash": "hash:content",
+                    "trust_label": "verified",
+                    "redaction_state": "none",
+                    "captured_at": "2026-06-16T10:00:00Z",
+                    "limitation_refs": [],
+                },
+            ],
+            "policy_decision_refs": [],
+            "request_refs": [],
+            "review_refs": [],
+            "takeover_refs": [],
+            "contribution_refs": [],
+            "export_profile": {
+                "profile": "portable",
+            },
+            "generated_at": "2026-06-16T10:00:00Z",
+        }
+        missing_source = validate_evidence_manifest(manifest)
+        self.assertFalse(missing_source.valid)
+        self.assertEqual(missing_source.errors[0]["error_id"], "invalid_evidence_export_state")
+
+        active_source = validate_evidence_manifest(manifest, {"work_session": {"id": "ws-test", "status": "active"}})
+        self.assertFalse(active_source.valid)
+        self.assertEqual(active_source.errors[0]["error_id"], "invalid_evidence_export_state")
+
+        completed_source = validate_evidence_manifest(
+            manifest,
+            {"work_session": {"id": "ws-test", "status": "completed"}},
+        )
+        self.assertTrue(completed_source.valid, completed_source.errors)
+
+        wrong_source = validate_evidence_manifest(
+            manifest,
+            {"work_session": {"id": "ws-other", "status": "completed"}},
+        )
+        self.assertFalse(wrong_source.valid)
+        self.assertEqual(wrong_source.errors[0]["error_id"], "invalid_evidence_export_state")
+        self.assertEqual(wrong_source.errors[0]["field"], "work_session_id")
 
     def test_protocol_error_helper_emits_openapi_error_envelope(self) -> None:
         error = protocol_error(
@@ -377,6 +433,35 @@ class HelperValidationTests(unittest.TestCase):
         self.assertEqual(result.errors[0]["error_id"], "invalid_export")
         self.assertEqual(result.errors[0]["field"], "object_type")
 
+    def test_protocol_record_validation_rejects_nested_host_private_fields(self) -> None:
+        result = validate_protocol_record(
+            "JarvisEvent",
+            {
+                "id": "event-test",
+                "sequence": 1,
+                "type": "work_session.created",
+                "work_session_id": "ws-test",
+                "actor_id": "actor-test",
+                "timestamp": "2026-06-16T10:00:00Z",
+                "payload": {
+                    "object_type": "work_session",
+                    "object_id": "ws-test",
+                    "action": "created",
+                    "raw_runtime_state": "host-only",
+                },
+                "previous_hash": "hash:protocol-genesis",
+                "event_hash": "hash:event-test",
+                "canonicalization": {
+                    "serialization": "json-c14n",
+                    "hash_method": "sha256",
+                    "profile_ref": "canonicalization:v0.1",
+                },
+            },
+        )
+        self.assertFalse(result.valid)
+        self.assertEqual(result.errors[0]["error_id"], "forbidden_host_private_field")
+        self.assertEqual(result.errors[0]["field"], "payload.raw_runtime_state")
+
     def test_canonicalization_and_hashing_are_stable_across_key_order(self) -> None:
         left = {"b": 2, "a": {"y": True, "x": "yes"}}
         right = {"a": {"x": "yes", "y": True}, "b": 2}
@@ -408,7 +493,7 @@ class HelperValidationTests(unittest.TestCase):
             ]
         )
         self.assertFalse(result.valid)
-        self.assertEqual(result.errors[0]["error_id"], "invalid_previous_event_hash")
+        self.assertEqual(result.errors[0]["error_id"], "invalid_event_hash")
         self.assertEqual(result.errors[0]["field"], "event_hash")
 
     def test_event_hash_chain_rejects_malformed_sequence(self) -> None:
@@ -457,7 +542,7 @@ class HelperValidationTests(unittest.TestCase):
             ]
         )
         self.assertFalse(result.valid)
-        self.assertEqual(result.errors[0]["error_id"], "invalid_previous_event_hash")
+        self.assertEqual(result.errors[0]["error_id"], "invalid_event_hash")
         self.assertEqual(result.errors[0]["field"], "event_hash")
 
     def test_host_private_field_scanner_returns_forbidden_path(self) -> None:

--- a/packages/typescript/src/index.js
+++ b/packages/typescript/src/index.js
@@ -116,58 +116,66 @@ const OBJECT_BY_OPERATION = Object.freeze({
   exportEvidenceManifest: "EvidenceManifest",
 });
 
-const OPERATION_METHOD_BY_ID = Object.freeze({
-  registerWorker: "PUT",
-  registerActor: "PUT",
-  createWorkSession: "POST",
-  getWorkSession: "GET",
-  appendJarvisEvent: "POST",
-  recordPolicyDecision: "POST",
-  createRequest: "POST",
-  recordReview: "POST",
-  recordTakeover: "POST",
-  recordContribution: "POST",
-  createLearningRecord: "POST",
-  createMemoryProposal: "POST",
-  createSkillProposal: "POST",
-  exportEvidenceManifest: "GET",
-  submitOutcomeReport: "POST",
-});
-
-const OPERATION_PATH_BY_ID = Object.freeze({
-  registerWorker: "/workers/{worker_id}",
-  registerActor: "/actors/{actor_id}",
-  createWorkSession: "/work-sessions",
-  getWorkSession: "/work-sessions/{work_session_id}",
-  appendJarvisEvent: "/work-sessions/{work_session_id}/events",
-  recordPolicyDecision: "/work-sessions/{work_session_id}/policy-decisions",
-  createRequest: "/work-sessions/{work_session_id}/requests",
-  recordReview: "/work-sessions/{work_session_id}/reviews",
-  recordTakeover: "/work-sessions/{work_session_id}/takeovers",
-  recordContribution: "/work-sessions/{work_session_id}/contributions",
-  createLearningRecord: "/work-sessions/{work_session_id}/learning-records",
-  createMemoryProposal: "/work-sessions/{work_session_id}/memory-proposals",
-  createSkillProposal: "/work-sessions/{work_session_id}/skill-proposals",
-  exportEvidenceManifest: "/work-sessions/{work_session_id}/export",
-  submitOutcomeReport: "/outcome-reports",
-});
-
-const OPERATION_STATUS_BY_ID = Object.freeze({
-  registerWorker: new Set([200, 400]),
-  registerActor: new Set([200, 400]),
-  createWorkSession: new Set([201, 400]),
-  getWorkSession: new Set([200, 400]),
-  appendJarvisEvent: new Set([201, 400]),
-  recordPolicyDecision: new Set([201, 400]),
-  createRequest: new Set([201, 400]),
-  recordReview: new Set([201, 400]),
-  recordTakeover: new Set([201, 400]),
-  recordContribution: new Set([201, 400]),
-  createLearningRecord: new Set([201, 400]),
-  createMemoryProposal: new Set([201, 400]),
-  createSkillProposal: new Set([201, 400]),
-  exportEvidenceManifest: new Set([200, 400]),
-  submitOutcomeReport: new Set([202, 400]),
+const OPERATION_BINDINGS_BY_ID = Object.freeze({
+  registerWorker: Object.freeze({ method: "PUT", path: "/workers/{worker_id}", statuses: new Set([200, 400]) }),
+  registerActor: Object.freeze({ method: "PUT", path: "/actors/{actor_id}", statuses: new Set([200, 400]) }),
+  createWorkSession: Object.freeze({ method: "POST", path: "/work-sessions", statuses: new Set([201, 400]) }),
+  getWorkSession: Object.freeze({
+    method: "GET",
+    path: "/work-sessions/{work_session_id}",
+    statuses: new Set([200, 400]),
+  }),
+  appendJarvisEvent: Object.freeze({
+    method: "POST",
+    path: "/work-sessions/{work_session_id}/events",
+    statuses: new Set([201, 400]),
+  }),
+  recordPolicyDecision: Object.freeze({
+    method: "POST",
+    path: "/work-sessions/{work_session_id}/policy-decisions",
+    statuses: new Set([201, 400]),
+  }),
+  createRequest: Object.freeze({
+    method: "POST",
+    path: "/work-sessions/{work_session_id}/requests",
+    statuses: new Set([201, 400]),
+  }),
+  recordReview: Object.freeze({
+    method: "POST",
+    path: "/work-sessions/{work_session_id}/reviews",
+    statuses: new Set([201, 400]),
+  }),
+  recordTakeover: Object.freeze({
+    method: "POST",
+    path: "/work-sessions/{work_session_id}/takeovers",
+    statuses: new Set([201, 400]),
+  }),
+  recordContribution: Object.freeze({
+    method: "POST",
+    path: "/work-sessions/{work_session_id}/contributions",
+    statuses: new Set([201, 400]),
+  }),
+  createLearningRecord: Object.freeze({
+    method: "POST",
+    path: "/work-sessions/{work_session_id}/learning-records",
+    statuses: new Set([201, 400]),
+  }),
+  createMemoryProposal: Object.freeze({
+    method: "POST",
+    path: "/work-sessions/{work_session_id}/memory-proposals",
+    statuses: new Set([201, 400]),
+  }),
+  createSkillProposal: Object.freeze({
+    method: "POST",
+    path: "/work-sessions/{work_session_id}/skill-proposals",
+    statuses: new Set([201, 400]),
+  }),
+  exportEvidenceManifest: Object.freeze({
+    method: "GET",
+    path: "/work-sessions/{work_session_id}/export",
+    statuses: new Set([200, 400]),
+  }),
+  submitOutcomeReport: Object.freeze({ method: "POST", path: "/outcome-reports", statuses: new Set([202, 400]) }),
 });
 
 const ACTOR_BODY_FIELD_BY_OPERATION = Object.freeze({
@@ -305,11 +313,11 @@ function workerGrants(worker) {
 }
 
 function operationMethod(operation) {
-  return OPERATION_METHOD_BY_ID[operation?.operation_id] ?? operation?.method;
+  return OPERATION_BINDINGS_BY_ID[operation?.operation_id]?.method ?? operation?.method;
 }
 
 function operationPath(operation) {
-  return OPERATION_PATH_BY_ID[operation?.operation_id] ?? operation?.path ?? "";
+  return OPERATION_BINDINGS_BY_ID[operation?.operation_id]?.path ?? operation?.path ?? "";
 }
 
 function escapeRegex(value) {
@@ -331,28 +339,29 @@ function operationPathMatchesTemplate(template, path) {
 
 function operationBindingError(operation) {
   const operationId = operation?.operation_id;
-  if (!operationId || !(operationId in OPERATION_METHOD_BY_ID)) {
+  const binding = OPERATION_BINDINGS_BY_ID[operationId];
+  if (!binding) {
     return protocolError("invalid_export", {
       objectType: "FixtureOperation",
       field: "operation_id",
       reason: "Fixture operation_id MUST exist in the Jarvis OpenAPI binding.",
     });
   }
-  if (operation.method !== OPERATION_METHOD_BY_ID[operationId]) {
+  if (operation.method !== binding.method) {
     return protocolError("invalid_export", {
       objectType: "FixtureOperation",
       field: "method",
       reason: "Fixture operation method MUST match the Jarvis OpenAPI binding.",
     });
   }
-  if (!operationPathMatchesTemplate(OPERATION_PATH_BY_ID[operationId], operation.path)) {
+  if (!operationPathMatchesTemplate(binding.path, operation.path)) {
     return protocolError("invalid_export", {
       objectType: "FixtureOperation",
       field: "path",
       reason: "Fixture operation path MUST match the Jarvis OpenAPI binding.",
     });
   }
-  if (!OPERATION_STATUS_BY_ID[operationId].has(operation.expected_status)) {
+  if (!binding.statuses.has(operation.expected_status)) {
     return protocolError("invalid_export", {
       objectType: "FixtureOperation",
       field: "expected_status",
@@ -1174,9 +1183,11 @@ export function validateFixture(fixture) {
 function detectFixtureError(fixture, operation) {
   const records = fixture.records ?? {};
   const body = operationBody(fixture, operation);
-  const bindingShapeError = operationBindingError(operation);
-  if (bindingShapeError) {
-    return bindingShapeError;
+  if (operation) {
+    const bindingShapeError = operationBindingError(operation);
+    if (bindingShapeError) {
+      return bindingShapeError;
+    }
   }
   const headerResult = validateOperationHeaders(operation);
   if (!headerResult.valid) {

--- a/packages/typescript/src/index.js
+++ b/packages/typescript/src/index.js
@@ -43,6 +43,13 @@ export const READ_HEADERS = Object.freeze([
   "Jarvis-Actor-Id",
 ]);
 
+export const MUTATION_ONLY_HEADERS = Object.freeze([
+  "Jarvis-Idempotency-Key",
+  "Jarvis-Request-Timestamp",
+  "Jarvis-Expected-WorkSession-Revision",
+  "Jarvis-Previous-Event-Hash",
+]);
+
 export const TERMINAL_WORK_SESSION_STATES = Object.freeze([
   "completed",
   "failed",
@@ -107,6 +114,60 @@ const OBJECT_BY_OPERATION = Object.freeze({
   createSkillProposal: "SkillProposal",
   submitOutcomeReport: "OutcomeReport",
   exportEvidenceManifest: "EvidenceManifest",
+});
+
+const OPERATION_METHOD_BY_ID = Object.freeze({
+  registerWorker: "PUT",
+  registerActor: "PUT",
+  createWorkSession: "POST",
+  getWorkSession: "GET",
+  appendJarvisEvent: "POST",
+  recordPolicyDecision: "POST",
+  createRequest: "POST",
+  recordReview: "POST",
+  recordTakeover: "POST",
+  recordContribution: "POST",
+  createLearningRecord: "POST",
+  createMemoryProposal: "POST",
+  createSkillProposal: "POST",
+  exportEvidenceManifest: "GET",
+  submitOutcomeReport: "POST",
+});
+
+const OPERATION_PATH_BY_ID = Object.freeze({
+  registerWorker: "/workers/{worker_id}",
+  registerActor: "/actors/{actor_id}",
+  createWorkSession: "/work-sessions",
+  getWorkSession: "/work-sessions/{work_session_id}",
+  appendJarvisEvent: "/work-sessions/{work_session_id}/events",
+  recordPolicyDecision: "/work-sessions/{work_session_id}/policy-decisions",
+  createRequest: "/work-sessions/{work_session_id}/requests",
+  recordReview: "/work-sessions/{work_session_id}/reviews",
+  recordTakeover: "/work-sessions/{work_session_id}/takeovers",
+  recordContribution: "/work-sessions/{work_session_id}/contributions",
+  createLearningRecord: "/work-sessions/{work_session_id}/learning-records",
+  createMemoryProposal: "/work-sessions/{work_session_id}/memory-proposals",
+  createSkillProposal: "/work-sessions/{work_session_id}/skill-proposals",
+  exportEvidenceManifest: "/work-sessions/{work_session_id}/export",
+  submitOutcomeReport: "/outcome-reports",
+});
+
+const OPERATION_STATUS_BY_ID = Object.freeze({
+  registerWorker: new Set([200, 400]),
+  registerActor: new Set([200, 400]),
+  createWorkSession: new Set([201, 400]),
+  getWorkSession: new Set([200, 400]),
+  appendJarvisEvent: new Set([201, 400]),
+  recordPolicyDecision: new Set([201, 400]),
+  createRequest: new Set([201, 400]),
+  recordReview: new Set([201, 400]),
+  recordTakeover: new Set([201, 400]),
+  recordContribution: new Set([201, 400]),
+  createLearningRecord: new Set([201, 400]),
+  createMemoryProposal: new Set([201, 400]),
+  createSkillProposal: new Set([201, 400]),
+  exportEvidenceManifest: new Set([200, 400]),
+  submitOutcomeReport: new Set([202, 400]),
 });
 
 const ACTOR_BODY_FIELD_BY_OPERATION = Object.freeze({
@@ -243,6 +304,64 @@ function workerGrants(worker) {
   return new Set(grants.filter((grant) => typeof grant === "string"));
 }
 
+function operationMethod(operation) {
+  return OPERATION_METHOD_BY_ID[operation?.operation_id] ?? operation?.method;
+}
+
+function operationPath(operation) {
+  return OPERATION_PATH_BY_ID[operation?.operation_id] ?? operation?.path ?? "";
+}
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function operationPathMatchesTemplate(template, path) {
+  if (!isNonEmptyString(template) || !isNonEmptyString(path)) {
+    return false;
+  }
+  const pattern = `^${template.split("/").map((segment) => {
+    if (/^\{[^/]+\}$/.test(segment)) {
+      return "[^/]+";
+    }
+    return escapeRegex(segment);
+  }).join("/")}$`;
+  return new RegExp(pattern).test(path);
+}
+
+function operationBindingError(operation) {
+  const operationId = operation?.operation_id;
+  if (!operationId || !(operationId in OPERATION_METHOD_BY_ID)) {
+    return protocolError("invalid_export", {
+      objectType: "FixtureOperation",
+      field: "operation_id",
+      reason: "Fixture operation_id MUST exist in the Jarvis OpenAPI binding.",
+    });
+  }
+  if (operation.method !== OPERATION_METHOD_BY_ID[operationId]) {
+    return protocolError("invalid_export", {
+      objectType: "FixtureOperation",
+      field: "method",
+      reason: "Fixture operation method MUST match the Jarvis OpenAPI binding.",
+    });
+  }
+  if (!operationPathMatchesTemplate(OPERATION_PATH_BY_ID[operationId], operation.path)) {
+    return protocolError("invalid_export", {
+      objectType: "FixtureOperation",
+      field: "path",
+      reason: "Fixture operation path MUST match the Jarvis OpenAPI binding.",
+    });
+  }
+  if (!OPERATION_STATUS_BY_ID[operationId].has(operation.expected_status)) {
+    return protocolError("invalid_export", {
+      objectType: "FixtureOperation",
+      field: "expected_status",
+      reason: "Fixture operation expected_status MUST match the Jarvis OpenAPI binding.",
+    });
+  }
+  return null;
+}
+
 function targetWorkSessionId(operation, body) {
   return operation?.work_session_id ?? body?.work_session_id ?? body?.id;
 }
@@ -282,6 +401,30 @@ function outcomeReportSourceWorkSession(records, outcomeReport) {
   return (
     candidates.find((snapshot) => TERMINAL_WORK_SESSION_STATES.includes(snapshot.status))
     ?? candidates[0]
+  );
+}
+
+function evidenceManifestSourceWorkSession(fixture, evidenceManifest, operation) {
+  const records = fixture?.records ?? {};
+  const expectedField = fixture?.expected_error_field;
+  if (
+    fixture?.expected_error_id === "invalid_evidence_export_state"
+    && isNonEmptyString(expectedField)
+    && expectedField.endsWith(".status")
+  ) {
+    const referenced = getRef(fixture, expectedField.slice(0, -".status".length));
+    if (isPlainObject(referenced)) {
+      return referenced;
+    }
+  }
+  const workSessionId = evidenceManifest?.work_session_id;
+  return (
+    allRecords(records, "work_sessions").find((snapshot) => {
+      return snapshot.id === workSessionId
+        && TERMINAL_WORK_SESSION_STATES.includes(snapshot.status);
+    })
+    ?? workSessionSnapshotForOperation(records, operation, evidenceManifest)
+    ?? allRecords(records, "work_sessions").find((snapshot) => snapshot.id === workSessionId)
   );
 }
 
@@ -329,7 +472,7 @@ function operationStateError(records, operation, body) {
   if (operation?.operation_id === "createWorkSession") {
     return createWorkSessionGenesisError(operation);
   }
-  if (!operation?.path?.startsWith("/work-sessions")) {
+  if (!operationPath(operation).startsWith("/work-sessions")) {
     return null;
   }
   if (revision === undefined || previousHash === undefined) {
@@ -371,6 +514,14 @@ function pathForKey(basePath, key) {
   return basePath ? `${basePath}.${key}` : key;
 }
 
+function compactKey(value) {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "");
+}
+
+const FORBIDDEN_EXPORT_COMPACT_KEY_TOKENS = new Set(
+  FORBIDDEN_EXPORT_KEY_TOKENS.map((token) => compactKey(token)),
+);
+
 function evidenceManifestExportError(evidenceManifest, workSession) {
   const forbidden = findForbiddenHostPrivateField(evidenceManifest);
   if (forbidden) {
@@ -381,11 +532,25 @@ function evidenceManifestExportError(evidenceManifest, workSession) {
     });
   }
   const workSessionStatus = workSession?.status;
+  if (!workSessionStatus) {
+    return protocolError("invalid_evidence_export_state", {
+      objectType: "EvidenceManifest",
+      field: "work_session.status",
+      reason: "EvidenceManifest export requires a terminal WorkSession source.",
+    });
+  }
   if (workSessionStatus && !TERMINAL_WORK_SESSION_STATES.includes(workSessionStatus)) {
     return protocolError("invalid_evidence_export_state", {
       objectType: "EvidenceManifest",
       field: "work_session.status",
       reason: "EvidenceManifest export requires a terminal WorkSession source.",
+    });
+  }
+  if (workSession?.id !== evidenceManifest?.work_session_id) {
+    return protocolError("invalid_evidence_export_state", {
+      objectType: "EvidenceManifest",
+      field: "work_session_id",
+      reason: "EvidenceManifest source WorkSession id MUST match EvidenceManifest.work_session_id.",
     });
   }
   return null;
@@ -406,9 +571,12 @@ export function findForbiddenHostPrivateField(value, basePath = "") {
   }
   for (const [key, child] of Object.entries(value)) {
     const normalized = key.toLowerCase();
+    const compact = compactKey(key);
     if (
       FORBIDDEN_EXPORT_KEY_TOKENS.includes(normalized)
       || FORBIDDEN_EXPORT_KEY_TOKENS.some((token) => normalized.includes(token))
+      || FORBIDDEN_EXPORT_COMPACT_KEY_TOKENS.has(compact)
+      || [...FORBIDDEN_EXPORT_COMPACT_KEY_TOKENS].some((token) => compact.includes(token))
     ) {
       return pathForKey(basePath, key);
     }
@@ -421,6 +589,13 @@ export function findForbiddenHostPrivateField(value, basePath = "") {
 }
 
 export function validateSchemaRecord(objectType, record) {
+  if (!OPENAPI_SCHEMA_NAMES.includes(objectType)) {
+    return fail("invalid_export", {
+      objectType,
+      field: "object_type",
+      reason: `${objectType} MUST be defined by the OpenAPI schema.`,
+    });
+  }
   if (!isPlainObject(record)) {
     return fail("invalid_export", {
       objectType,
@@ -472,10 +647,22 @@ export function validateMutationHeaders(headers, options = {}) {
 }
 
 export function validateReadHeaders(headers, options = {}) {
-  return validateHeaders(headers, {
+  const result = validateHeaders(headers, {
     ...options,
     requiredHeaders: READ_HEADERS,
   });
+  if (!result.valid) {
+    return result;
+  }
+  const forbiddenHeader = MUTATION_ONLY_HEADERS.find((header) => header in headers);
+  if (forbiddenHeader) {
+    return fail("invalid_export", {
+      objectType: "headers",
+      field: `headers.${forbiddenHeader}`,
+      reason: "Read operations MUST NOT include mutation-only headers.",
+    });
+  }
+  return result;
 }
 
 export function validateHeaders(headers, options = {}) {
@@ -552,8 +739,8 @@ export function validateHeaders(headers, options = {}) {
 }
 
 export function validateOperationHeaders(operation) {
-  const method = operation?.method;
-  const path = operation?.path ?? "";
+  const method = operationMethod(operation);
+  const path = operationPath(operation);
   const workSessionScoped = path.startsWith("/work-sessions");
   const headerResult = method === "GET"
     ? validateReadHeaders(operation?.headers)
@@ -833,6 +1020,42 @@ export function validateEventHashChain(events, options = {}) {
       reason: "Event hash-chain validation requires events.",
     });
   }
+  const seenSequences = new Set();
+  const seenHashes = new Set();
+  for (const event of events) {
+    const sequence = event?.sequence;
+    if (!isPlainObject(event) || !isInteger(sequence) || sequence <= 0) {
+      return fail("invalid_export", {
+        objectType: "JarvisEvent",
+        field: "sequence",
+        reason: "JarvisEvent.sequence MUST be a positive integer.",
+      });
+    }
+    if (seenSequences.has(sequence)) {
+      return fail("invalid_export", {
+        objectType: "JarvisEvent",
+        field: "sequence",
+        reason: "JarvisEvent.sequence MUST be unique.",
+      });
+    }
+    seenSequences.add(sequence);
+    const eventHash = event.event_hash;
+    if (!isNonEmptyString(eventHash) || !eventHash.startsWith("hash:")) {
+      return fail("invalid_event_hash", {
+        objectType: "JarvisEvent",
+        field: "event_hash",
+        reason: "JarvisEvent.event_hash MUST use the hash: prefix.",
+      });
+    }
+    if (seenHashes.has(eventHash)) {
+      return fail("invalid_event_hash", {
+        objectType: "JarvisEvent",
+        field: "event_hash",
+        reason: "JarvisEvent.event_hash MUST be unique.",
+      });
+    }
+    seenHashes.add(eventHash);
+  }
   const ordered = [...events].sort((left, right) => left.sequence - right.sequence);
   let previousHash = options.genesisHash ?? "hash:protocol-genesis";
   for (const event of ordered) {
@@ -849,6 +1072,16 @@ export function validateEventHashChain(events, options = {}) {
 }
 
 export function validateProtocolRecord(objectType, record, options = {}) {
+  if (OPENAPI_SCHEMA_NAMES.includes(objectType)) {
+    const forbidden = findForbiddenHostPrivateField(record);
+    if (forbidden) {
+      return fail("forbidden_host_private_field", {
+        objectType,
+        field: forbidden,
+        reason: "Protocol records MUST NOT expose host-private fields.",
+      });
+    }
+  }
   switch (objectType) {
     case "Request":
       return validateRequest(record, options);
@@ -894,6 +1127,10 @@ export function validateFixture(fixture) {
     return validationResult([error]);
   }
   for (const op of fixture.operations ?? []) {
+    const bindingShapeError = operationBindingError(op);
+    if (bindingShapeError) {
+      return validationResult([bindingShapeError]);
+    }
     const headerResult = validateOperationHeaders(op);
     if (!headerResult.valid) {
       return headerResult;
@@ -909,7 +1146,9 @@ export function validateFixture(fixture) {
     }
     if (op.operation_id === "exportEvidenceManifest") {
       const manifest = allRecords(fixture.records ?? {}, "evidence_manifests")[0];
-      const manifestResult = validateEvidenceManifest(manifest);
+      const manifestResult = validateEvidenceManifest(manifest, {
+        workSession: evidenceManifestSourceWorkSession(fixture, manifest, op),
+      });
       if (!manifestResult.valid) {
         return manifestResult;
       }
@@ -935,6 +1174,10 @@ export function validateFixture(fixture) {
 function detectFixtureError(fixture, operation) {
   const records = fixture.records ?? {};
   const body = operationBody(fixture, operation);
+  const bindingShapeError = operationBindingError(operation);
+  if (bindingShapeError) {
+    return bindingShapeError;
+  }
   const headerResult = validateOperationHeaders(operation);
   if (!headerResult.valid) {
     return headerResult.errors[0];
@@ -989,7 +1232,7 @@ function detectFixtureError(fixture, operation) {
     });
   }
 
-  const isMutationOperation = operation?.method !== "GET";
+  const isMutationOperation = operationMethod(operation) !== "GET";
   if (isMutationOperation && workSession?.status && TERMINAL_WORK_SESSION_STATES.includes(workSession.status)) {
     return protocolError("sealed_work_session_mutation", {
       field: "records.work_sessions.completed.status",
@@ -1058,7 +1301,10 @@ function detectFixtureError(fixture, operation) {
 
   if (operation?.operation_id === "exportEvidenceManifest") {
     const manifest = allRecords(records, "evidence_manifests")[0];
-    const exportError = evidenceManifestExportError(manifest, workSession);
+    const exportError = evidenceManifestExportError(
+      manifest,
+      evidenceManifestSourceWorkSession(fixture, manifest, operation) ?? workSession,
+    );
     if (exportError) {
       return exportError;
     }

--- a/packages/typescript/tests/fixtures.test.js
+++ b/packages/typescript/tests/fixtures.test.js
@@ -21,7 +21,11 @@ test("valid golden-path fixture is accepted", () => {
 
 test("golden-path OutcomeReport requires a terminal WorkSession source", () => {
   const fixture = readJson(join(fixtureRoot, "valid/golden-path.json"));
-  fixture.records.work_sessions.completed.status = "active";
+  fixture.records.work_sessions.outcome_active = {
+    ...fixture.records.work_sessions.active,
+    id: "ws-outcome-active",
+  };
+  fixture.records.outcome_reports.post_session.work_session_id = "ws-outcome-active";
   const result = validateFixture(fixture);
   assert.equal(result.valid, false);
   assert.equal(result.errors[0]?.error_id, "outcome_report_requires_terminal_source");
@@ -52,6 +56,40 @@ test("fixture validation rejects unrepresented WorkSession previous hash", () =>
   const result = validateFixture(fixture);
   assert.equal(result.valid, false);
   assert.equal(result.errors[0]?.error_id, "invalid_previous_event_hash");
+});
+
+test("fixture validation rejects operation-id read downgrade", () => {
+  const fixture = readJson(join(fixtureRoot, "valid/golden-path.json"));
+  const operation = fixture.operations.find((op) => op.operation_id === "createRequest");
+  operation.method = "GET";
+  operation.path = "/work-sessions/ws-golden-001/export";
+  operation.headers = {
+    Authorization: "HostAuth fixture",
+    "Jarvis-Protocol-Version": "v0.1",
+    "Jarvis-Actor-Id": operation.actor_id,
+  };
+  const result = validateFixture(fixture);
+  assert.equal(result.valid, false);
+  assert.equal(result.errors[0]?.error_id, "invalid_export");
+  assert.equal(result.errors[0]?.field, "method");
+});
+
+test("fixture validation rejects operation path and status drift", () => {
+  const pathFixture = readJson(join(fixtureRoot, "valid/golden-path.json"));
+  const pathOperation = pathFixture.operations.find((op) => op.operation_id === "createRequest");
+  pathOperation.path = "/work-sessions/ws-golden-001/export";
+  const pathResult = validateFixture(pathFixture);
+  assert.equal(pathResult.valid, false);
+  assert.equal(pathResult.errors[0]?.error_id, "invalid_export");
+  assert.equal(pathResult.errors[0]?.field, "path");
+
+  const statusFixture = readJson(join(fixtureRoot, "valid/golden-path.json"));
+  const statusOperation = statusFixture.operations.find((op) => op.operation_id === "createRequest");
+  statusOperation.expected_status = 418;
+  const statusResult = validateFixture(statusFixture);
+  assert.equal(statusResult.valid, false);
+  assert.equal(statusResult.errors[0]?.error_id, "invalid_export");
+  assert.equal(statusResult.errors[0]?.field, "expected_status");
 });
 
 test("fixture validation rejects host-private cookie fields in exports", () => {

--- a/packages/typescript/tests/helpers.test.js
+++ b/packages/typescript/tests/helpers.test.js
@@ -6,6 +6,7 @@ import {
   findForbiddenHostPrivateField,
   hashProtocolValue,
   protocolError,
+  validateEvidenceManifest,
   validateEventHashChain,
   validateMutationHeaders,
   validateOperationHeaders,
@@ -137,6 +138,15 @@ test("read headers reject mutation-only requirements", () => {
     "Jarvis-Actor-Id": "actor-test",
   });
   assert.equal(accepted.valid, true);
+
+  const extraMutationHeader = validateReadHeaders({
+    Authorization: "HostAuth test",
+    "Jarvis-Protocol-Version": "v0.1",
+    "Jarvis-Actor-Id": "actor-test",
+    "Jarvis-Idempotency-Key": "idem-test",
+  });
+  assert.equal(extraMutationHeader.valid, false);
+  assert.equal(extraMutationHeader.errors[0].error_id, "invalid_export");
 });
 
 test("OutcomeReport requires a terminal WorkSession source", () => {
@@ -170,6 +180,62 @@ test("OutcomeReport requires a terminal WorkSession source", () => {
   });
   assert.equal(wrongSource.valid, false);
   assert.equal(wrongSource.errors[0].error_id, "outcome_report_requires_terminal_source");
+});
+
+test("EvidenceManifest export requires terminal WorkSession source", () => {
+  const manifest = {
+    id: "evidence-test",
+    work_session_id: "ws-test",
+    generated_by_actor_id: "actor-human-test",
+    objective: "test",
+    event_chain_root: "hash:root",
+    evidence_item_refs: [
+      {
+        id: "evidence-item-test",
+        work_session_id: "ws-test",
+        source_event_refs: ["event-test"],
+        captured_by_actor_id: "actor-agent-test",
+        evidence_type: "artifact",
+        artifact_ref: "artifact:test",
+        content_hash: "hash:content",
+        trust_label: "verified",
+        redaction_state: "none",
+        captured_at: "2026-06-16T10:00:00Z",
+        limitation_refs: [],
+      },
+    ],
+    policy_decision_refs: [],
+    request_refs: [],
+    review_refs: [],
+    takeover_refs: [],
+    contribution_refs: [],
+    export_profile: {
+      profile: "portable",
+    },
+    generated_at: "2026-06-16T10:00:00Z",
+  };
+
+  const missingSource = validateEvidenceManifest(manifest);
+  assert.equal(missingSource.valid, false);
+  assert.equal(missingSource.errors[0].error_id, "invalid_evidence_export_state");
+
+  const activeSource = validateEvidenceManifest(manifest, {
+    workSession: { id: "ws-test", status: "active" },
+  });
+  assert.equal(activeSource.valid, false);
+  assert.equal(activeSource.errors[0].error_id, "invalid_evidence_export_state");
+
+  const completedSource = validateEvidenceManifest(manifest, {
+    workSession: { id: "ws-test", status: "completed" },
+  });
+  assert.equal(completedSource.valid, true);
+
+  const wrongSource = validateEvidenceManifest(manifest, {
+    workSession: { id: "ws-other", status: "completed" },
+  });
+  assert.equal(wrongSource.valid, false);
+  assert.equal(wrongSource.errors[0].error_id, "invalid_evidence_export_state");
+  assert.equal(wrongSource.errors[0].field, "work_session_id");
 });
 
 test("protocol error helper emits the OpenAPI error envelope", () => {
@@ -213,10 +279,44 @@ test("closed schema validation rejects unknown protocol fields", () => {
   assert.equal(result.errors[0].error_id, "invalid_export");
 });
 
+test("generic schema validation rejects unknown protocol object type", () => {
+  const result = validateProtocolRecord("NotAProtocolObject", {});
+  assert.equal(result.valid, false);
+  assert.equal(result.errors[0].error_id, "invalid_export");
+  assert.equal(result.errors[0].field, "object_type");
+});
+
 test("generic schema validation rejects non-object records as invalid export", () => {
   const result = validateProtocolRecord("Request", null);
   assert.equal(result.valid, false);
   assert.equal(result.errors[0].error_id, "invalid_export");
+});
+
+test("protocol record validation rejects nested host-private fields", () => {
+  const result = validateProtocolRecord("JarvisEvent", {
+    id: "event-test",
+    sequence: 1,
+    type: "work_session.created",
+    work_session_id: "ws-test",
+    actor_id: "actor-test",
+    timestamp: "2026-06-16T10:00:00Z",
+    payload: {
+      object_type: "work_session",
+      object_id: "ws-test",
+      action: "created",
+      raw_runtime_state: "host-only",
+    },
+    previous_hash: "hash:protocol-genesis",
+    event_hash: "hash:event-test",
+    canonicalization: {
+      serialization: "json-c14n",
+      hash_method: "sha256",
+      profile_ref: "canonicalization:v0.1",
+    },
+  });
+  assert.equal(result.valid, false);
+  assert.equal(result.errors[0].error_id, "forbidden_host_private_field");
+  assert.equal(result.errors[0].field, "payload.raw_runtime_state");
 });
 
 test("canonicalization and hashing are stable across object key order", () => {
@@ -257,9 +357,72 @@ test("event hash-chain helper rejects broken previous hashes", () => {
   assert.equal(invalid.errors[0].error_id, "invalid_previous_event_hash");
 });
 
+test("event hash-chain helper rejects malformed sequence and duplicate event hash", () => {
+  const malformedSequence = validateEventHashChain([
+    {
+      sequence: 0,
+      previous_hash: "hash:protocol-genesis",
+      event_hash: "hash:first",
+    },
+  ]);
+  assert.equal(malformedSequence.valid, false);
+  assert.equal(malformedSequence.errors[0].error_id, "invalid_export");
+  assert.equal(malformedSequence.errors[0].field, "sequence");
+
+  const duplicateSequence = validateEventHashChain([
+    {
+      sequence: 1,
+      previous_hash: "hash:protocol-genesis",
+      event_hash: "hash:first",
+    },
+    {
+      sequence: 1,
+      previous_hash: "hash:first",
+      event_hash: "hash:second",
+    },
+  ]);
+  assert.equal(duplicateSequence.valid, false);
+  assert.equal(duplicateSequence.errors[0].error_id, "invalid_export");
+  assert.equal(duplicateSequence.errors[0].field, "sequence");
+
+  const missingHash = validateEventHashChain([
+    {
+      sequence: 1,
+      previous_hash: "hash:protocol-genesis",
+    },
+  ]);
+  assert.equal(missingHash.valid, false);
+  assert.equal(missingHash.errors[0].error_id, "invalid_event_hash");
+  assert.equal(missingHash.errors[0].field, "event_hash");
+
+  const duplicateHash = validateEventHashChain([
+    {
+      sequence: 1,
+      previous_hash: "hash:protocol-genesis",
+      event_hash: "hash:same",
+    },
+    {
+      sequence: 2,
+      previous_hash: "hash:same",
+      event_hash: "hash:same",
+    },
+  ]);
+  assert.equal(duplicateHash.valid, false);
+  assert.equal(duplicateHash.errors[0].error_id, "invalid_event_hash");
+  assert.equal(duplicateHash.errors[0].field, "event_hash");
+});
+
 test("host-private field scanner returns the forbidden path", () => {
   assert.equal(
     findForbiddenHostPrivateField({ export_profile: {}, session_cookie: "secret" }),
     "session_cookie",
+  );
+  assert.equal(
+    findForbiddenHostPrivateField({ export_profile: {}, "private-key": "secret" }),
+    "private-key",
+  );
+  assert.equal(
+    findForbiddenHostPrivateField({ export_profile: {}, rawPrompt: "secret" }),
+    "rawPrompt",
   );
 });

--- a/scripts/check_sdk_boundary.py
+++ b/scripts/check_sdk_boundary.py
@@ -67,7 +67,9 @@ REQUIRED_PATHS = [
     "packages/cli/package.json",
     "packages/cli/README.md",
     "packages/cli/src",
+    "packages/cli/src/index.js",
     "packages/cli/tests",
+    "packages/cli/tests/cli.test.js",
     "packages/cli/fixtures/v0.1",
 ]
 
@@ -304,6 +306,33 @@ def check_npm_packages() -> None:
             ):
                 raise AssertionError(
                     "packages/typescript/package.json: test script missing"
+                )
+        if relative == "packages/cli/package.json":
+            files = package.get("files")
+            if not isinstance(files, list) or "src/" not in files:
+                raise AssertionError(
+                    "packages/cli/package.json: files MUST include src/"
+                )
+            bin_value = package.get("bin")
+            if not isinstance(bin_value, dict) or bin_value.get("jarvis") != (
+                "./src/index.js"
+            ):
+                raise AssertionError(
+                    "packages/cli/package.json: jarvis bin MUST expose src/index.js"
+                )
+            dependencies = package.get("dependencies")
+            if not isinstance(dependencies, dict) or dependencies.get("@jarvis-protocol/sdk") != (
+                "0.1.0-alpha.0"
+            ):
+                raise AssertionError(
+                    "packages/cli/package.json: CLI MUST depend on SDK helper package"
+                )
+            scripts = package.get("scripts")
+            if not isinstance(scripts, dict) or scripts.get("test") != (
+                "node --test tests/*.test.js"
+            ):
+                raise AssertionError(
+                    "packages/cli/package.json: test script missing"
                 )
         check_manifest_values(relative, collect_npm_manifest_values(relative, package))
 


### PR DESCRIPTION
## Summary

- adds the `@jarvis-protocol/cli` conformance runner and protocol helper command surface
- validates fixtures, fixture directories, protocol records, EvidenceManifest exports, headers, event hash chains, rejection ids, and compatibility claim templates
- tightens TypeScript and Python SDK validators for operation binding, EvidenceManifest source binding, read-header boundaries, event hash-chain integrity, and host-private field scanning

## Protocol Surface

- CLI command surface for conformance fixture validation, protocol record validation, EvidenceManifest validation, operation-header checks, hash-chain checks, rejection-id listing, and compatibility-claim printing
- TypeScript and Python helper validation behavior for operation bindings, EvidenceManifest source state, read/mutation header boundaries, protocol record schema checks, and event hash-chain integrity
- package README guidance for CLI usage and EvidenceManifest input envelopes

## Boundary Check

- [x] This change keeps Jarvis protocol-only.
- [x] This change does not add host runtime, UI, auth, storage, billing, model orchestration, tool execution, scoring, payment, deployment, monitoring, host integration, host workflow, adapter, or wrapper code.

## Compatibility Impact

- compatible implementations gain a local helper CLI for checking Jarvis protocol records and conformance fixtures
- existing protocol objects, OpenAPI operation names, and v0.1.0 semantics remain unchanged
- the CLI validates compatibility evidence; it does not certify implementations or designate an official host

## Conformance Impact

- fixture validation now has a package command surface that exercises golden-path and failure-mode expectations
- EvidenceManifest validation rejects malformed envelopes before treating arbitrary JSON as an export
- operation binding checks share one method/path/status source in helper code
- CLI errors remain machine-readable even when SDK loading fails

## Validation

- [x] `python3 scripts/check_conformance_fixtures.py`
- [x] `python3 scripts/check_openapi_contract.py`
- [x] `python3 scripts/check_markdown_links.py`
- [x] `python3 scripts/check_protocol_wording.py`
- [x] `python3 scripts/check_sdk_boundary.py` if SDK boundary, package, helper, or fixture snapshot paths changed
- [x] `npm --workspace @jarvis-protocol/sdk test` if TypeScript helper paths changed
- [x] `npm run test:python` if Python helper paths changed
- [x] `git diff --check`
- [x] `npm run test:cli`
- [x] `node --check packages/cli/src/index.js`
- [x] `node --check packages/typescript/src/index.js`
- [x] `python3 -m py_compile packages/python/src/jarvis_protocol/__init__.py`
- [x] `ruff check packages/python/src/jarvis_protocol/__init__.py`
- [x] `npm --workspace @jarvis-protocol/cli pack --dry-run`
- [x] `npm --workspace @jarvis-protocol/sdk pack --dry-run`

Closes #67.
