### PR TITLE
[codex] Add public docs site foundation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,9 +24,10 @@
 - [ ] `python3 scripts/check_conformance_fixtures.py`
 - [ ] `python3 scripts/check_openapi_contract.py`
 - [ ] `python3 scripts/check_markdown_links.py`
+- [ ] `python3 scripts/check_docs_site.py` if docs site files changed
 - [ ] `python3 scripts/check_protocol_wording.py`
 - [ ] `python3 scripts/check_sdk_boundary.py` if SDK boundary, package, helper, or fixture snapshot paths changed
 - [ ] `npm --workspace @jarvis-protocol/sdk test` if TypeScript helper paths changed
 - [ ] `npm run test:python` if Python helper paths changed
 - [ ] `git diff --check`
-- [ ] `node --check demo/assets/app.js` if demo JavaScript changed
+- [ ] `node --check demo/assets/app.js` if docs site JavaScript changed

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,4 +1,4 @@
-name: Deploy Jarvis demo to GitHub Pages
+name: Deploy Jarvis docs site to GitHub Pages
 
 on:
   push:
@@ -34,7 +34,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install Python dependencies
-        run: python -m pip install pyyaml
+        run: python -m pip install pyyaml==6.0.1
 
       - name: Validate conformance fixtures
         run: python3 scripts/check_conformance_fixtures.py
@@ -45,13 +45,16 @@ jobs:
       - name: Validate Markdown links
         run: python3 scripts/check_markdown_links.py
 
+      - name: Validate docs site
+        run: python3 scripts/check_docs_site.py
+
       - name: Validate protocol wording
         run: python3 scripts/check_protocol_wording.py
 
       - name: Check committed whitespace
         run: git diff-tree --check --no-commit-id --root -r HEAD
 
-      - name: Validate demo JavaScript syntax
+      - name: Validate docs site JavaScript syntax
         run: node --check demo/assets/app.js
 
       - name: Configure Pages

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Validate Markdown links
         run: python3 scripts/check_markdown_links.py
 
+      - name: Validate docs site
+        run: python3 scripts/check_docs_site.py
+
       - name: Validate protocol wording
         run: python3 scripts/check_protocol_wording.py
 
@@ -66,5 +69,5 @@ jobs:
             git diff-tree --check --no-commit-id --root -r HEAD
           fi
 
-      - name: Validate demo JavaScript syntax
+      - name: Validate docs site JavaScript syntax
         run: node --check demo/assets/app.js

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -310,6 +310,7 @@ Every protocol PR MUST run:
 python3 scripts/check_conformance_fixtures.py
 python3 scripts/check_openapi_contract.py
 python3 scripts/check_markdown_links.py
+python3 scripts/check_docs_site.py
 python3 scripts/check_protocol_wording.py
 git diff --check
 ```

--- a/README.md
+++ b/README.md
@@ -30,16 +30,19 @@ Release materials:
 - [SECURITY.md](./SECURITY.md)
 - [docs/releases/v0.1.0.md](./docs/releases/v0.1.0.md)
 
-## Interactive Simulation
+## Public Documentation Site
 
-The simulation is non-normative public explanation. It is not protocol proof
-and it is not a host UI implementation.
+The public documentation site is the first entry point for the protocol,
+OpenAPI contract, conformance surface, SDK helper tooling, examples, release
+status, and non-normative walkthrough.
 
-Open the live simulation here:
+Open the live documentation site here:
 
 https://flow-research.github.io/jarvis/
 
-The page is served directly by GitHub Pages from this repository.
+The walkthrough on the site is non-normative public explanation. It is not
+protocol proof and it is not a host UI implementation. The page is served
+directly by GitHub Pages from this repository.
 
 ## One-Line Definition
 
@@ -314,9 +317,14 @@ Jarvis-owned agents.
   positioning lock.
 - [docs/architecture_brief/](./docs/architecture_brief/) - shareable protocol
   architecture brief and PDF.
+- [docs/openapi/](./docs/openapi/) - OpenAPI 3.1 communication binding.
 - [docs/conformance/](./docs/conformance/) - compatibility mapping,
   conformance entries, fixtures, validator requirements, and existing-agent
   proof plan.
+- [docs/examples/](./docs/examples/) - protocol record, existing-agent
+  compatibility, and compatible-host mapping examples.
+- [packages/](./packages/) - TypeScript, Python, and CLI protocol helper
+  packages.
 - [docs/reviews/](./docs/reviews/) - protocol readiness and acceptance review
   criteria.
 - [docs/releases/](./docs/releases/) - protocol release notes and validation

--- a/demo/assets/styles.css
+++ b/demo/assets/styles.css
@@ -24,6 +24,7 @@
 html {
   min-width: 320px;
   background: var(--void);
+  scroll-behavior: smooth;
 }
 
 body {
@@ -73,6 +74,10 @@ button {
   font: inherit;
 }
 
+a {
+  color: inherit;
+}
+
 #signalCanvas {
   position: fixed;
   inset: 0;
@@ -96,6 +101,54 @@ button {
   justify-content: space-between;
   gap: 18px;
   border-bottom: 1px solid var(--line);
+}
+
+.topnav {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 6px;
+}
+
+.topnav a,
+.status-chip {
+  min-height: 34px;
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgb(16 23 17 / 72%);
+  color: #c8d3c8;
+  font-size: 0.78rem;
+  font-weight: 850;
+  text-decoration: none;
+}
+
+.topnav a {
+  padding: 0 12px;
+}
+
+.topnav a:hover {
+  border-color: rgb(120 247 180 / 62%);
+  color: var(--ink);
+}
+
+.topnav a:focus-visible,
+.command:focus-visible,
+.doc-card a:focus-visible,
+.link-table a:focus-visible,
+.example-grid a:focus-visible,
+.package-grid a:focus-visible,
+.brand:focus-visible {
+  outline: 2px solid var(--mint);
+  outline-offset: 3px;
+}
+
+.status-chip {
+  justify-content: center;
+  min-width: 86px;
+  padding: 0 10px;
+  color: var(--mint);
 }
 
 .brand {
@@ -177,10 +230,10 @@ button {
 }
 
 .hero-copy h1 {
-  max-width: 1040px;
+  max-width: 1120px;
   margin: 14px 0 18px;
-  font-size: clamp(3.2rem, 8vw, 8.7rem);
-  line-height: 0.88;
+  font-size: clamp(3.1rem, 6.8vw, 7rem);
+  line-height: 0.94;
   letter-spacing: 0;
   text-wrap: balance;
   overflow-wrap: break-word;
@@ -222,6 +275,7 @@ button {
   background: rgb(244 240 230 / 7%);
   color: var(--ink);
   font-weight: 900;
+  text-decoration: none;
   padding: 0 16px;
   cursor: pointer;
   transition:
@@ -254,7 +308,11 @@ button {
 
 .mission-panel,
 .simulator,
-.story-strip article,
+.doc-card,
+.spine-list article,
+.example-grid article,
+.package-grid article,
+.boundary-strip article,
 .rail,
 .operating-stage,
 .sequence {
@@ -264,6 +322,199 @@ button {
     rgb(8 12 9 / 82%);
   box-shadow: var(--shadow);
   backdrop-filter: blur(18px);
+}
+
+.doc-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+  margin: 10px 0 14px;
+}
+
+.doc-card {
+  min-height: 260px;
+  display: grid;
+  align-content: start;
+  gap: 14px;
+  border-radius: 8px;
+  padding: 18px;
+}
+
+.doc-card span,
+.boundary-strip span {
+  color: var(--mint);
+  font-weight: 950;
+}
+
+.doc-card h2,
+.example-grid h3,
+.package-grid h3,
+.boundary-strip p,
+.spine-list p {
+  margin: 0;
+}
+
+.doc-card h2 {
+  font-size: 1.16rem;
+  line-height: 1.2;
+}
+
+.doc-card p,
+.spine-list p,
+.example-grid p,
+.package-grid p,
+.boundary-strip p,
+.section-copy p,
+.conformance-band p {
+  color: var(--muted);
+  line-height: 1.62;
+}
+
+.doc-card a,
+.link-table a,
+.example-grid a,
+.package-grid a {
+  color: var(--mint);
+  font-weight: 900;
+  text-decoration: none;
+}
+
+.doc-card a:hover,
+.link-table a:hover,
+.example-grid a:hover,
+.package-grid a:hover {
+  color: var(--cyan);
+}
+
+.protocol-section,
+.spec-grid,
+.examples-section,
+.sdk-section,
+.conformance-band {
+  display: grid;
+  gap: 18px;
+  margin-top: 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background:
+    linear-gradient(180deg, rgb(255 255 255 / 5%), rgb(255 255 255 / 2%)),
+    rgb(8 12 9 / 76%);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(18px);
+}
+
+.protocol-section,
+.spec-grid,
+.examples-section,
+.sdk-section {
+  grid-template-columns: minmax(360px, 0.56fr) minmax(0, 1fr);
+  padding: 22px;
+}
+
+.section-copy h2,
+.conformance-band h2 {
+  margin: 10px 0 0;
+  font-size: clamp(1.8rem, 3.2vw, 3.45rem);
+  line-height: 1.05;
+  letter-spacing: 0;
+  text-wrap: balance;
+  overflow-wrap: break-word;
+}
+
+.section-copy p,
+.conformance-band p {
+  margin: 18px 0 0;
+  max-width: 760px;
+}
+
+.spine-list,
+.example-grid,
+.package-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.spine-list article,
+.example-grid article,
+.package-grid article {
+  min-height: 145px;
+  display: grid;
+  align-content: start;
+  gap: 10px;
+  padding: 16px;
+  border-radius: 8px;
+}
+
+.spine-list strong,
+.example-grid h3,
+.package-grid h3 {
+  color: var(--ink);
+  font-size: 1.02rem;
+}
+.link-table {
+  display: grid;
+  gap: 10px;
+}
+
+.link-table a {
+  min-height: 72px;
+  display: grid;
+  align-content: center;
+  gap: 5px;
+  padding: 14px 16px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgb(255 255 255 / 4%);
+}
+
+.link-table span {
+  color: var(--ink);
+  font-weight: 950;
+}
+
+.link-table small {
+  color: var(--muted);
+  line-height: 1.4;
+}
+
+.conformance-band {
+  grid-template-columns: minmax(280px, 0.9fr) minmax(0, 1.1fr);
+  align-items: center;
+  padding: 22px;
+}
+
+.conformance-band pre {
+  min-width: 0;
+  overflow: auto;
+  margin: 0;
+  padding: 18px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #050704;
+  color: var(--bone);
+  line-height: 1.65;
+}
+
+.package-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.example-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.example-grid article,
+.package-grid article {
+  min-height: 210px;
+}
+
+.walkthrough-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 0 0 16px;
+  scroll-margin-top: 18px;
 }
 
 .mission-panel {
@@ -449,6 +700,14 @@ button {
   gap: 14px;
   align-items: start;
   margin-bottom: 16px;
+}
+
+.stage-counters {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+  max-width: 420px;
 }
 
 .stage-top h2 {
@@ -841,9 +1100,30 @@ button {
   line-height: 1.58;
 }
 
+.boundary-strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin-top: 14px;
+}
+
+.boundary-strip article {
+  min-height: 160px;
+  display: grid;
+  align-content: start;
+  gap: 14px;
+  border-radius: 8px;
+  padding: 18px;
+}
+
 @media (max-width: 1260px) {
   .hero-grid,
-  .simulator {
+  .simulator,
+  .protocol-section,
+  .spec-grid,
+  .examples-section,
+  .sdk-section,
+  .conformance-band {
     grid-template-columns: 1fr;
   }
 
@@ -852,7 +1132,11 @@ button {
   }
 
   .right-stack,
-  .story-strip {
+  .story-strip,
+  .doc-grid,
+  .example-grid,
+  .package-grid,
+  .boundary-strip {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
@@ -874,6 +1158,19 @@ button {
   .stage-top {
     align-items: flex-start;
     flex-direction: column;
+  }
+
+  .stage-counters {
+    justify-content: flex-start;
+    max-width: 100%;
+  }
+
+  .topnav {
+    justify-content: flex-start;
+  }
+
+  .status-chip {
+    min-width: 0;
   }
 
   .topbar-meta {
@@ -906,8 +1203,8 @@ button {
 
   .hero-copy h1 {
     max-width: 100%;
-    font-size: clamp(2.55rem, 10.8vw, 3rem);
-    line-height: 0.95;
+    font-size: clamp(1.92rem, 8.1vw, 2.18rem);
+    line-height: 1.08;
     text-wrap: auto;
   }
 
@@ -936,6 +1233,11 @@ button {
   .mission-grid,
   .right-stack,
   .story-strip,
+  .doc-grid,
+  .spine-list,
+  .example-grid,
+  .package-grid,
+  .boundary-strip,
   .phase-brief,
   .sequence ol {
     grid-template-columns: 1fr;
@@ -943,9 +1245,19 @@ button {
 
   .mission-panel,
   .simulator,
+  .protocol-section,
+  .spec-grid,
+  .examples-section,
+  .sdk-section,
+  .conformance-band,
   .operating-stage,
   .sequence,
   .rail,
+  .doc-card,
+  .spine-list article,
+  .example-grid article,
+  .package-grid article,
+  .boundary-strip article,
   .story-strip article {
     width: 100%;
     max-width: 100%;
@@ -963,8 +1275,23 @@ button {
   }
 
   .simulator,
-  .operating-stage {
+  .operating-stage,
+  .protocol-section,
+  .spec-grid,
+  .examples-section,
+  .sdk-section,
+  .conformance-band {
     padding: 10px;
+  }
+
+  .section-copy h2,
+  .conformance-band h2 {
+    font-size: clamp(1.9rem, 10vw, 2.55rem);
+  }
+
+  .walkthrough-controls {
+    display: grid;
+    grid-template-columns: 1fr;
   }
 
   .protocol-map {
@@ -1014,6 +1341,24 @@ button {
   }
 
   .data-beam {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+  }
+
+  #signalCanvas {
     display: none;
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -3,48 +3,312 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Jarvis</title>
+    <title>Jarvis Protocol Documentation</title>
     <meta
       name="description"
-      content="A non-normative public walkthrough of Jarvis as the human-agent collaboration and learning-loop protocol."
+      content="Jarvis protocol documentation for governed human-agent collaboration, reviewable requests, portable evidence, and shared learning."
     />
-    <link rel="icon" href="./assets/favicon.svg?v=protocol7" type="image/svg+xml" />
-    <link rel="stylesheet" href="./assets/styles.css?v=protocol7" />
+    <link rel="icon" href="./assets/favicon.svg?v=docs1" type="image/svg+xml" />
+    <link rel="stylesheet" href="./assets/styles.css?v=docs1" />
   </head>
   <body>
     <canvas id="signalCanvas" aria-hidden="true"></canvas>
     <main class="shell">
-      <header class="topbar" aria-label="Jarvis walkthrough header">
-        <a class="brand" href="./">
+      <header class="topbar" aria-label="Jarvis documentation header">
+        <a class="brand" href="./" aria-label="Jarvis documentation home">
           <span class="brand-mark">J</span>
           <span>
             <strong>Jarvis</strong>
-            <small>protocol walkthrough</small>
+            <small>protocol docs</small>
           </span>
         </a>
-        <div class="topbar-meta">
-          <span>Example WorkSession WS-1042</span>
-          <span>OpenAPI 3.1 binding</span>
-          <span id="topbarStatus">created</span>
-        </div>
+        <nav class="topnav" aria-label="Primary documentation links">
+          <a href="#start">Start</a>
+          <a href="#protocol">Protocol</a>
+          <a href="#spec">Spec</a>
+          <a href="#examples">Examples</a>
+          <a href="#conformance">Conformance</a>
+          <a href="#sdk">SDK</a>
+          <a href="#walkthrough">Walkthrough</a>
+        </nav>
+        <span class="status-chip">v0.1.0</span>
       </header>
 
-      <section class="hero-grid" aria-labelledby="page-title">
+      <section class="hero-grid" id="start" aria-labelledby="page-title">
         <div class="hero-copy">
           <p class="kicker">Human-agent collaboration and learning loop</p>
-          <h1 id="page-title">
-            Jarvis
-          </h1>
+          <h1 id="page-title">Jarvis Protocol Documentation</h1>
           <p class="hero-text">
-            MCP connects agents to tools. A2A connects agents to agents.
-            AG-UI connects agents to UI. Jarvis records how HumanWorkers and
-            AgentWorkers collaborate, produce evidence, and learn.
+            Jarvis defines how HumanWorkers and AgentWorkers collaborate inside
+            governed WorkSessions, create scoped Requests when blocked, capture
+            human Review and Takeover, record attributable Contribution, export
+            portable EvidenceManifest records, and carry governed Learning into
+            future work.
           </p>
           <p class="demo-boundary">
-            Non-normative walkthrough. Not protocol proof. Not a host UI
-            implementation.
+            Jarvis is a protocol. Hosts own UI, auth, storage, execution, model
+            calls, tool execution, monitoring, deployment, and host workflow.
           </p>
-          <div class="hero-actions" aria-label="Walkthrough controls">
+          <div class="hero-actions" aria-label="Documentation entry links">
+            <a
+              class="command primary"
+              href="https://raw.githubusercontent.com/Flow-Research/jarvis/main/docs/openapi/jarvis-openapi.yaml"
+            >
+              OpenAPI Spec
+            </a>
+            <a
+              class="command"
+              href="https://github.com/Flow-Research/jarvis/blob/main/docs/conformance/checklist.md"
+            >
+              Conformance Checklist
+            </a>
+            <a class="command" href="#walkthrough-controls">Run Walkthrough</a>
+            <a class="command ghost" href="https://github.com/Flow-Research/jarvis">
+              GitHub
+            </a>
+          </div>
+        </div>
+
+        <aside class="mission-panel" aria-label="Protocol Alpha status">
+          <div class="mission-header">
+            <span class="pulse"></span>
+            <span>Protocol Alpha</span>
+          </div>
+          <dl class="mission-grid">
+            <div>
+              <dt>Version</dt>
+              <dd>v0.1.0</dd>
+            </div>
+            <div>
+              <dt>Binding</dt>
+              <dd>OpenAPI 3.1</dd>
+            </div>
+            <div>
+              <dt>Evidence</dt>
+              <dd>portable</dd>
+            </div>
+            <div>
+              <dt>Status</dt>
+              <dd>Protocol Alpha</dd>
+            </div>
+          </dl>
+        </aside>
+      </section>
+
+      <section class="doc-grid" aria-label="Start here documentation cards">
+        <article class="doc-card">
+          <span>01</span>
+          <h2>Read the protocol spine</h2>
+          <p>
+            Start with the core objects and Request protocol. They define the
+            human-agent pair, WorkSession, policy gate, review loop, evidence,
+            and governed learning.
+          </p>
+          <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/11-core-protocol-objects.md">
+            Core objects
+          </a>
+        </article>
+        <article class="doc-card">
+          <span>02</span>
+          <h2>Use the machine contract</h2>
+          <p>
+            OpenAPI 3.1 is the primary machine-readable communication binding
+            for operations, headers, schemas, errors, and examples.
+          </p>
+          <a href="https://raw.githubusercontent.com/Flow-Research/jarvis/main/docs/openapi/jarvis-openapi.yaml">OpenAPI YAML</a>
+        </article>
+        <article class="doc-card">
+          <span>03</span>
+          <h2>Prove compatibility</h2>
+          <p>
+            Compatible implementations pass the conformance checklist and
+            fixture expectations without adopting a Jarvis-owned runtime.
+          </p>
+          <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/conformance/README.md">Conformance docs</a>
+        </article>
+        <article class="doc-card">
+          <span>04</span>
+          <h2>Run helper tooling</h2>
+          <p>
+            The SDK helper packages validate protocol records, headers,
+            EvidenceManifest exports, event chains, and conformance fixtures.
+          </p>
+          <a href="https://github.com/Flow-Research/jarvis/blob/main/packages/README.md">Packages</a>
+        </article>
+      </section>
+
+      <section class="protocol-section" id="protocol" aria-labelledby="protocol-title">
+        <div class="section-copy">
+          <p class="kicker">Protocol model</p>
+          <h2 id="protocol-title">The unit is the human-agent team.</h2>
+          <p>
+            Jarvis does not define a personal agent, model runtime, planner, or
+            workspace product. Jarvis defines the shared record that lets a
+            human and an agent work together with policy, review, attribution,
+            evidence, and learning.
+          </p>
+        </div>
+        <div class="spine-list" aria-label="Jarvis protocol layers">
+          <article>
+            <strong>HumanWorker + AgentWorker</strong>
+            <p>Workers participate as protocol actors with authority and contribution scope.</p>
+          </article>
+          <article>
+            <strong>WorkSession</strong>
+            <p>The durable protocol record for goals, events, requests, reviews, evidence, and learning.</p>
+          </article>
+          <article>
+            <strong>PolicyDecision</strong>
+            <p>Every AgentWorker action that affects a WorkSession records policy state before acceptance.</p>
+          </article>
+          <article>
+            <strong>Request, Review, Takeover</strong>
+            <p>Blocked scope routes to human judgment; authority stays bounded and attributable.</p>
+          </article>
+          <article>
+            <strong>Contribution + EvidenceManifest</strong>
+            <p>Jarvis records who did what and exports portable evidence without host-private fields.</p>
+          </article>
+          <article>
+            <strong>LearningRecord + Proposals</strong>
+            <p>Human, agent, and pair learning move forward only through governed protocol records.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="spec-grid" id="spec" aria-labelledby="spec-title">
+        <div class="section-copy">
+          <p class="kicker">Spec entry points</p>
+          <h2 id="spec-title">Read the contract from the same paths implementers use.</h2>
+        </div>
+        <div class="link-table" aria-label="Specification links">
+          <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/14-protocol-lock.md">
+            <span>Protocol Lock</span>
+            <small>Locked v0.1 protocol decisions and boundaries</small>
+          </a>
+          <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/15-openapi-communication-binding.md">
+            <span>Communication Binding</span>
+            <small>HTTP operations, headers, versioning, and error envelope</small>
+          </a>
+          <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/12-request-protocol.md">
+            <span>Request Protocol</span>
+            <small>Scoped deferral, Review, Takeover, and anti-livelock rules</small>
+          </a>
+          <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/13-contribution-evidence-learning.md">
+            <span>Evidence + Learning</span>
+            <small>Contribution, EvidenceManifest, LearningRecord, and proposals</small>
+          </a>
+          <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/examples/protocol-records.md">
+            <span>Protocol Records</span>
+            <small>Concrete v0.1 record examples</small>
+          </a>
+          <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/releases/v0.1.0.md">
+            <span>Release Notes</span>
+            <small>Protocol Alpha release scope and limits</small>
+          </a>
+        </div>
+      </section>
+
+      <section class="examples-section" id="examples" aria-labelledby="examples-title">
+        <div class="section-copy">
+          <p class="kicker">Examples</p>
+          <h2 id="examples-title">Map real work into protocol records.</h2>
+          <p>
+            Examples show how existing agents and hosts participate through
+            Jarvis records without becoming Jarvis-owned agents, adapters, or
+            runtimes.
+          </p>
+        </div>
+        <div class="example-grid" aria-label="Example documentation links">
+          <article>
+            <h3>Protocol Records</h3>
+            <p>Concrete Worker, Actor, WorkSession, Request, Review, Contribution, EvidenceManifest, and LearningRecord examples.</p>
+            <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/examples/protocol-records.md">Read record examples</a>
+          </article>
+          <article>
+            <h3>Existing Agent Compatibility</h3>
+            <p>How an existing agent participates through Jarvis records without being rewritten as a Jarvis agent.</p>
+            <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/examples/existing-agent-compatibility.md">Read compatibility example</a>
+          </article>
+          <article>
+            <h3>Compatible Host Mapping</h3>
+            <p>How a host maps native collaboration events into Jarvis protocol records while keeping implementation private.</p>
+            <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/examples/compatible-host-mapping.md">Read host mapping</a>
+          </article>
+        </div>
+      </section>
+
+      <section class="conformance-band" id="conformance" aria-labelledby="conformance-title">
+        <div>
+          <p class="kicker">Conformance</p>
+          <h2 id="conformance-title">Compatibility is proven through records.</h2>
+          <p>
+            A compatible implementation proves required headers, Actor
+            authority, WorkSession revision, previous event hash, PolicyDecision
+            preconditions, Request resolution, Takeover lock epochs,
+            Contribution attribution, EvidenceManifest export safety, and
+            governed learning.
+          </p>
+        </div>
+        <pre aria-label="Conformance CLI command"><code>npm run test:cli
+node packages/cli/src/index.js validate fixtures docs/conformance/fixtures
+node packages/cli/src/index.js list rejection-ids</code></pre>
+      </section>
+
+      <section class="sdk-section" id="sdk" aria-labelledby="sdk-title">
+        <div class="section-copy">
+          <p class="kicker">SDK helper tooling</p>
+          <h2 id="sdk-title">Helpers implement the protocol contract. They do not run agents.</h2>
+          <p>
+            Jarvis helper packages provide generated OpenAPI surfaces,
+            validators, event helpers, hash-chain helpers, header checks,
+            EvidenceManifest checks, protocol errors, fixture snapshots, and a
+            conformance runner CLI.
+          </p>
+        </div>
+        <div class="package-grid" aria-label="SDK helper packages">
+          <article>
+            <h3>TypeScript</h3>
+            <p>Protocol types, validators, event helpers, header checks, and fixture snapshots.</p>
+            <a href="https://github.com/Flow-Research/jarvis/blob/main/packages/typescript/README.md">Read TypeScript package</a>
+          </article>
+          <article>
+            <h3>Python</h3>
+            <p>Protocol models, validators, hash-chain helpers, and fixture validation.</p>
+            <a href="https://github.com/Flow-Research/jarvis/blob/main/packages/python/README.md">Read Python package</a>
+          </article>
+          <article>
+            <h3>CLI</h3>
+            <p>Conformance fixture runner and protocol helper commands for local checks.</p>
+            <a href="https://github.com/Flow-Research/jarvis/blob/main/packages/cli/README.md">Read CLI package</a>
+          </article>
+        </div>
+      </section>
+
+      <section class="simulator" id="walkthrough" aria-label="Jarvis protocol walkthrough">
+        <nav class="sequence" aria-label="WorkSession steps">
+          <div class="section-label">Interactive walkthrough</div>
+          <ol id="timeline"></ol>
+        </nav>
+
+        <section class="operating-stage" aria-label="Protocol record path">
+          <div class="stage-top">
+            <div>
+              <span class="section-label">Current phase</span>
+              <h2 id="stepTitle">Mutation Headers</h2>
+            </div>
+            <div class="stage-counters" aria-label="Walkthrough state">
+              <span class="counter" id="stepCounter">01 / 12</span>
+              <span class="counter" id="topbarStatus">created</span>
+              <span class="counter" id="missionState">Ready</span>
+              <span class="counter" id="evidenceCount">01 item</span>
+            </div>
+          </div>
+          <div
+            class="walkthrough-controls"
+            id="walkthrough-controls"
+            aria-label="Walkthrough controls"
+          >
             <button class="command primary" id="startBtn" type="button">
               Start Walkthrough
             </button>
@@ -59,48 +323,6 @@
               Autoplay
             </button>
             <button class="command ghost" id="resetBtn" type="button">Reset</button>
-          </div>
-        </div>
-
-        <aside class="mission-panel" aria-label="Walkthrough state">
-          <div class="mission-header">
-            <span class="pulse"></span>
-            <span id="missionState">Ready</span>
-          </div>
-          <dl class="mission-grid">
-            <div>
-              <dt>Workers</dt>
-              <dd>Human + Agent</dd>
-            </div>
-            <div>
-              <dt>Protocol</dt>
-              <dd>Jarvis v0.1</dd>
-            </div>
-            <div>
-              <dt>Evidence</dt>
-              <dd id="evidenceCount">01 item</dd>
-            </div>
-            <div>
-              <dt>Autonomy</dt>
-              <dd>bounded</dd>
-            </div>
-          </dl>
-        </aside>
-      </section>
-
-      <section class="simulator" aria-label="Jarvis protocol walkthrough">
-        <nav class="sequence" aria-label="WorkSession steps">
-          <div class="section-label">OpenAPI record path</div>
-          <ol id="timeline"></ol>
-        </nav>
-
-        <section class="operating-stage" aria-label="Protocol record path">
-          <div class="stage-top">
-            <div>
-              <span class="section-label">Current phase</span>
-              <h2 id="stepTitle">Mutation Headers</h2>
-            </div>
-            <span class="counter" id="stepCounter">01 / 12</span>
           </div>
 
           <div class="protocol-map" aria-label="Human-agent protocol map">
@@ -154,7 +376,7 @@
 
         <aside class="right-stack" aria-label="Record rails">
           <section class="rail policy-rail" aria-labelledby="policyTitle">
-              <div class="rail-head">
+            <div class="rail-head">
               <span class="section-label">Mutation gate</span>
               <h3 id="policyTitle">Protocol checks</h3>
             </div>
@@ -182,43 +404,22 @@
         </aside>
       </section>
 
-      <section class="story-strip" aria-label="Jarvis model summary">
+      <section class="boundary-strip" aria-label="Jarvis boundary summary">
         <article>
-          <span>01</span>
-          <h3>WorkSession is the record</h3>
-          <p>
-            WorkSession is the durable protocol record for human-agent work:
-            goals, events, requests, reviews, contributions, evidence, and
-            learning.
-          </p>
+          <span>Jarvis owns</span>
+          <p>protocol records, lifecycle rules, OpenAPI binding, errors, conformance, evidence, and governed learning.</p>
         </article>
         <article>
-          <span>02</span>
-          <h3>Policy governs autonomy</h3>
-          <p>
-            The AgentWorker works inside human-defined policy. Outside policy,
-            it creates a Request instead of acting silently.
-          </p>
+          <span>Hosts own</span>
+          <p>UI, identity, auth, storage, runtime, tools, models, monitoring, deployment, and workflow.</p>
         </article>
         <article>
-          <span>03</span>
-          <h3>Learning is governed</h3>
-          <p>
-            Human learning, agent learning, and pair learning stay governed
-            through LearningRecord, MemoryProposal, and SkillProposal records.
-          </p>
-        </article>
-        <article>
-          <span>04</span>
-          <h3>Evidence travels with work</h3>
-          <p>
-            Jarvis records what happened as it happens. EvidenceManifest gives
-            the human worker and agent worker a portable evidence record.
-          </p>
+          <span>Alpha limit</span>
+          <p>v0.1.0 does not certify implementations, designate an official host, or claim production adoption.</p>
         </article>
       </section>
     </main>
 
-    <script src="./assets/app.js?v=protocol7"></script>
+    <script src="./assets/app.js?v=docs1"></script>
   </body>
 </html>

--- a/docs/planning/ROADMAP.md
+++ b/docs/planning/ROADMAP.md
@@ -21,7 +21,8 @@ Week 1 protocol lock is complete.
 
 Current protocol status: Jarvis v0.1.0 is released as Protocol Alpha.
 
-Current active work: public docs site work and implementation proof planning.
+Current active work: public docs site foundation and protocol-record
+compatibility evidence planning.
 
 Release-readiness work for the v0.1.0 tag is complete:
 
@@ -429,6 +430,31 @@ Done when:
   behavior, monitoring, observability, host integration, and host workflow
 - local validation passes
 
+## Public Documentation Site Foundation
+
+Status: in progress.
+
+Owner: Documentation
+
+Output:
+
+- public documentation entry point
+- protocol overview
+- OpenAPI and specification links
+- conformance entry links
+- SDK helper tooling links
+- non-normative interactive walkthrough
+
+Done when:
+
+- public site introduces Jarvis as protocol-only
+- public site links to the OpenAPI contract, conformance docs, examples,
+  package docs, and release notes
+- walkthrough stays non-normative and does not claim host UI implementation or
+  protocol proof
+- GitHub Pages workflow validates docs-site JavaScript
+- local validation passes
+
 ## v0.2 Evidence And Learning Beta
 
 Goal: strengthen the compounding loop.
@@ -546,5 +572,5 @@ and example record mappers.
    Jarvis.
 7. Keep every Jarvis SDK discussion limited to protocol implementation helpers.
 8. Continue public documentation site work inside protocol-owned scope.
-9. Start implementation proof only through Jarvis protocol records, not host
+9. Start compatibility evidence only through Jarvis protocol records, not host
    runtime ownership.

--- a/scripts/check_docs_site.py
+++ b/scripts/check_docs_site.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Validate the static Jarvis docs site links and local assets."""
+
+from html.parser import HTMLParser
+from pathlib import Path
+from urllib.parse import urlparse
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SITE_ROOT = ROOT / "demo"
+INDEX = SITE_ROOT / "index.html"
+RAW_PREFIX = "/Flow-Research/jarvis/main/"
+BLOB_PREFIX = "/Flow-Research/jarvis/blob/main/"
+
+
+class SiteParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.ids: set[str] = set()
+        self.refs: list[tuple[str, str]] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attr_map = {key: value for key, value in attrs if value is not None}
+        if "id" in attr_map:
+            self.ids.add(attr_map["id"])
+        for attr in ("href", "src"):
+            if attr in attr_map:
+                self.refs.append((attr, attr_map[attr]))
+
+
+def clean_ref(value: str) -> str:
+    return value.split("?", 1)[0].split("#", 1)[0]
+
+
+def local_target_exists(value: str) -> bool:
+    target = clean_ref(value)
+    if not target:
+        return True
+    return (SITE_ROOT / target).resolve().is_relative_to(SITE_ROOT) and (SITE_ROOT / target).resolve().exists()
+
+
+def github_target_exists(value: str) -> bool:
+    parsed = urlparse(value)
+    if parsed.netloc == "github.com" and parsed.path == "/Flow-Research/jarvis":
+        return True
+    if parsed.netloc == "github.com" and parsed.path.startswith(BLOB_PREFIX):
+        target = parsed.path.removeprefix(BLOB_PREFIX)
+        return (ROOT / target).exists()
+    if parsed.netloc == "raw.githubusercontent.com" and parsed.path.startswith(RAW_PREFIX):
+        target = parsed.path.removeprefix(RAW_PREFIX)
+        return (ROOT / target).exists()
+    return False
+
+
+def main() -> int:
+    parser = SiteParser()
+    parser.feed(INDEX.read_text(encoding="utf-8"))
+    failures: list[str] = []
+
+    for attr, value in parser.refs:
+        if value.startswith("#"):
+            fragment = value[1:]
+            if fragment and fragment not in parser.ids:
+                failures.append(f"{INDEX.relative_to(ROOT)}: missing fragment target {value}")
+            continue
+        if value.startswith("./"):
+            if not local_target_exists(value):
+                failures.append(f"{INDEX.relative_to(ROOT)}: broken local {attr}: {value}")
+            continue
+        if value.startswith("https://"):
+            if not github_target_exists(value):
+                failures.append(f"{INDEX.relative_to(ROOT)}: unsupported or broken external {attr}: {value}")
+            continue
+        if value.startswith("mailto:"):
+            continue
+        failures.append(f"{INDEX.relative_to(ROOT)}: unsupported {attr}: {value}")
+
+    if failures:
+        print("\n".join(failures))
+        return 1
+
+    print("docs site ok")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- turns the GitHub Pages root into a public Jarvis documentation site instead of only an interactive walkthrough
- adds direct entry points for protocol docs, OpenAPI, conformance, examples, packages, release notes, and GitHub
- keeps the walkthrough as non-normative public explanation inside the docs site
- adds `scripts/check_docs_site.py` to validate static site assets, fragments, and repo-backed GitHub/raw links
- updates README, roadmap, PR template, and Pages/validation workflows for docs-site language

## Protocol Surface

- no protocol object, OpenAPI operation, schema, fixture, error id, or conformance rule changes
- public documentation now presents the v0.1.0 Protocol Alpha surface through site navigation
- roadmap names current follow-up work as protocol-record compatibility evidence planning, not host implementation work

## Boundary Check

- [x] This change keeps Jarvis protocol-only.
- [x] This change does not add host runtime, UI, auth, storage, billing, model orchestration, tool execution, scoring, payment, deployment, monitoring, host integration, host workflow, adapter, or wrapper code.

## Compatibility Impact

- compatible implementations get clearer public entry points for the OpenAPI contract, conformance docs, examples, and helper packages
- the docs site does not certify implementations, designate an official host, or claim production adoption
- existing GitHub Pages deployment remains static and continues to publish from `demo/`

## Conformance Impact

- no conformance semantics changed
- CI now validates docs-site local assets, fragments, and repository-backed links through `python3 scripts/check_docs_site.py`
- docs-site JavaScript remains syntax-checked in validation and Pages workflows

## Validation

- [x] `python3 scripts/check_conformance_fixtures.py`
- [x] `python3 scripts/check_openapi_contract.py`
- [x] `python3 scripts/check_markdown_links.py`
- [x] `python3 scripts/check_docs_site.py` if docs site files changed
- [x] `python3 scripts/check_protocol_wording.py`
- [x] `python3 scripts/check_sdk_boundary.py` if SDK boundary, package, helper, or fixture snapshot paths changed
- [ ] `npm --workspace @jarvis-protocol/sdk test` if TypeScript helper paths changed
- [ ] `npm run test:python` if Python helper paths changed
- [x] `git diff --check`
- [x] `node --check demo/assets/app.js` if docs site JavaScript changed

Additional review:

- [x] boundary/wording reviewer
- [x] frontend layout reviewer
- [x] docs information architecture reviewer
- [x] security/workflow reviewer
- [x] desktop/mobile browser screenshot and layout checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public documentation site layout with clearer sections for protocol overview, examples, conformance, and SDK guidance.
  * Updated the README to point to the new documentation site and reorganized the docs index.

* **Bug Fixes**
  * Added additional validation for documentation-site links and page references.
  * Improved deployment and local check steps to include the new documentation-site validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->