### PR TITLE
[codex] Add protocol record evidence pack

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,9 +24,10 @@
 - [ ] `python3 scripts/check_conformance_fixtures.py`
 - [ ] `python3 scripts/check_openapi_contract.py`
 - [ ] `python3 scripts/check_markdown_links.py`
-- [ ] `python3 scripts/check_docs_site.py` if docs site files changed
+- [ ] `python3 scripts/check_docs_site.py`
+- [ ] `python3 scripts/check_example_evidence_packs.py`
 - [ ] `python3 scripts/check_protocol_wording.py`
-- [ ] `python3 scripts/check_sdk_boundary.py` if SDK boundary, package, helper, or fixture snapshot paths changed
+- [ ] `python3 scripts/check_sdk_boundary.py`
 - [ ] `npm --workspace @jarvis-protocol/sdk test` if TypeScript helper paths changed
 - [ ] `npm run test:python` if Python helper paths changed
 - [ ] `git diff --check`

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Validate docs site
         run: python3 scripts/check_docs_site.py
 
+      - name: Validate example evidence packs
+        run: python3 scripts/check_example_evidence_packs.py
+
       - name: Validate protocol wording
         run: python3 scripts/check_protocol_wording.py
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Validate docs site
         run: python3 scripts/check_docs_site.py
 
+      - name: Validate example evidence packs
+        run: python3 scripts/check_example_evidence_packs.py
+
       - name: Validate protocol wording
         run: python3 scripts/check_protocol_wording.py
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -311,14 +311,19 @@ python3 scripts/check_conformance_fixtures.py
 python3 scripts/check_openapi_contract.py
 python3 scripts/check_markdown_links.py
 python3 scripts/check_docs_site.py
+python3 scripts/check_example_evidence_packs.py
 python3 scripts/check_protocol_wording.py
+python3 scripts/check_sdk_boundary.py
 git diff --check
 ```
 
 Fixture changes MUST run `python3 scripts/check_conformance_fixtures.py`.
 
-SDK boundary, package, helper, and fixture-snapshot changes MUST run
-`python3 scripts/check_sdk_boundary.py`.
+Example evidence pack changes MUST run
+`python3 scripts/check_example_evidence_packs.py`.
+
+SDK boundary, package, helper, and fixture-snapshot changes MUST still treat
+`python3 scripts/check_sdk_boundary.py` as a blocking gate.
 
 TypeScript helper changes MUST run
 `npm --workspace @jarvis-protocol/sdk test`.

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Jarvis-owned agents.
   conformance entries, fixtures, validator requirements, and existing-agent
   proof plan.
 - [docs/examples/](./docs/examples/) - protocol record, existing-agent
-  compatibility, and compatible-host mapping examples.
+  compatibility, compatible-host mapping examples, and evidence packs.
 - [packages/](./packages/) - TypeScript, Python, and CLI protocol helper
   packages.
 - [docs/reviews/](./docs/reviews/) - protocol readiness and acceptance review
@@ -338,7 +338,10 @@ Every protocol PR MUST run:
 python3 scripts/check_conformance_fixtures.py
 python3 scripts/check_openapi_contract.py
 python3 scripts/check_markdown_links.py
+python3 scripts/check_docs_site.py
+python3 scripts/check_example_evidence_packs.py
 python3 scripts/check_protocol_wording.py
+python3 scripts/check_sdk_boundary.py
 git diff --check
 ```
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -235,6 +235,11 @@
             <p>How a host maps native collaboration events into Jarvis protocol records while keeping implementation private.</p>
             <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/examples/compatible-host-mapping.md">Read host mapping</a>
           </article>
+          <article>
+            <h3>Evidence Pack</h3>
+            <p>Machine-checkable protocol records for an existing-agent review loop, validated without host runtime code.</p>
+            <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/examples/evidence-packs/existing-agent-review/README.md">Open evidence pack</a>
+          </article>
         </div>
       </section>
 
@@ -250,9 +255,10 @@
             governed learning.
           </p>
         </div>
-        <pre aria-label="Conformance CLI command"><code>npm run test:cli
+        <pre aria-label="Protocol validation commands"><code>npm run test:cli
 node packages/cli/src/index.js validate fixtures docs/conformance/fixtures
-node packages/cli/src/index.js list rejection-ids</code></pre>
+node packages/cli/src/index.js list rejection-ids
+python3 scripts/check_example_evidence_packs.py</code></pre>
       </section>
 
       <section class="sdk-section" id="sdk" aria-labelledby="sdk-title">

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,17 @@ and existing-agent compatibility proof.
 - [conformance/existing-agent-proof-plan.md](./conformance/existing-agent-proof-plan.md)
 - [conformance/fixtures/README.md](./conformance/fixtures/README.md)
 
+## Examples
+
+Examples show protocol records and record-compatibility evidence without
+defining host-owned execution.
+
+- [examples/README.md](./examples/README.md)
+- [examples/protocol-records.md](./examples/protocol-records.md)
+- [examples/existing-agent-compatibility.md](./examples/existing-agent-compatibility.md)
+- [examples/compatible-host-mapping.md](./examples/compatible-host-mapping.md)
+- [examples/evidence-packs/existing-agent-review/README.md](./examples/evidence-packs/existing-agent-review/README.md)
+
 ## OpenAPI
 
 The OpenAPI directory contains the v0.1 machine-readable communication binding.

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -17,7 +17,7 @@ adapters, wrappers, SDK implementation, or host workflow.
   native collaboration events into Jarvis protocol records while keeping
   implementation private.
 - [evidence-packs/existing-agent-review/README.md](./evidence-packs/existing-agent-review/README.md)
-  - machine-checkable protocol-record evidence pack for the existing-agent
+  machine-checkable protocol-record evidence pack for the existing-agent
   review-resolution loop.
 
 ## Validation

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,0 +1,32 @@
+# Jarvis Examples
+
+Jarvis examples show protocol records only.
+
+They do not define runtime behavior, host UI, storage, auth, model calls, tool
+execution, billing, scoring, payment, deployment, monitoring, host integration,
+adapters, wrappers, SDK implementation, or host workflow.
+
+## Public Examples
+
+- [protocol-records.md](./protocol-records.md) - concrete v0.1 protocol record
+  examples for one human-agent collaboration loop.
+- [existing-agent-compatibility.md](./existing-agent-compatibility.md) - how an
+  existing native agent participates through Jarvis records without being
+  rewritten as a Jarvis-owned agent.
+- [compatible-host-mapping.md](./compatible-host-mapping.md) - how hosts map
+  native collaboration events into Jarvis protocol records while keeping
+  implementation private.
+- [evidence-packs/existing-agent-review/README.md](./evidence-packs/existing-agent-review/README.md)
+  - machine-checkable protocol-record evidence pack for the existing-agent
+  review-resolution loop.
+
+## Validation
+
+Validate evidence packs from the repository root:
+
+```bash
+python3 scripts/check_example_evidence_packs.py
+```
+
+Evidence packs prove record compatibility only. They do not certify an
+implementation and do not claim production adoption.

--- a/docs/examples/evidence-packs/existing-agent-review/README.md
+++ b/docs/examples/evidence-packs/existing-agent-review/README.md
@@ -1,0 +1,84 @@
+# Existing-Agent Review Evidence Pack
+
+This evidence pack shows one existing-agent collaboration loop as Jarvis v0.1
+protocol records.
+
+Jarvis records protocol state. Hosts own native execution.
+
+## Boundary
+
+This pack does not define adapter code, wrapper code, host runtime behavior,
+host UI, model calls, tool execution, storage, auth, billing, scoring, payment,
+deployment, monitoring, host integration, or host workflow.
+
+The pack uses
+[docs/conformance/fixtures/valid/golden-path.json](../../../conformance/fixtures/valid/golden-path.json)
+as its source fixture and extracts a public record bundle from it. The records
+show:
+
+- HumanWorker and AgentWorker participant records
+- WorkSession and Policy records
+- PolicyDecision before accepted AgentWorker state
+- scoped Request
+- HumanWorker Review with bounded ApprovalScope
+- Contribution attribution
+- EvidenceManifest export from a terminal WorkSession
+- governed LearningRecord, MemoryProposal, and SkillProposal
+- OutcomeReport from a terminal source WorkSession
+- operation headers for mutation and read surfaces
+- JarvisEvent hash-chain validation
+
+## Files
+
+```txt
+manifest.json
+records/
+evidence/evidence-manifest.json
+events/event-chain.json
+headers/
+```
+
+`manifest.json` defines the source fixture refs, record files, context refs,
+EvidenceManifest source, event chain, and operation header checks.
+
+Record files use the helper-compatible envelope:
+
+```json
+{
+  "object_type": "Request",
+  "record": {}
+}
+```
+
+Records that require protocol context include only the minimum protocol context
+needed for validation. Context does not add host runtime state.
+
+## Validation
+
+Validate all evidence packs from the repository root:
+
+```bash
+python3 scripts/check_example_evidence_packs.py
+```
+
+Validate one record with the CLI:
+
+```bash
+node packages/cli/src/index.js validate record docs/examples/evidence-packs/existing-agent-review/records/request-approved.json
+```
+
+Validate the EvidenceManifest export:
+
+```bash
+node packages/cli/src/index.js validate evidence-manifest docs/examples/evidence-packs/existing-agent-review/evidence/evidence-manifest.json
+```
+
+Validate the event hash chain:
+
+```bash
+node packages/cli/src/index.js check hash-chain docs/examples/evidence-packs/existing-agent-review/events/event-chain.json
+```
+
+The evidence pack proves record compatibility only. It does not certify an
+implementation, does not claim production adoption, and does not define host
+execution.

--- a/docs/examples/evidence-packs/existing-agent-review/events/event-chain.json
+++ b/docs/examples/evidence-packs/existing-agent-review/events/event-chain.json
@@ -1,0 +1,238 @@
+{
+  "events": [
+    {
+      "id": "event-worksession-created",
+      "sequence": 1,
+      "type": "work_session.created",
+      "work_session_id": "ws-golden-001",
+      "actor_id": "actor-human-golden",
+      "timestamp": "2026-06-16T10:01:00Z",
+      "payload": {
+        "object_type": "work_session",
+        "object_id": "ws-golden-001",
+        "action": "created",
+        "summary": "WorkSession created with HumanWorker, AgentWorker, objective, and Policy."
+      },
+      "previous_hash": "hash:protocol-genesis",
+      "event_hash": "hash:event-worksession-created",
+      "canonicalization": {
+        "serialization": "json-c14n",
+        "hash_method": "sha256",
+        "profile_ref": "canonicalization:v0.1"
+      }
+    },
+    {
+      "id": "event-policy-denied",
+      "sequence": 2,
+      "type": "policy_decision.recorded",
+      "work_session_id": "ws-golden-001",
+      "actor_id": "actor-agent-golden",
+      "timestamp": "2026-06-16T10:04:00Z",
+      "payload": {
+        "object_type": "policy_decision",
+        "object_id": "pd-golden-source-denied",
+        "action": "deny",
+        "summary": "Policy denied external source collection and required Request."
+      },
+      "previous_hash": "hash:event-worksession-created",
+      "event_hash": "hash:event-policy-denied",
+      "canonicalization": {
+        "serialization": "json-c14n",
+        "hash_method": "sha256",
+        "profile_ref": "canonicalization:v0.1"
+      }
+    },
+    {
+      "id": "event-request-created",
+      "sequence": 3,
+      "type": "request.created",
+      "work_session_id": "ws-golden-001",
+      "actor_id": "actor-agent-golden",
+      "timestamp": "2026-06-16T10:05:00Z",
+      "payload": {
+        "object_type": "request",
+        "object_id": "req-golden-source",
+        "action": "created",
+        "summary": "AgentWorker created scoped Request for HumanWorker approval."
+      },
+      "previous_hash": "hash:event-policy-denied",
+      "event_hash": "hash:event-request-created",
+      "canonicalization": {
+        "serialization": "json-c14n",
+        "hash_method": "sha256",
+        "profile_ref": "canonicalization:v0.1"
+      }
+    },
+    {
+      "id": "event-review-approved",
+      "sequence": 4,
+      "type": "review.recorded",
+      "work_session_id": "ws-golden-001",
+      "actor_id": "actor-human-golden",
+      "timestamp": "2026-06-16T10:08:00Z",
+      "payload": {
+        "object_type": "review",
+        "object_id": "review-golden-source-approval",
+        "action": "approve",
+        "summary": "HumanWorker approved Request with bounded ApprovalScope."
+      },
+      "previous_hash": "hash:event-request-created",
+      "event_hash": "hash:event-review-approved",
+      "canonicalization": {
+        "serialization": "json-c14n",
+        "hash_method": "sha256",
+        "profile_ref": "canonicalization:v0.1"
+      }
+    },
+    {
+      "id": "event-policy-allowed",
+      "sequence": 5,
+      "type": "policy_decision.recorded",
+      "work_session_id": "ws-golden-001",
+      "actor_id": "actor-agent-golden",
+      "timestamp": "2026-06-16T10:08:30Z",
+      "payload": {
+        "object_type": "policy_decision",
+        "object_id": "pd-golden-source-approved",
+        "action": "allow",
+        "summary": "AgentWorker resumed inside bounded ApprovalScope."
+      },
+      "previous_hash": "hash:event-review-approved",
+      "event_hash": "hash:event-policy-allowed",
+      "canonicalization": {
+        "serialization": "json-c14n",
+        "hash_method": "sha256",
+        "profile_ref": "canonicalization:v0.1"
+      }
+    },
+    {
+      "id": "event-evidence-captured",
+      "sequence": 6,
+      "type": "evidence.captured",
+      "work_session_id": "ws-golden-001",
+      "actor_id": "actor-agent-golden",
+      "timestamp": "2026-06-16T10:12:00Z",
+      "payload": {
+        "object_type": "evidence_manifest",
+        "object_id": "evidence-source-summary",
+        "action": "evidence_item_captured",
+        "evidence_refs": [
+          "evidence-source-summary"
+        ],
+        "summary": "AgentWorker captured source summary evidence during work."
+      },
+      "previous_hash": "hash:event-policy-allowed",
+      "event_hash": "hash:event-evidence-captured",
+      "canonicalization": {
+        "serialization": "json-c14n",
+        "hash_method": "sha256",
+        "profile_ref": "canonicalization:v0.1"
+      }
+    },
+    {
+      "id": "event-contribution-recorded",
+      "sequence": 7,
+      "type": "contribution.recorded",
+      "work_session_id": "ws-golden-001",
+      "actor_id": "actor-human-golden",
+      "timestamp": "2026-06-16T10:16:00Z",
+      "payload": {
+        "object_type": "contribution",
+        "object_id": "contribution-golden-shared-answer",
+        "action": "recorded",
+        "summary": "Shared Contribution recorded with human and agent contributor refs."
+      },
+      "previous_hash": "hash:event-evidence-captured",
+      "event_hash": "hash:event-contribution-recorded",
+      "canonicalization": {
+        "serialization": "json-c14n",
+        "hash_method": "sha256",
+        "profile_ref": "canonicalization:v0.1"
+      }
+    },
+    {
+      "id": "event-learning-recorded",
+      "sequence": 8,
+      "type": "learning.recorded",
+      "work_session_id": "ws-golden-001",
+      "actor_id": "actor-human-golden",
+      "timestamp": "2026-06-16T10:18:00Z",
+      "payload": {
+        "object_type": "learning_record",
+        "object_id": "learning-golden-pair",
+        "action": "accepted",
+        "summary": "Pair learning recorded from Request, Review, and evidence capture."
+      },
+      "previous_hash": "hash:event-contribution-recorded",
+      "event_hash": "hash:event-learning-recorded",
+      "canonicalization": {
+        "serialization": "json-c14n",
+        "hash_method": "sha256",
+        "profile_ref": "canonicalization:v0.1"
+      }
+    },
+    {
+      "id": "event-memory-proposal-created",
+      "sequence": 9,
+      "type": "memory_proposal.created",
+      "work_session_id": "ws-golden-001",
+      "actor_id": "actor-human-golden",
+      "timestamp": "2026-06-16T10:19:00Z",
+      "payload": {
+        "object_type": "memory_proposal",
+        "object_id": "memory-proposal-golden",
+        "action": "proposed",
+        "summary": "MemoryProposal keeps durable memory change governed."
+      },
+      "previous_hash": "hash:event-learning-recorded",
+      "event_hash": "hash:event-memory-proposal-created",
+      "canonicalization": {
+        "serialization": "json-c14n",
+        "hash_method": "sha256",
+        "profile_ref": "canonicalization:v0.1"
+      }
+    },
+    {
+      "id": "event-skill-proposal-created",
+      "sequence": 10,
+      "type": "skill_proposal.created",
+      "work_session_id": "ws-golden-001",
+      "actor_id": "actor-human-golden",
+      "timestamp": "2026-06-16T10:20:00Z",
+      "payload": {
+        "object_type": "skill_proposal",
+        "object_id": "skill-proposal-golden",
+        "action": "proposed",
+        "summary": "SkillProposal keeps reusable process change governed."
+      },
+      "previous_hash": "hash:event-memory-proposal-created",
+      "event_hash": "hash:event-skill-proposal-created",
+      "canonicalization": {
+        "serialization": "json-c14n",
+        "hash_method": "sha256",
+        "profile_ref": "canonicalization:v0.1"
+      }
+    },
+    {
+      "id": "event-worksession-completed",
+      "sequence": 11,
+      "type": "work_session.completed",
+      "work_session_id": "ws-golden-001",
+      "actor_id": "actor-human-golden",
+      "timestamp": "2026-06-16T10:25:00Z",
+      "payload": {
+        "object_type": "work_session",
+        "object_id": "ws-golden-001",
+        "action": "completed",
+        "summary": "WorkSession completed before EvidenceManifest export."
+      },
+      "previous_hash": "hash:event-skill-proposal-created",
+      "event_hash": "hash:event-worksession-completed",
+      "canonicalization": {
+        "serialization": "json-c14n",
+        "hash_method": "sha256",
+        "profile_ref": "canonicalization:v0.1"
+      }
+    }
+  ]
+}

--- a/docs/examples/evidence-packs/existing-agent-review/evidence/evidence-manifest.json
+++ b/docs/examples/evidence-packs/existing-agent-review/evidence/evidence-manifest.json
@@ -1,0 +1,80 @@
+{
+  "evidence_manifest": {
+    "id": "evidence-manifest-golden",
+    "work_session_id": "ws-golden-001",
+    "generated_by_actor_id": "actor-human-golden",
+    "objective": "Produce an evidence-backed answer with human review and governed learning.",
+    "event_chain_root": "hash:event-worksession-completed",
+    "evidence_item_refs": [
+      {
+        "id": "evidence-source-summary",
+        "work_session_id": "ws-golden-001",
+        "source_event_refs": [
+          "event-evidence-captured"
+        ],
+        "captured_by_actor_id": "actor-agent-golden",
+        "evidence_type": "source_summary",
+        "artifact_ref": "artifact:source-summary",
+        "content_hash": "hash:source-summary",
+        "trust_label": "reviewed",
+        "redaction_state": "redacted",
+        "captured_at": "2026-06-16T10:12:00Z",
+        "limitation_refs": [
+          "limitation:none-recorded"
+        ]
+      }
+    ],
+    "policy_decision_refs": [
+      "pd-golden-source-denied",
+      "pd-golden-source-approved"
+    ],
+    "request_refs": [
+      "req-golden-source"
+    ],
+    "review_refs": [
+      "review-golden-source-approval"
+    ],
+    "takeover_refs": [],
+    "contribution_refs": [
+      "contribution-golden-shared-answer"
+    ],
+    "export_profile": {
+      "profile": "portable_evidence_manifest",
+      "version": "v0.1",
+      "redaction_profile_ref": "redaction:portable-safe"
+    },
+    "generated_at": "2026-06-16T10:26:00Z",
+    "artifact_refs": [
+      "artifact:reviewed-answer",
+      "artifact:source-summary"
+    ],
+    "limitation_refs": [
+      "limitation:none-recorded"
+    ],
+    "redaction_refs": [
+      "redaction:portable-safe"
+    ]
+  },
+  "work_session": {
+    "id": "ws-golden-001",
+    "protocol_version": "v0.1",
+    "created_by_actor_id": "actor-human-golden",
+    "objective": "Produce an evidence-backed answer with human review and governed learning.",
+    "human_worker_id": "worker-human-golden",
+    "agent_worker_id": "worker-agent-golden",
+    "policy_id": "policy-golden-bounded",
+    "status": "completed",
+    "revision": 11,
+    "last_event_hash": "hash:event-worksession-completed",
+    "event_log_ref": "event-log:ws-golden-001",
+    "created_at": "2026-06-16T10:01:00Z",
+    "updated_at": "2026-06-16T10:25:00Z",
+    "source_ref": "source:golden-path-fixture",
+    "context_manifest_ref": "context:task-brief",
+    "contribution_ledger_ref": "ledger:ws-golden-001",
+    "evidence_manifest_ref": "evidence-manifest-golden",
+    "learning_record_refs": [
+      "learning-golden-pair"
+    ]
+  }
+}

--- a/docs/examples/evidence-packs/existing-agent-review/headers/00-register-worker-human.json
+++ b/docs/examples/evidence-packs/existing-agent-review/headers/00-register-worker-human.json
@@ -1,0 +1,15 @@
+{
+  "operation_id": "registerWorker",
+  "method": "PUT",
+  "path": "/workers/worker-human-golden",
+  "headers": {
+    "Authorization": "HostAuth fixture",
+    "Jarvis-Protocol-Version": "v0.1",
+    "Jarvis-Actor-Id": "actor-fixture-registrar",
+    "Jarvis-Idempotency-Key": "idem-register-worker-human-golden",
+    "Jarvis-Request-Timestamp": "2026-06-16T10:00:00Z"
+  },
+  "body_ref": "records.workers.human",
+  "actor_id": "actor-fixture-registrar",
+  "expected_status": 200
+}

--- a/docs/examples/evidence-packs/existing-agent-review/headers/01-register-worker-agent.json
+++ b/docs/examples/evidence-packs/existing-agent-review/headers/01-register-worker-agent.json
@@ -1,0 +1,15 @@
+{
+  "operation_id": "registerWorker",
+  "method": "PUT",
+  "path": "/workers/worker-agent-golden",
+  "headers": {
+    "Authorization": "HostAuth fixture",
+    "Jarvis-Protocol-Version": "v0.1",
+    "Jarvis-Actor-Id": "actor-fixture-registrar",
+    "Jarvis-Idempotency-Key": "idem-register-worker-agent-golden",
+    "Jarvis-Request-Timestamp": "2026-06-16T10:00:01Z"
+  },
+  "body_ref": "records.workers.agent",
+  "actor_id": "actor-fixture-registrar",
+  "expected_status": 200
+}

--- a/docs/examples/evidence-packs/existing-agent-review/headers/02-register-actor-human.json
+++ b/docs/examples/evidence-packs/existing-agent-review/headers/02-register-actor-human.json
@@ -1,0 +1,15 @@
+{
+  "operation_id": "registerActor",
+  "method": "PUT",
+  "path": "/actors/actor-human-golden",
+  "headers": {
+    "Authorization": "HostAuth fixture",
+    "Jarvis-Protocol-Version": "v0.1",
+    "Jarvis-Actor-Id": "actor-fixture-registrar",
+    "Jarvis-Idempotency-Key": "idem-register-actor-human-golden",
+    "Jarvis-Request-Timestamp": "2026-06-16T10:00:02Z"
+  },
+  "body_ref": "records.actors.human",
+  "actor_id": "actor-fixture-registrar",
+  "expected_status": 200
+}

--- a/docs/examples/evidence-packs/existing-agent-review/headers/03-register-actor-agent.json
+++ b/docs/examples/evidence-packs/existing-agent-review/headers/03-register-actor-agent.json
@@ -1,0 +1,15 @@
+{
+  "operation_id": "registerActor",
+  "method": "PUT",
+  "path": "/actors/actor-agent-golden",
+  "headers": {
+    "Authorization": "HostAuth fixture",
+    "Jarvis-Protocol-Version": "v0.1",
+    "Jarvis-Actor-Id": "actor-fixture-registrar",
+    "Jarvis-Idempotency-Key": "idem-register-actor-agent-golden",
+    "Jarvis-Request-Timestamp": "2026-06-16T10:00:03Z"
+  },
+  "body_ref": "records.actors.agent",
+  "actor_id": "actor-fixture-registrar",
+  "expected_status": 200
+}

--- a/docs/examples/evidence-packs/existing-agent-review/headers/04-create-work-session-genesis-request.json
+++ b/docs/examples/evidence-packs/existing-agent-review/headers/04-create-work-session-genesis-request.json
@@ -1,0 +1,19 @@
+{
+  "operation_id": "createWorkSession",
+  "method": "POST",
+  "path": "/work-sessions",
+  "headers": {
+    "Authorization": "HostAuth fixture",
+    "Jarvis-Protocol-Version": "v0.1",
+    "Jarvis-Actor-Id": "actor-human-golden",
+    "Jarvis-Idempotency-Key": "idem-create-worksession-golden",
+    "Jarvis-Request-Timestamp": "2026-06-16T10:01:00Z",
+    "Jarvis-Expected-WorkSession-Revision": 0,
+    "Jarvis-Previous-Event-Hash": "hash:protocol-genesis"
+  },
+  "body_ref": "records.work_sessions.genesis_request",
+  "actor_id": "actor-human-golden",
+  "work_session_id": "ws-golden-001",
+  "expected_status": 201,
+  "expected_event_ref": "event-worksession-created"
+}

--- a/docs/examples/evidence-packs/existing-agent-review/headers/05-record-policy-decision-external-source-denied.json
+++ b/docs/examples/evidence-packs/existing-agent-review/headers/05-record-policy-decision-external-source-denied.json
@@ -1,0 +1,19 @@
+{
+  "operation_id": "recordPolicyDecision",
+  "method": "POST",
+  "path": "/work-sessions/ws-golden-001/policy-decisions",
+  "headers": {
+    "Authorization": "HostAuth fixture",
+    "Jarvis-Protocol-Version": "v0.1",
+    "Jarvis-Actor-Id": "actor-agent-golden",
+    "Jarvis-Idempotency-Key": "idem-policy-denied-golden",
+    "Jarvis-Request-Timestamp": "2026-06-16T10:04:00Z",
+    "Jarvis-Expected-WorkSession-Revision": 1,
+    "Jarvis-Previous-Event-Hash": "hash:event-worksession-created"
+  },
+  "body_ref": "records.policy_decisions.external_source_denied",
+  "actor_id": "actor-agent-golden",
+  "work_session_id": "ws-golden-001",
+  "expected_status": 201,
+  "expected_event_ref": "event-policy-denied"
+}

--- a/docs/examples/evidence-packs/existing-agent-review/headers/06-create-request-pending.json
+++ b/docs/examples/evidence-packs/existing-agent-review/headers/06-create-request-pending.json
@@ -1,0 +1,19 @@
+{
+  "operation_id": "createRequest",
+  "method": "POST",
+  "path": "/work-sessions/ws-golden-001/requests",
+  "headers": {
+    "Authorization": "HostAuth fixture",
+    "Jarvis-Protocol-Version": "v0.1",
+    "Jarvis-Actor-Id": "actor-agent-golden",
+    "Jarvis-Idempotency-Key": "idem-request-source-golden",
+    "Jarvis-Request-Timestamp": "2026-06-16T10:05:00Z",
+    "Jarvis-Expected-WorkSession-Revision": 2,
+    "Jarvis-Previous-Event-Hash": "hash:event-policy-denied"
+  },
+  "body_ref": "records.requests.pending",
+  "actor_id": "actor-agent-golden",
+  "work_session_id": "ws-golden-001",
+  "expected_status": 201,
+  "expected_event_ref": "event-request-created"
+}

--- a/docs/examples/evidence-packs/existing-agent-review/headers/07-record-review-approve-source.json
+++ b/docs/examples/evidence-packs/existing-agent-review/headers/07-record-review-approve-source.json
@@ -1,0 +1,19 @@
+{
+  "operation_id": "recordReview",
+  "method": "POST",
+  "path": "/work-sessions/ws-golden-001/reviews",
+  "headers": {
+    "Authorization": "HostAuth fixture",
+    "Jarvis-Protocol-Version": "v0.1",
+    "Jarvis-Actor-Id": "actor-human-golden",
+    "Jarvis-Idempotency-Key": "idem-review-source-golden",
+    "Jarvis-Request-Timestamp": "2026-06-16T10:08:00Z",
+    "Jarvis-Expected-WorkSession-Revision": 3,
+    "Jarvis-Previous-Event-Hash": "hash:event-request-created"
+  },
+  "body_ref": "records.reviews.approve_source",
+  "actor_id": "actor-human-golden",
+  "work_session_id": "ws-golden-001",
+  "expected_status": 201,
+  "expected_event_ref": "event-review-approved"
+}

--- a/docs/examples/evidence-packs/existing-agent-review/headers/08-record-policy-decision-external-source-allowed.json
+++ b/docs/examples/evidence-packs/existing-agent-review/headers/08-record-policy-decision-external-source-allowed.json
@@ -1,0 +1,19 @@
+{
+  "operation_id": "recordPolicyDecision",
+  "method": "POST",
+  "path": "/work-sessions/ws-golden-001/policy-decisions",
+  "headers": {
+    "Authorization": "HostAuth fixture",
+    "Jarvis-Protocol-Version": "v0.1",
+    "Jarvis-Actor-Id": "actor-agent-golden",
+    "Jarvis-Idempotency-Key": "idem-policy-allowed-golden",
+    "Jarvis-Request-Timestamp": "2026-06-16T10:08:30Z",
+    "Jarvis-Expected-WorkSession-Revision": 4,
+    "Jarvis-Previous-Event-Hash": "hash:event-review-approved"
+  },
+  "body_ref": "records.policy_decisions.external_source_allowed",
+  "actor_id": "actor-agent-golden",
+  "work_session_id": "ws-golden-001",
+  "expected_status": 201,
+  "expected_event_ref": "event-policy-allowed"
+}

--- a/docs/examples/evidence-packs/existing-agent-review/headers/09-append-jarvis-event-evidence-captured.json
+++ b/docs/examples/evidence-packs/existing-agent-review/headers/09-append-jarvis-event-evidence-captured.json
@@ -1,0 +1,19 @@
+{
+  "operation_id": "appendJarvisEvent",
+  "method": "POST",
+  "path": "/work-sessions/ws-golden-001/events",
+  "headers": {
+    "Authorization": "HostAuth fixture",
+    "Jarvis-Protocol-Version": "v0.1",
+    "Jarvis-Actor-Id": "actor-agent-golden",
+    "Jarvis-Idempotency-Key": "idem-evidence-captured-golden",
+    "Jarvis-Request-Timestamp": "2026-06-16T10:12:00Z",
+    "Jarvis-Expected-WorkSession-Revision": 5,
+    "Jarvis-Previous-Event-Hash": "hash:event-policy-allowed"
+  },
+  "body_ref": "records.jarvis_events.evidence_captured",
+  "actor_id": "actor-agent-golden",
+  "work_session_id": "ws-golden-001",
+  "expected_status": 201,
+  "expected_event_ref": "event-evidence-captured"
+}

--- a/docs/examples/evidence-packs/existing-agent-review/headers/10-record-contribution-shared-answer.json
+++ b/docs/examples/evidence-packs/existing-agent-review/headers/10-record-contribution-shared-answer.json
@@ -1,0 +1,19 @@
+{
+  "operation_id": "recordContribution",
+  "method": "POST",
+  "path": "/work-sessions/ws-golden-001/contributions",
+  "headers": {
+    "Authorization": "HostAuth fixture",
+    "Jarvis-Protocol-Version": "v0.1",
+    "Jarvis-Actor-Id": "actor-human-golden",
+    "Jarvis-Idempotency-Key": "idem-contribution-golden",
+    "Jarvis-Request-Timestamp": "2026-06-16T10:16:00Z",
+    "Jarvis-Expected-WorkSession-Revision": 6,
+    "Jarvis-Previous-Event-Hash": "hash:event-evidence-captured"
+  },
+  "body_ref": "records.contributions.shared_answer",
+  "actor_id": "actor-human-golden",
+  "work_session_id": "ws-golden-001",
+  "expected_status": 201,
+  "expected_event_ref": "event-contribution-recorded"
+}

--- a/docs/examples/evidence-packs/existing-agent-review/headers/11-create-learning-record-pair.json
+++ b/docs/examples/evidence-packs/existing-agent-review/headers/11-create-learning-record-pair.json
@@ -1,0 +1,19 @@
+{
+  "operation_id": "createLearningRecord",
+  "method": "POST",
+  "path": "/work-sessions/ws-golden-001/learning-records",
+  "headers": {
+    "Authorization": "HostAuth fixture",
+    "Jarvis-Protocol-Version": "v0.1",
+    "Jarvis-Actor-Id": "actor-human-golden",
+    "Jarvis-Idempotency-Key": "idem-learning-golden",
+    "Jarvis-Request-Timestamp": "2026-06-16T10:18:00Z",
+    "Jarvis-Expected-WorkSession-Revision": 7,
+    "Jarvis-Previous-Event-Hash": "hash:event-contribution-recorded"
+  },
+  "body_ref": "records.learning_records.pair",
+  "actor_id": "actor-human-golden",
+  "work_session_id": "ws-golden-001",
+  "expected_status": 201,
+  "expected_event_ref": "event-learning-recorded"
+}

--- a/docs/examples/evidence-packs/existing-agent-review/headers/12-create-memory-proposal-source-policy-pattern.json
+++ b/docs/examples/evidence-packs/existing-agent-review/headers/12-create-memory-proposal-source-policy-pattern.json
@@ -1,0 +1,19 @@
+{
+  "operation_id": "createMemoryProposal",
+  "method": "POST",
+  "path": "/work-sessions/ws-golden-001/memory-proposals",
+  "headers": {
+    "Authorization": "HostAuth fixture",
+    "Jarvis-Protocol-Version": "v0.1",
+    "Jarvis-Actor-Id": "actor-human-golden",
+    "Jarvis-Idempotency-Key": "idem-memory-proposal-golden",
+    "Jarvis-Request-Timestamp": "2026-06-16T10:19:00Z",
+    "Jarvis-Expected-WorkSession-Revision": 8,
+    "Jarvis-Previous-Event-Hash": "hash:event-learning-recorded"
+  },
+  "body_ref": "records.memory_proposals.source_policy_pattern",
+  "actor_id": "actor-human-golden",
+  "work_session_id": "ws-golden-001",
+  "expected_status": 201,
+  "expected_event_ref": "event-memory-proposal-created"
+}

--- a/docs/examples/evidence-packs/existing-agent-review/headers/13-create-skill-proposal-bounded-source-collection.json
+++ b/docs/examples/evidence-packs/existing-agent-review/headers/13-create-skill-proposal-bounded-source-collection.json
@@ -1,0 +1,19 @@
+{
+  "operation_id": "createSkillProposal",
+  "method": "POST",
+  "path": "/work-sessions/ws-golden-001/skill-proposals",
+  "headers": {
+    "Authorization": "HostAuth fixture",
+    "Jarvis-Protocol-Version": "v0.1",
+    "Jarvis-Actor-Id": "actor-human-golden",
+    "Jarvis-Idempotency-Key": "idem-skill-proposal-golden",
+    "Jarvis-Request-Timestamp": "2026-06-16T10:20:00Z",
+    "Jarvis-Expected-WorkSession-Revision": 9,
+    "Jarvis-Previous-Event-Hash": "hash:event-memory-proposal-created"
+  },
+  "body_ref": "records.skill_proposals.bounded_source_collection",
+  "actor_id": "actor-human-golden",
+  "work_session_id": "ws-golden-001",
+  "expected_status": 201,
+  "expected_event_ref": "event-skill-proposal-created"
+}

--- a/docs/examples/evidence-packs/existing-agent-review/headers/14-append-jarvis-event-worksession-completed.json
+++ b/docs/examples/evidence-packs/existing-agent-review/headers/14-append-jarvis-event-worksession-completed.json
@@ -1,0 +1,19 @@
+{
+  "operation_id": "appendJarvisEvent",
+  "method": "POST",
+  "path": "/work-sessions/ws-golden-001/events",
+  "headers": {
+    "Authorization": "HostAuth fixture",
+    "Jarvis-Protocol-Version": "v0.1",
+    "Jarvis-Actor-Id": "actor-human-golden",
+    "Jarvis-Idempotency-Key": "idem-worksession-completed-golden",
+    "Jarvis-Request-Timestamp": "2026-06-16T10:25:00Z",
+    "Jarvis-Expected-WorkSession-Revision": 10,
+    "Jarvis-Previous-Event-Hash": "hash:event-skill-proposal-created"
+  },
+  "body_ref": "records.jarvis_events.worksession_completed",
+  "actor_id": "actor-human-golden",
+  "work_session_id": "ws-golden-001",
+  "expected_status": 201,
+  "expected_event_ref": "event-worksession-completed"
+}

--- a/docs/examples/evidence-packs/existing-agent-review/headers/15-export-evidence-manifest-ws-golden-001.json
+++ b/docs/examples/evidence-packs/existing-agent-review/headers/15-export-evidence-manifest-ws-golden-001.json
@@ -1,0 +1,13 @@
+{
+  "operation_id": "exportEvidenceManifest",
+  "method": "GET",
+  "path": "/work-sessions/ws-golden-001/export",
+  "headers": {
+    "Authorization": "HostAuth fixture",
+    "Jarvis-Protocol-Version": "v0.1",
+    "Jarvis-Actor-Id": "actor-human-golden"
+  },
+  "actor_id": "actor-human-golden",
+  "work_session_id": "ws-golden-001",
+  "expected_status": 200
+}

--- a/docs/examples/evidence-packs/existing-agent-review/headers/16-submit-outcome-report-post-session.json
+++ b/docs/examples/evidence-packs/existing-agent-review/headers/16-submit-outcome-report-post-session.json
@@ -1,0 +1,15 @@
+{
+  "operation_id": "submitOutcomeReport",
+  "method": "POST",
+  "path": "/outcome-reports",
+  "headers": {
+    "Authorization": "HostAuth fixture",
+    "Jarvis-Protocol-Version": "v0.1",
+    "Jarvis-Actor-Id": "actor-human-golden",
+    "Jarvis-Idempotency-Key": "idem-outcome-report-golden",
+    "Jarvis-Request-Timestamp": "2026-06-16T10:30:00Z"
+  },
+  "body_ref": "records.outcome_reports.post_session",
+  "actor_id": "actor-human-golden",
+  "expected_status": 202
+}

--- a/docs/examples/evidence-packs/existing-agent-review/manifest.json
+++ b/docs/examples/evidence-packs/existing-agent-review/manifest.json
@@ -15,6 +15,7 @@
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/HumanWorker",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/AgentWorker",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/WorkSession",
+    "docs/openapi/jarvis-openapi.yaml#/components/schemas/JarvisEvent",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Policy",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/PolicyDecision",
     "docs/openapi/jarvis-openapi.yaml#/components/schemas/Request",

--- a/docs/examples/evidence-packs/existing-agent-review/manifest.json
+++ b/docs/examples/evidence-packs/existing-agent-review/manifest.json
@@ -1,0 +1,218 @@
+{
+  "pack_id": "existing-agent-review-evidence-v01",
+  "protocol_version": "v0.1",
+  "title": "Existing-agent review-resolution evidence pack",
+  "description": "Protocol-record evidence that an existing native agent collaboration loop maps to Jarvis v0.1 records without Jarvis owning host execution.",
+  "source_fixture": "docs/conformance/fixtures/valid/golden-path.json",
+  "source_contract_refs": [
+    "docs/conformance/existing-agent-proof-plan.md",
+    "docs/examples/existing-agent-compatibility.md",
+    "docs/examples/protocol-records.md",
+    "docs/conformance/checklist.md",
+    "docs/protocol/15-openapi-communication-binding.md",
+    "docs/openapi/jarvis-openapi.yaml#/components/schemas/Worker",
+    "docs/openapi/jarvis-openapi.yaml#/components/schemas/Actor",
+    "docs/openapi/jarvis-openapi.yaml#/components/schemas/HumanWorker",
+    "docs/openapi/jarvis-openapi.yaml#/components/schemas/AgentWorker",
+    "docs/openapi/jarvis-openapi.yaml#/components/schemas/WorkSession",
+    "docs/openapi/jarvis-openapi.yaml#/components/schemas/Policy",
+    "docs/openapi/jarvis-openapi.yaml#/components/schemas/PolicyDecision",
+    "docs/openapi/jarvis-openapi.yaml#/components/schemas/Request",
+    "docs/openapi/jarvis-openapi.yaml#/components/schemas/Review",
+    "docs/openapi/jarvis-openapi.yaml#/components/schemas/Contribution",
+    "docs/openapi/jarvis-openapi.yaml#/components/schemas/EvidenceManifest",
+    "docs/openapi/jarvis-openapi.yaml#/components/schemas/LearningRecord",
+    "docs/openapi/jarvis-openapi.yaml#/components/schemas/MemoryProposal",
+    "docs/openapi/jarvis-openapi.yaml#/components/schemas/SkillProposal",
+    "docs/openapi/jarvis-openapi.yaml#/components/schemas/OutcomeReport"
+  ],
+  "host_shape_ref": "command_line_host_boundary",
+  "records": [
+    {
+      "path": "records/worker-human.json",
+      "object_type": "Worker",
+      "source_ref": "records.workers.human"
+    },
+    {
+      "path": "records/worker-agent.json",
+      "object_type": "Worker",
+      "source_ref": "records.workers.agent"
+    },
+    {
+      "path": "records/actor-human.json",
+      "object_type": "Actor",
+      "source_ref": "records.actors.human"
+    },
+    {
+      "path": "records/actor-agent.json",
+      "object_type": "Actor",
+      "source_ref": "records.actors.agent"
+    },
+    {
+      "path": "records/human-worker.json",
+      "object_type": "HumanWorker",
+      "source_ref": "records.human_workers.primary"
+    },
+    {
+      "path": "records/agent-worker.json",
+      "object_type": "AgentWorker",
+      "source_ref": "records.agent_workers.primary"
+    },
+    {
+      "path": "records/policy.json",
+      "object_type": "Policy",
+      "source_ref": "records.policies.bounded"
+    },
+    {
+      "path": "records/work-session-completed.json",
+      "object_type": "WorkSession",
+      "source_ref": "records.work_sessions.completed"
+    },
+    {
+      "path": "records/policy-decision-denied.json",
+      "object_type": "PolicyDecision",
+      "source_ref": "records.policy_decisions.external_source_denied"
+    },
+    {
+      "path": "records/request-approved.json",
+      "object_type": "Request",
+      "source_ref": "records.requests.approved"
+    },
+    {
+      "path": "records/review-approve-source.json",
+      "object_type": "Review",
+      "source_ref": "records.reviews.approve_source",
+      "context_refs": {
+        "request": "records.requests.pending"
+      }
+    },
+    {
+      "path": "records/contribution-shared-answer.json",
+      "object_type": "Contribution",
+      "source_ref": "records.contributions.shared_answer"
+    },
+    {
+      "path": "records/learning-record-pair.json",
+      "object_type": "LearningRecord",
+      "source_ref": "records.learning_records.pair"
+    },
+    {
+      "path": "records/memory-proposal-source-policy-pattern.json",
+      "object_type": "MemoryProposal",
+      "source_ref": "records.memory_proposals.source_policy_pattern"
+    },
+    {
+      "path": "records/skill-proposal-bounded-source-collection.json",
+      "object_type": "SkillProposal",
+      "source_ref": "records.skill_proposals.bounded_source_collection"
+    },
+    {
+      "path": "records/outcome-report-post-session.json",
+      "object_type": "OutcomeReport",
+      "source_ref": "records.outcome_reports.post_session",
+      "context_refs": {
+        "workSession": "records.work_sessions.completed"
+      }
+    }
+  ],
+  "evidence_manifests": [
+    {
+      "path": "evidence/evidence-manifest.json",
+      "source_ref": "records.evidence_manifests.portable_export",
+      "work_session_ref": "records.work_sessions.completed"
+    }
+  ],
+  "event_chains": [
+    {
+      "path": "events/event-chain.json",
+      "source_refs": [
+        "records.jarvis_events.worksession_created",
+        "records.jarvis_events.policy_denied",
+        "records.jarvis_events.request_event",
+        "records.jarvis_events.review_approved",
+        "records.jarvis_events.policy_allowed",
+        "records.jarvis_events.evidence_captured",
+        "records.jarvis_events.contribution_recorded",
+        "records.jarvis_events.learning_recorded",
+        "records.jarvis_events.memory_proposal_created",
+        "records.jarvis_events.skill_proposal_created",
+        "records.jarvis_events.worksession_completed"
+      ]
+    }
+  ],
+  "operation_headers": [
+    {
+      "path": "headers/00-register-worker-human.json",
+      "source_operation_index": 0
+    },
+    {
+      "path": "headers/01-register-worker-agent.json",
+      "source_operation_index": 1
+    },
+    {
+      "path": "headers/02-register-actor-human.json",
+      "source_operation_index": 2
+    },
+    {
+      "path": "headers/03-register-actor-agent.json",
+      "source_operation_index": 3
+    },
+    {
+      "path": "headers/04-create-work-session-genesis-request.json",
+      "source_operation_index": 4
+    },
+    {
+      "path": "headers/05-record-policy-decision-external-source-denied.json",
+      "source_operation_index": 5
+    },
+    {
+      "path": "headers/06-create-request-pending.json",
+      "source_operation_index": 6
+    },
+    {
+      "path": "headers/07-record-review-approve-source.json",
+      "source_operation_index": 7
+    },
+    {
+      "path": "headers/08-record-policy-decision-external-source-allowed.json",
+      "source_operation_index": 8
+    },
+    {
+      "path": "headers/09-append-jarvis-event-evidence-captured.json",
+      "source_operation_index": 9
+    },
+    {
+      "path": "headers/10-record-contribution-shared-answer.json",
+      "source_operation_index": 10
+    },
+    {
+      "path": "headers/11-create-learning-record-pair.json",
+      "source_operation_index": 11
+    },
+    {
+      "path": "headers/12-create-memory-proposal-source-policy-pattern.json",
+      "source_operation_index": 12
+    },
+    {
+      "path": "headers/13-create-skill-proposal-bounded-source-collection.json",
+      "source_operation_index": 13
+    },
+    {
+      "path": "headers/14-append-jarvis-event-worksession-completed.json",
+      "source_operation_index": 14
+    },
+    {
+      "path": "headers/15-export-evidence-manifest-ws-golden-001.json",
+      "source_operation_index": 15
+    },
+    {
+      "path": "headers/16-submit-outcome-report-post-session.json",
+      "source_operation_index": 16
+    }
+  ],
+  "pack_limits": {
+    "certifies_implementation": false,
+    "claims_production_adoption": false,
+    "defines_host_execution": false
+  }
+}

--- a/docs/examples/evidence-packs/existing-agent-review/records/actor-agent.json
+++ b/docs/examples/evidence-packs/existing-agent-review/records/actor-agent.json
@@ -1,0 +1,25 @@
+{
+  "object_type": "Actor",
+  "record": {
+    "id": "actor-agent-golden",
+    "worker_id": "worker-agent-golden",
+    "type": "agent",
+    "event_authority": {
+      "can_append_events": true,
+      "allowed_event_types": [
+        "policy_decision.recorded",
+        "request.created",
+        "evidence.captured",
+        "contribution.recorded"
+      ]
+    },
+    "contribution_scope": {
+      "contribution_roles": [
+        "agent",
+        "shared"
+      ]
+    },
+    "created_at": "2026-06-16T10:00:00Z",
+    "valid_from": "2026-06-16T10:00:00Z"
+  }
+}

--- a/docs/examples/evidence-packs/existing-agent-review/records/actor-human.json
+++ b/docs/examples/evidence-packs/existing-agent-review/records/actor-human.json
@@ -1,0 +1,28 @@
+{
+  "object_type": "Actor",
+  "record": {
+    "id": "actor-human-golden",
+    "worker_id": "worker-human-golden",
+    "type": "human",
+    "event_authority": {
+      "can_append_events": true,
+      "allowed_event_types": [
+        "work_session.created",
+        "review.recorded",
+        "contribution.recorded",
+        "learning.recorded",
+        "memory_proposal.created",
+        "skill_proposal.created",
+        "work_session.completed"
+      ]
+    },
+    "contribution_scope": {
+      "contribution_roles": [
+        "human",
+        "shared"
+      ]
+    },
+    "created_at": "2026-06-16T10:00:00Z",
+    "valid_from": "2026-06-16T10:00:00Z"
+  }
+}

--- a/docs/examples/evidence-packs/existing-agent-review/records/agent-worker.json
+++ b/docs/examples/evidence-packs/existing-agent-review/records/agent-worker.json
@@ -1,0 +1,24 @@
+{
+  "object_type": "AgentWorker",
+  "record": {
+    "worker_id": "worker-agent-golden",
+    "actor_id": "actor-agent-golden",
+    "agent_ref": "agent:golden-agent",
+    "role": "bounded research and drafting agent",
+    "capability_refs": [
+      {
+        "ref": "capability:source_summary",
+        "capability_type": "research",
+        "required": true
+      }
+    ],
+    "autonomy_level": "bounded_execute",
+    "operating_constraints": [
+      "record PolicyDecision before action affects WorkSession state",
+      "create Request when Policy denies action",
+      "capture evidence during work"
+    ],
+    "tool_access_profile": "tool-profile:policy-bounded",
+    "memory_access_profile": "memory-profile:read-only"
+  }
+}

--- a/docs/examples/evidence-packs/existing-agent-review/records/contribution-shared-answer.json
+++ b/docs/examples/evidence-packs/existing-agent-review/records/contribution-shared-answer.json
@@ -1,0 +1,39 @@
+{
+  "object_type": "Contribution",
+  "record": {
+    "id": "contribution-golden-shared-answer",
+    "work_session_id": "ws-golden-001",
+    "contributor_refs": [
+      {
+        "worker_id": "worker-human-golden",
+        "actor_id": "actor-human-golden",
+        "contribution_role": "human"
+      },
+      {
+        "worker_id": "worker-agent-golden",
+        "actor_id": "actor-agent-golden",
+        "contribution_role": "agent"
+      }
+    ],
+    "contributor_type": "shared",
+    "contribution_type": "artifact",
+    "event_refs": [
+      "event-evidence-captured",
+      "event-contribution-recorded"
+    ],
+    "created_at": "2026-06-16T10:16:00Z",
+    "artifact_refs": [
+      "artifact:reviewed-answer"
+    ],
+    "review_refs": [
+      "review-golden-source-approval"
+    ],
+    "evidence_refs": [
+      "evidence-source-summary"
+    ],
+    "confidence": 0.92,
+    "limitations": [
+      "limitation:none-recorded"
+    ]
+  }
+}

--- a/docs/examples/evidence-packs/existing-agent-review/records/human-worker.json
+++ b/docs/examples/evidence-packs/existing-agent-review/records/human-worker.json
@@ -1,0 +1,35 @@
+{
+  "object_type": "HumanWorker",
+  "record": {
+    "worker_id": "worker-human-golden",
+    "actor_id": "actor-human-golden",
+    "role": "policy owner and reviewer",
+    "policy_authority": {
+      "grants": [
+        "policy:own",
+        "policy:narrow"
+      ]
+    },
+    "review_authority": {
+      "grants": [
+        "review:approve",
+        "review:narrow",
+        "review:deny",
+        "takeover:start"
+      ]
+    },
+    "profile_ref": "profile:human-golden",
+    "domain_context_refs": [
+      "context:task-brief"
+    ],
+    "preferences": {
+      "review.default_detail": "evidence_first"
+    },
+    "boundaries": [
+      "external source access requires review"
+    ],
+    "known_patterns": [
+      "ask for bounded approval before external source collection"
+    ]
+  }
+}

--- a/docs/examples/evidence-packs/existing-agent-review/records/learning-record-pair.json
+++ b/docs/examples/evidence-packs/existing-agent-review/records/learning-record-pair.json
@@ -1,0 +1,28 @@
+{
+  "object_type": "LearningRecord",
+  "record": {
+    "id": "learning-golden-pair",
+    "work_session_id": "ws-golden-001",
+    "created_by_actor_id": "actor-human-golden",
+    "subject_type": "pair",
+    "subject_ref": "pair:worker-human-golden+worker-agent-golden",
+    "lesson_type": "bounded_external_source_approval",
+    "source_event_refs": [
+      "event-request-created",
+      "event-review-approved",
+      "event-evidence-captured"
+    ],
+    "review_state": "accepted",
+    "scope": "scope:future-source-collection",
+    "created_at": "2026-06-16T10:18:00Z",
+    "proposed_change": {
+      "pattern": "Ask for bounded external source approval before collecting evidence outside local context."
+    },
+    "memory_proposal_refs": [
+      "memory-proposal-golden"
+    ],
+    "skill_proposal_refs": [
+      "skill-proposal-golden"
+    ]
+  }
+}

--- a/docs/examples/evidence-packs/existing-agent-review/records/memory-proposal-source-policy-pattern.json
+++ b/docs/examples/evidence-packs/existing-agent-review/records/memory-proposal-source-policy-pattern.json
@@ -1,0 +1,30 @@
+{
+  "object_type": "MemoryProposal",
+  "record": {
+    "id": "memory-proposal-golden",
+    "work_session_id": "ws-golden-001",
+    "proposed_by_actor_id": "actor-human-golden",
+    "proposed_for": "pair",
+    "memory_scope": "scope:future-source-collection",
+    "memory_type": "collaboration_pattern",
+    "content": {
+      "pattern": "External source collection requires bounded approval tied to WorkSession, Actor, action hash, expiry, and max uses."
+    },
+    "provenance": [
+      "event-request-created",
+      "event-review-approved",
+      "learning-golden-pair"
+    ],
+    "confidence": 0.9,
+    "review_required": true,
+    "status": "pending_review",
+    "created_at": "2026-06-16T10:19:00Z",
+    "source_event_refs": [
+      "event-review-approved",
+      "event-learning-recorded"
+    ],
+    "learning_record_refs": [
+      "learning-golden-pair"
+    ]
+  }
+}

--- a/docs/examples/evidence-packs/existing-agent-review/records/outcome-report-post-session.json
+++ b/docs/examples/evidence-packs/existing-agent-review/records/outcome-report-post-session.json
@@ -1,0 +1,45 @@
+{
+  "object_type": "OutcomeReport",
+  "record": {
+    "id": "outcome-report-golden",
+    "work_session_id": "ws-golden-001",
+    "source_ref": "source:completed-worksession:ws-golden-001",
+    "reporter_ref": "reporter:fixture-evaluator",
+    "accepted_by_actor_id": "actor-human-golden",
+    "outcome": "accepted",
+    "learning_record_refs": [
+      "learning-golden-pair"
+    ],
+    "received_at": "2026-06-16T10:30:00Z",
+    "external_system_ref": "external:evaluation-system",
+    "reporter_actor_id": "actor-human-golden",
+    "reason": "Post-session feedback confirms the bounded Request and Review loop improved future source collection.",
+    "reviewer_feedback_refs": [
+      "feedback:bounded-source-loop-accepted"
+    ]
+  },
+  "context": {
+    "workSession": {
+      "id": "ws-golden-001",
+      "protocol_version": "v0.1",
+      "created_by_actor_id": "actor-human-golden",
+      "objective": "Produce an evidence-backed answer with human review and governed learning.",
+      "human_worker_id": "worker-human-golden",
+      "agent_worker_id": "worker-agent-golden",
+      "policy_id": "policy-golden-bounded",
+      "status": "completed",
+      "revision": 11,
+      "last_event_hash": "hash:event-worksession-completed",
+      "event_log_ref": "event-log:ws-golden-001",
+      "created_at": "2026-06-16T10:01:00Z",
+      "updated_at": "2026-06-16T10:25:00Z",
+      "source_ref": "source:golden-path-fixture",
+      "context_manifest_ref": "context:task-brief",
+      "contribution_ledger_ref": "ledger:ws-golden-001",
+      "evidence_manifest_ref": "evidence-manifest-golden",
+      "learning_record_refs": [
+        "learning-golden-pair"
+      ]
+    }
+  }
+}

--- a/docs/examples/evidence-packs/existing-agent-review/records/policy-decision-denied.json
+++ b/docs/examples/evidence-packs/existing-agent-review/records/policy-decision-denied.json
@@ -1,0 +1,24 @@
+{
+  "object_type": "PolicyDecision",
+  "record": {
+    "id": "pd-golden-source-denied",
+    "work_session_id": "ws-golden-001",
+    "actor_id": "actor-agent-golden",
+    "policy_id": "policy-golden-bounded",
+    "requested_action": {
+      "action": "fetch_external_source",
+      "target_ref": "source:external-reference",
+      "scope_ref": "scope:external-source"
+    },
+    "normalized_action_hash": "hash:action-fetch-external-source",
+    "risk_class": "medium",
+    "result": "deny",
+    "reason": "Policy requires HumanWorker review before external source collection.",
+    "created_at": "2026-06-16T10:04:00Z",
+    "data_sensitivity": "public",
+    "denied_grant_refs": [
+      "grant:external-source-read"
+    ],
+    "request_id": "req-golden-source"
+  }
+}

--- a/docs/examples/evidence-packs/existing-agent-review/records/policy.json
+++ b/docs/examples/evidence-packs/existing-agent-review/records/policy.json
@@ -1,0 +1,56 @@
+{
+  "object_type": "Policy",
+  "record": {
+    "id": "policy-golden-bounded",
+    "owner_worker_id": "worker-human-golden",
+    "created_by_actor_id": "actor-human-golden",
+    "autonomy_level": "bounded_execute",
+    "allowed_actions": [
+      {
+        "action": "draft_answer",
+        "scope_ref": "scope:local-worksession",
+        "grant_refs": [
+          "grant:local-context-read"
+        ]
+      }
+    ],
+    "denied_actions": [
+      {
+        "action": "fetch_external_source",
+        "scope_ref": "scope:external-source"
+      }
+    ],
+    "review_required_actions": [
+      {
+        "action": "submit_final_artifact",
+        "scope_ref": "scope:final-submission"
+      }
+    ],
+    "risk_classes": [
+      "low",
+      "medium",
+      "high"
+    ],
+    "escalation_rules": [
+      {
+        "trigger": "external_source_access",
+        "risk_class": "medium",
+        "required_action": "create_request",
+        "reviewer_ref": "worker-human-golden",
+        "reason": "HumanWorker review gates external source collection."
+      }
+    ],
+    "created_at": "2026-06-16T10:00:00Z",
+    "tool_grants": [
+      "grant:local-context-read"
+    ],
+    "memory_grants": [
+      "grant:read-confirmed-memory"
+    ],
+    "request_limits": {
+      "max_pending_requests": 3,
+      "max_repeated_denials": 1,
+      "default_expiry_seconds": 1800
+    }
+  }
+}

--- a/docs/examples/evidence-packs/existing-agent-review/records/request-approved.json
+++ b/docs/examples/evidence-packs/existing-agent-review/records/request-approved.json
@@ -1,0 +1,56 @@
+{
+  "object_type": "Request",
+  "record": {
+    "id": "req-golden-source",
+    "protocol_version": "v0.1",
+    "work_session_id": "ws-golden-001",
+    "requester_actor_id": "actor-agent-golden",
+    "requester_worker_id": "worker-agent-golden",
+    "target_human_worker_id": "worker-human-golden",
+    "policy_decision_id": "pd-golden-source-denied",
+    "type": "permission",
+    "blocking_scope": "action",
+    "reason_code": "policy_denied",
+    "reason_summary": "External source access is outside current Policy until HumanWorker review.",
+    "requested_action": {
+      "action": "fetch_external_source",
+      "target_ref": "source:external-reference",
+      "scope_ref": "scope:external-source"
+    },
+    "requested_outcome": "Approve external source collection for this WorkSession only.",
+    "risk_class": "medium",
+    "human_decision_needed": "Approve, narrow, deny, correct, or take over the blocked action.",
+    "options": [
+      {
+        "id": "option-approve-current-session",
+        "label": "Approve current WorkSession scope",
+        "effect": "AgentWorker collects the referenced source for this WorkSession only.",
+        "risk_class": "medium",
+        "scope_ref": "scope:external-source"
+      },
+      {
+        "id": "option-deny",
+        "label": "Deny external collection",
+        "effect": "AgentWorker continues with existing evidence and records the limitation.",
+        "risk_class": "low",
+        "scope_ref": "scope:local-worksession"
+      }
+    ],
+    "default_if_no_response": {
+      "action": "continue_with_limited_evidence",
+      "reason": "The blocked action remains stopped and the WorkSession records an evidence limitation.",
+      "limitation_ref": "limitation:external-source-not-reviewed"
+    },
+    "status": "approved",
+    "created_at": "2026-06-16T10:05:00Z",
+    "expires_at": "2026-06-16T10:35:00Z",
+    "missing_permission_or_context": "Policy grant for external source collection",
+    "policy_refs": [
+      "policy-golden-bounded"
+    ],
+    "data_sensitivity": "public",
+    "recommended_option": "option-approve-current-session",
+    "resolved_at": "2026-06-16T10:08:00Z",
+    "resolved_by_review_id": "review-golden-source-approval"
+  }
+}

--- a/docs/examples/evidence-packs/existing-agent-review/records/review-approve-source.json
+++ b/docs/examples/evidence-packs/existing-agent-review/records/review-approve-source.json
@@ -1,0 +1,92 @@
+{
+  "object_type": "Review",
+  "record": {
+    "id": "review-golden-source-approval",
+    "work_session_id": "ws-golden-001",
+    "reviewer_actor_id": "actor-human-golden",
+    "reviewer_worker_id": "worker-human-golden",
+    "target_ref": "request:req-golden-source",
+    "decision": "approve",
+    "created_at": "2026-06-16T10:08:00Z",
+    "comments": "Approved for the referenced source and current WorkSession only.",
+    "approval_scope": {
+      "request_id": "req-golden-source",
+      "review_id": "review-golden-source-approval",
+      "policy_decision_id": "pd-golden-source-denied",
+      "request_revision": 3,
+      "request_event_hash": "hash:event-request-created",
+      "normalized_action_hash": "hash:action-fetch-external-source",
+      "approved_action": {
+        "action": "fetch_external_source",
+        "target_ref": "source:external-reference",
+        "scope_ref": "scope:external-source"
+      },
+      "allowed_scope": {
+        "scope_ref": "scope:external-source",
+        "grant_refs": [
+          "grant:review-approved-external-source"
+        ]
+      },
+      "denied_scope": {
+        "scope_ref": "scope:all-other-external-sources"
+      },
+      "expires_at": "2026-06-16T10:35:00Z",
+      "max_uses": 1,
+      "applies_to_work_session_id": "ws-golden-001",
+      "applies_to_actor_id": "actor-agent-golden"
+    }
+  },
+  "context": {
+    "request": {
+      "id": "req-golden-source",
+      "protocol_version": "v0.1",
+      "work_session_id": "ws-golden-001",
+      "requester_actor_id": "actor-agent-golden",
+      "requester_worker_id": "worker-agent-golden",
+      "target_human_worker_id": "worker-human-golden",
+      "policy_decision_id": "pd-golden-source-denied",
+      "type": "permission",
+      "blocking_scope": "action",
+      "reason_code": "policy_denied",
+      "reason_summary": "External source access is outside current Policy until HumanWorker review.",
+      "requested_action": {
+        "action": "fetch_external_source",
+        "target_ref": "source:external-reference",
+        "scope_ref": "scope:external-source"
+      },
+      "requested_outcome": "Approve external source collection for this WorkSession only.",
+      "risk_class": "medium",
+      "human_decision_needed": "Approve, narrow, deny, correct, or take over the blocked action.",
+      "options": [
+        {
+          "id": "option-approve-current-session",
+          "label": "Approve current WorkSession scope",
+          "effect": "AgentWorker collects the referenced source for this WorkSession only.",
+          "risk_class": "medium",
+          "scope_ref": "scope:external-source"
+        },
+        {
+          "id": "option-deny",
+          "label": "Deny external collection",
+          "effect": "AgentWorker continues with existing evidence and records the limitation.",
+          "risk_class": "low",
+          "scope_ref": "scope:local-worksession"
+        }
+      ],
+      "default_if_no_response": {
+        "action": "continue_with_limited_evidence",
+        "reason": "The blocked action remains stopped and the WorkSession records an evidence limitation.",
+        "limitation_ref": "limitation:external-source-not-reviewed"
+      },
+      "status": "pending",
+      "created_at": "2026-06-16T10:05:00Z",
+      "expires_at": "2026-06-16T10:35:00Z",
+      "missing_permission_or_context": "Policy grant for external source collection",
+      "policy_refs": [
+        "policy-golden-bounded"
+      ],
+      "data_sensitivity": "public",
+      "recommended_option": "option-approve-current-session"
+    }
+  }
+}

--- a/docs/examples/evidence-packs/existing-agent-review/records/skill-proposal-bounded-source-collection.json
+++ b/docs/examples/evidence-packs/existing-agent-review/records/skill-proposal-bounded-source-collection.json
@@ -1,0 +1,51 @@
+{
+  "object_type": "SkillProposal",
+  "record": {
+    "id": "skill-proposal-golden",
+    "work_session_id": "ws-golden-001",
+    "proposed_by_actor_id": "actor-human-golden",
+    "proposed_for": "pair",
+    "skill_scope": "scope:future-source-collection",
+    "skill_name": "bounded_external_source_collection",
+    "trigger_conditions": [
+      "AgentWorker needs evidence outside local context",
+      "Policy denies or requires review for the action"
+    ],
+    "procedure": [
+      "Record PolicyDecision before action acceptance",
+      "Create scoped Request with risk, options, and fallback",
+      "Wait for Review approval or narrowing",
+      "Execute only inside ApprovalScope",
+      "Capture evidence refs during work"
+    ],
+    "review_checks": [
+      "Request references blocking PolicyDecision",
+      "ApprovalScope binds action hash, WorkSession, Actor, expiry, and max uses",
+      "EvidenceManifest excludes host-private fields"
+    ],
+    "failure_cases": [
+      "Request resolves without Review",
+      "Evidence appears after the fact",
+      "Skill activates without review"
+    ],
+    "provenance": [
+      "event-request-created",
+      "event-review-approved",
+      "event-evidence-captured",
+      "learning-golden-pair"
+    ],
+    "status": "pending_review",
+    "created_at": "2026-06-16T10:20:00Z",
+    "required_tools": [
+      "tool:source-reader"
+    ],
+    "source_event_refs": [
+      "event-request-created",
+      "event-review-approved",
+      "event-evidence-captured"
+    ],
+    "learning_record_refs": [
+      "learning-golden-pair"
+    ]
+  }
+}

--- a/docs/examples/evidence-packs/existing-agent-review/records/work-session-completed.json
+++ b/docs/examples/evidence-packs/existing-agent-review/records/work-session-completed.json
@@ -1,0 +1,25 @@
+{
+  "object_type": "WorkSession",
+  "record": {
+    "id": "ws-golden-001",
+    "protocol_version": "v0.1",
+    "created_by_actor_id": "actor-human-golden",
+    "objective": "Produce an evidence-backed answer with human review and governed learning.",
+    "human_worker_id": "worker-human-golden",
+    "agent_worker_id": "worker-agent-golden",
+    "policy_id": "policy-golden-bounded",
+    "status": "completed",
+    "revision": 11,
+    "last_event_hash": "hash:event-worksession-completed",
+    "event_log_ref": "event-log:ws-golden-001",
+    "created_at": "2026-06-16T10:01:00Z",
+    "updated_at": "2026-06-16T10:25:00Z",
+    "source_ref": "source:golden-path-fixture",
+    "context_manifest_ref": "context:task-brief",
+    "contribution_ledger_ref": "ledger:ws-golden-001",
+    "evidence_manifest_ref": "evidence-manifest-golden",
+    "learning_record_refs": [
+      "learning-golden-pair"
+    ]
+  }
+}

--- a/docs/examples/evidence-packs/existing-agent-review/records/worker-agent.json
+++ b/docs/examples/evidence-packs/existing-agent-review/records/worker-agent.json
@@ -1,0 +1,29 @@
+{
+  "object_type": "Worker",
+  "record": {
+    "id": "worker-agent-golden",
+    "type": "agent",
+    "role": "bounded executor",
+    "authority_scope": {
+      "grants": [
+        "action:propose",
+        "action:execute_after_policy",
+        "evidence:capture"
+      ]
+    },
+    "accountability_scope": {
+      "accountable_for": [
+        "policy_checked_execution",
+        "evidence_capture"
+      ]
+    },
+    "display_name": "AgentWorker Golden",
+    "capabilities": [
+      {
+        "ref": "capability:source_summary",
+        "capability_type": "research",
+        "required": true
+      }
+    ]
+  }
+}

--- a/docs/examples/evidence-packs/existing-agent-review/records/worker-human.json
+++ b/docs/examples/evidence-packs/existing-agent-review/records/worker-human.json
@@ -1,0 +1,30 @@
+{
+  "object_type": "Worker",
+  "record": {
+    "id": "worker-human-golden",
+    "type": "human",
+    "role": "responsible reviewer",
+    "authority_scope": {
+      "grants": [
+        "policy:own",
+        "review:approve",
+        "takeover:start"
+      ]
+    },
+    "accountability_scope": {
+      "accountable_for": [
+        "objective",
+        "policy",
+        "final_review"
+      ]
+    },
+    "display_name": "HumanWorker Golden",
+    "capabilities": [
+      {
+        "ref": "capability:review",
+        "capability_type": "human_judgment",
+        "required": true
+      }
+    ]
+  }
+}

--- a/docs/planning/ROADMAP.md
+++ b/docs/planning/ROADMAP.md
@@ -21,8 +21,8 @@ Week 1 protocol lock is complete.
 
 Current protocol status: Jarvis v0.1.0 is released as Protocol Alpha.
 
-Current active work: public docs site foundation and protocol-record
-compatibility evidence planning.
+Current active work: protocol-record compatibility evidence and public docs
+site maintenance.
 
 Release-readiness work for the v0.1.0 tag is complete:
 
@@ -432,7 +432,7 @@ Done when:
 
 ## Public Documentation Site Foundation
 
-Status: in progress.
+Status: complete.
 
 Owner: Documentation
 
@@ -453,6 +453,38 @@ Done when:
 - walkthrough stays non-normative and does not claim host UI implementation or
   protocol proof
 - GitHub Pages workflow validates docs-site JavaScript
+- local validation passes
+
+## Protocol Record Compatibility Evidence Pack
+
+Status: implemented.
+
+Owner: Developer Experience
+
+Output:
+
+- machine-checkable existing-agent evidence pack
+- protocol record envelopes
+- EvidenceManifest export envelope
+- JarvisEvent hash-chain envelope
+- operation header envelopes
+- evidence-pack validator
+
+Done when:
+
+- evidence pack derives from the canonical v0.1 golden-path fixture
+- evidence pack links to the existing-agent proof plan, protocol record
+  examples, conformance checklist, OpenAPI binding, and OpenAPI schemas
+- record files validate through protocol helper validators
+- EvidenceManifest export validates only from a terminal WorkSession source
+- OutcomeReport validates only from a terminal WorkSession source
+- event hash chain validates through JarvisEvent previous-hash and event-hash
+  rules
+- operation headers validate through the v0.1 header gate
+- evidence pack does not define adapter code, wrapper code, runtime behavior,
+  host UI, model calls, tool execution, storage, auth, billing, scoring,
+  payment, deployment, monitoring, host integration, or host workflow
+  behavior
 - local validation passes
 
 ## v0.2 Evidence And Learning Beta

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "packages/cli"
   ],
   "scripts": {
-    "check:protocol": "python3 scripts/check_conformance_fixtures.py && python3 scripts/check_openapi_contract.py && python3 scripts/check_markdown_links.py && python3 scripts/check_protocol_wording.py && git diff --check",
+    "check:protocol": "python3 scripts/check_conformance_fixtures.py && python3 scripts/check_openapi_contract.py && python3 scripts/check_markdown_links.py && python3 scripts/check_docs_site.py && python3 scripts/check_example_evidence_packs.py && python3 scripts/check_protocol_wording.py && python3 scripts/check_sdk_boundary.py && git diff --check",
     "check:sdk-boundary": "python3 scripts/check_sdk_boundary.py",
     "test:cli": "npm --workspace @jarvis-protocol/cli test",
     "test:python": "node scripts/run_python_package_tests.mjs",

--- a/scripts/check_example_evidence_packs.py
+++ b/scripts/check_example_evidence_packs.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""Validate public Jarvis protocol evidence packs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import sys
+from typing import Any
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACK_ROOT = ROOT / "docs" / "examples" / "evidence-packs"
+PYTHON_PACKAGE_SRC = ROOT / "packages" / "python" / "src"
+PROTOCOL_VERSION = "v0.1"
+CANONICAL_FIXTURE_REF = "docs/conformance/fixtures/valid/golden-path.json"
+CANONICAL_FIXTURE_ID = "valid-golden-path-v01"
+MANIFEST_KEYS = {
+    "pack_id",
+    "protocol_version",
+    "title",
+    "description",
+    "source_fixture",
+    "source_contract_refs",
+    "host_shape_ref",
+    "pack_limits",
+    "records",
+    "evidence_manifests",
+    "event_chains",
+    "operation_headers",
+}
+RECORD_ENVELOPE_KEYS = {"object_type", "record", "context"}
+EVIDENCE_MANIFEST_ENVELOPE_KEYS = {"evidence_manifest", "work_session"}
+EVENT_CHAIN_ENVELOPE_KEYS = {"events"}
+
+sys.path.insert(0, str(PYTHON_PACKAGE_SRC))
+
+import jarvis_protocol  # noqa: E402
+
+
+class EvidencePackError(Exception):
+    """Raised when a public evidence pack violates its protocol contract."""
+
+
+def rel(path: Path) -> str:
+    return str(path.relative_to(ROOT))
+
+
+def load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise EvidencePackError(f"{rel(path)}: invalid JSON: {exc}") from exc
+
+
+def assert_closed_object(path: Path, value: Any, allowed: set[str], label: str) -> None:
+    if not isinstance(value, dict):
+        raise EvidencePackError(f"{rel(path)}: {label} MUST be an object")
+    extra = sorted(set(value) - allowed)
+    if extra:
+        raise EvidencePackError(f"{rel(path)}: {label} contains unsupported fields: {', '.join(extra)}")
+    forbidden = jarvis_protocol.find_forbidden_host_private_field(value)
+    if forbidden:
+        raise EvidencePackError(f"{rel(path)}: {label} contains host-private field {forbidden}")
+
+
+def resolve_local_path(pack_dir: Path, value: Any) -> Path:
+    if not isinstance(value, str) or not value:
+        raise EvidencePackError(f"{rel(pack_dir)}: path values MUST be nonempty strings")
+    path = (pack_dir / value).resolve()
+    if not path.is_relative_to(pack_dir.resolve()):
+        raise EvidencePackError(f"{rel(pack_dir)}: pack paths MUST stay inside the pack")
+    if not path.exists():
+        raise EvidencePackError(f"{rel(path)}: referenced pack file does not exist")
+    return path
+
+
+def load_structured_ref(path: Path) -> Any:
+    if path.suffix in {".yaml", ".yml"}:
+        return yaml.safe_load(path.read_text(encoding="utf-8"))
+    if path.suffix == ".json":
+        return load_json(path)
+    raise EvidencePackError(f"{rel(path)}: fragments are supported only for JSON and YAML refs")
+
+
+def resolve_json_pointer(path: Path, document: Any, pointer: str) -> None:
+    if not pointer.startswith("/"):
+        raise EvidencePackError(f"{rel(path)}: source_contract_refs fragment MUST be a JSON Pointer")
+    current = document
+    for raw_part in pointer.strip("/").split("/"):
+        part = raw_part.replace("~1", "/").replace("~0", "~")
+        if isinstance(current, dict) and part in current:
+            current = current[part]
+            continue
+        if isinstance(current, list) and part.isdigit() and int(part) < len(current):
+            current = current[int(part)]
+            continue
+        raise EvidencePackError(f"{rel(path)}: source_contract_refs fragment does not resolve: #{pointer}")
+
+
+def resolve_repo_ref(path: Path, value: Any) -> Path:
+    if not isinstance(value, str) or not value:
+        raise EvidencePackError(f"{rel(path)}: repository refs MUST be nonempty strings")
+    local_ref, _, fragment = value.partition("#")
+    if not local_ref:
+        raise EvidencePackError(f"{rel(path)}: repository refs MUST include a local path")
+    target = (ROOT / local_ref).resolve()
+    if not target.is_relative_to(ROOT):
+        raise EvidencePackError(f"{rel(path)}: repository refs MUST stay inside repo")
+    if not target.exists():
+        raise EvidencePackError(f"{rel(path)}: missing repository ref {value}")
+    if fragment:
+        resolve_json_pointer(target, load_structured_ref(target), fragment)
+    return target
+
+
+def resolve_fixture_ref(fixture: Any, ref: str) -> Any:
+    current = fixture
+    for part in ref.split("."):
+        if isinstance(current, dict) and part in current:
+            current = current[part]
+            continue
+        raise EvidencePackError(f"fixture ref {ref} does not resolve")
+    return current
+
+
+def assert_result(path: Path, result: Any) -> None:
+    if result.valid:
+        return
+    first = result.errors[0] if result.errors else {}
+    raise EvidencePackError(
+        f"{rel(path)}: validation failed: "
+        f"{first.get('error_id', 'unknown_error')} {first.get('field', '')}"
+    )
+
+
+def normalized_context(context: dict[str, Any]) -> dict[str, Any]:
+    if "workSession" in context and "work_session" not in context:
+        return {**context, "work_session": context["workSession"]}
+    return context
+
+
+def check_source_contract_refs(manifest_path: Path, refs: Any) -> None:
+    if not isinstance(refs, list) or not refs:
+        raise EvidencePackError(f"{rel(manifest_path)}: source_contract_refs MUST be nonempty")
+    for ref in refs:
+        resolve_repo_ref(manifest_path, ref)
+
+
+def check_record_entry(
+    manifest_path: Path,
+    pack_dir: Path,
+    fixture: dict[str, Any],
+    entry: dict[str, Any],
+) -> int:
+    path = resolve_local_path(pack_dir, entry.get("path"))
+    envelope = load_json(path)
+    assert_closed_object(path, envelope, RECORD_ENVELOPE_KEYS, "record envelope")
+    object_type = entry.get("object_type")
+    source_ref = entry.get("source_ref")
+    if envelope.get("object_type") != object_type:
+        raise EvidencePackError(f"{rel(path)}: object_type mismatch")
+    source_record = resolve_fixture_ref(fixture, source_ref)
+    if envelope.get("record") != source_record:
+        raise EvidencePackError(f"{rel(path)}: record does not match {source_ref}")
+    context = envelope.get("context", {})
+    if not isinstance(context, dict):
+        raise EvidencePackError(f"{rel(path)}: context MUST be an object when present")
+    expected_context_refs = entry.get("context_refs", {})
+    if not isinstance(expected_context_refs, dict):
+        raise EvidencePackError(f"{rel(manifest_path)}: context_refs MUST be an object")
+    for key, ref in expected_context_refs.items():
+        expected = resolve_fixture_ref(fixture, ref)
+        if context.get(key) != expected:
+            raise EvidencePackError(f"{rel(path)}: context.{key} does not match {ref}")
+    assert_result(
+        path,
+        jarvis_protocol.validate_protocol_record(
+            object_type,
+            envelope.get("record"),
+            normalized_context(context),
+        ),
+    )
+    return 1
+
+
+def check_evidence_manifest_entry(
+    pack_dir: Path,
+    fixture: dict[str, Any],
+    entry: dict[str, Any],
+) -> int:
+    path = resolve_local_path(pack_dir, entry.get("path"))
+    envelope = load_json(path)
+    assert_closed_object(
+        path,
+        envelope,
+        EVIDENCE_MANIFEST_ENVELOPE_KEYS,
+        "EvidenceManifest envelope",
+    )
+    manifest = envelope.get("evidence_manifest")
+    work_session = envelope.get("work_session")
+    manifest_ref = entry.get("source_ref")
+    work_session_ref = entry.get("work_session_ref")
+    if manifest != resolve_fixture_ref(fixture, manifest_ref):
+        raise EvidencePackError(f"{rel(path)}: evidence_manifest does not match {manifest_ref}")
+    if work_session != resolve_fixture_ref(fixture, work_session_ref):
+        raise EvidencePackError(f"{rel(path)}: work_session does not match {work_session_ref}")
+    assert_result(
+        path,
+        jarvis_protocol.validate_evidence_manifest(
+            manifest,
+            {"work_session": work_session},
+        ),
+    )
+    return 1
+
+
+def check_event_chain_entry(pack_dir: Path, fixture: dict[str, Any], entry: dict[str, Any]) -> int:
+    path = resolve_local_path(pack_dir, entry.get("path"))
+    envelope = load_json(path)
+    assert_closed_object(path, envelope, EVENT_CHAIN_ENVELOPE_KEYS, "event chain envelope")
+    source_refs = entry.get("source_refs")
+    if not isinstance(source_refs, list) or not source_refs:
+        raise EvidencePackError(f"{rel(path)}: event chain source_refs MUST be nonempty")
+    expected_events = [resolve_fixture_ref(fixture, ref) for ref in source_refs]
+    if envelope.get("events") != expected_events:
+        raise EvidencePackError(f"{rel(path)}: events do not match source_refs")
+    assert_result(path, jarvis_protocol.validate_event_hash_chain(envelope.get("events")))
+    return 1
+
+
+def check_header_entry(pack_dir: Path, fixture: dict[str, Any], entry: dict[str, Any]) -> int:
+    path = resolve_local_path(pack_dir, entry.get("path"))
+    operation = load_json(path)
+    source_index = entry.get("source_operation_index")
+    operations = fixture.get("operations", [])
+    if not isinstance(source_index, int) or source_index < 0 or source_index >= len(operations):
+        raise EvidencePackError(f"{rel(path)}: source_operation_index is invalid")
+    source_operation = operations[source_index]
+    if operation != source_operation:
+        raise EvidencePackError(f"{rel(path)}: operation envelope does not match source operation")
+    assert_result(
+        path,
+        jarvis_protocol.validate_operation_headers(
+            operation,
+            {"skip_timestamp_skew": True},
+        ),
+    )
+    return 1
+
+
+def check_manifest(manifest_path: Path) -> int:
+    pack_dir = manifest_path.parent
+    manifest = load_json(manifest_path)
+    assert_closed_object(manifest_path, manifest, MANIFEST_KEYS, "manifest")
+    if manifest.get("protocol_version") != PROTOCOL_VERSION:
+        raise EvidencePackError(f"{rel(manifest_path)}: protocol_version MUST be {PROTOCOL_VERSION}")
+    if manifest.get("source_fixture") != CANONICAL_FIXTURE_REF:
+        raise EvidencePackError(
+            f"{rel(manifest_path)}: source_fixture MUST be {CANONICAL_FIXTURE_REF}"
+        )
+    source_fixture_path = resolve_repo_ref(manifest_path, manifest.get("source_fixture"))
+    fixture = load_json(source_fixture_path)
+    if (
+        fixture.get("fixture_id") != CANONICAL_FIXTURE_ID
+        or fixture.get("protocol_version") != PROTOCOL_VERSION
+        or fixture.get("kind") != "valid"
+    ):
+        raise EvidencePackError(
+            f"{rel(manifest_path)}: source_fixture MUST be the canonical valid v0.1 fixture"
+        )
+    check_source_contract_refs(manifest_path, manifest.get("source_contract_refs"))
+    host_shape_ref = manifest.get("host_shape_ref")
+    if not isinstance(host_shape_ref, str) or host_shape_ref != fixture.get("host_shape_ref"):
+        raise EvidencePackError(f"{rel(manifest_path)}: host_shape_ref MUST match source fixture metadata")
+    for section in ("records", "evidence_manifests", "event_chains", "operation_headers"):
+        if not isinstance(manifest.get(section), list) or not manifest[section]:
+            raise EvidencePackError(f"{rel(manifest_path)}: {section} MUST be a nonempty list")
+
+    checked = 0
+    for entry in manifest.get("records", []):
+        if not isinstance(entry, dict):
+            raise EvidencePackError(f"{rel(manifest_path)}: record entries MUST be objects")
+        checked += check_record_entry(manifest_path, pack_dir, fixture, entry)
+    for entry in manifest.get("evidence_manifests", []):
+        if not isinstance(entry, dict):
+            raise EvidencePackError(f"{rel(manifest_path)}: EvidenceManifest entries MUST be objects")
+        checked += check_evidence_manifest_entry(pack_dir, fixture, entry)
+    for entry in manifest.get("event_chains", []):
+        if not isinstance(entry, dict):
+            raise EvidencePackError(f"{rel(manifest_path)}: event chain entries MUST be objects")
+        checked += check_event_chain_entry(pack_dir, fixture, entry)
+    for entry in manifest.get("operation_headers", []):
+        if not isinstance(entry, dict):
+            raise EvidencePackError(f"{rel(manifest_path)}: header entries MUST be objects")
+        checked += check_header_entry(pack_dir, fixture, entry)
+    header_indexes = [entry.get("source_operation_index") for entry in manifest["operation_headers"]]
+    if sorted(header_indexes) != list(range(len(fixture.get("operations", [])))):
+        raise EvidencePackError(
+            f"{rel(manifest_path)}: operation_headers MUST cover every source fixture operation"
+        )
+    if checked == 0:
+        raise EvidencePackError(f"{rel(manifest_path)}: evidence pack MUST validate at least one entry")
+    return checked
+
+
+def main() -> int:
+    if not PACK_ROOT.exists():
+        print("docs/examples/evidence-packs is missing")
+        return 1
+    manifests = sorted(PACK_ROOT.glob("*/manifest.json"))
+    if not manifests:
+        print("docs/examples/evidence-packs contains no manifest.json files")
+        return 1
+    checked = 0
+    try:
+        for manifest_path in manifests:
+            checked += check_manifest(manifest_path)
+    except EvidencePackError as exc:
+        print(exc)
+        return 1
+    print(f"Validated {len(manifests)} example evidence pack(s), {checked} entries.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_example_evidence_packs.py
+++ b/scripts/check_example_evidence_packs.py
@@ -171,6 +171,11 @@ def check_record_entry(
     expected_context_refs = entry.get("context_refs", {})
     if not isinstance(expected_context_refs, dict):
         raise EvidencePackError(f"{rel(manifest_path)}: context_refs MUST be an object")
+    extra_context_keys = sorted(set(context) - set(expected_context_refs))
+    if extra_context_keys:
+        raise EvidencePackError(
+            f"{rel(path)}: context contains keys without a context_ref: {', '.join(extra_context_keys)}"
+        )
     for key, ref in expected_context_refs.items():
         expected = resolve_fixture_ref(fixture, ref)
         if context.get(key) != expected:


### PR DESCRIPTION
## Summary

Adds a public protocol-record evidence pack for the existing-agent review-resolution loop.

The pack derives from the canonical v0.1 golden-path fixture and exposes helper-compatible envelopes for records, EvidenceManifest export, JarvisEvent hash-chain validation, and every source fixture operation header. It proves record compatibility only; it does not certify an implementation, claim production adoption, or define host execution.

## Protocol Surface

- Adds `docs/examples/evidence-packs/existing-agent-review/` with machine-checkable protocol records.
- Adds `scripts/check_example_evidence_packs.py` to validate pack envelopes, OpenAPI source refs, canonical fixture refs, full operation header parity, EvidenceManifest terminal-source context, OutcomeReport terminal-source context, and event hash chains.
- Links the pack from README, docs index, examples index, docs site, roadmap, CI, Pages validation, and PR checklist.

## Boundary Check

- Jarvis remains protocol-only.
- Hosts still own runtime behavior, UI, auth, storage, model calls, tool execution, monitoring, host integration, deployment, and host workflow.
- The evidence pack contains protocol records and validation metadata only.

## Validation

- `npm run check:protocol`
- `npm --workspace @jarvis-protocol/sdk test`
- `npm run test:python`
- `npm run test:cli`
- `node packages/cli/src/index.js validate record docs/examples/evidence-packs/existing-agent-review/records/request-approved.json`
- `node packages/cli/src/index.js validate record docs/examples/evidence-packs/existing-agent-review/records/outcome-report-post-session.json`
- `node packages/cli/src/index.js validate evidence-manifest docs/examples/evidence-packs/existing-agent-review/evidence/evidence-manifest.json`
- `node packages/cli/src/index.js check hash-chain docs/examples/evidence-packs/existing-agent-review/events/event-chain.json`
- `node packages/cli/src/index.js check headers docs/examples/evidence-packs/existing-agent-review/headers/04-create-work-session-genesis-request.json --operation-id createWorkSession`

## Internal Review

Four reviewer agents checked boundary wording, security/validation, docs clarity, and engineering maintainability. Valid findings were fixed before this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new public example evidence pack with documentation, sample records, event history, and validation guidance.
  * Expanded the docs site and demo to surface evidence packs and protocol validation commands more clearly.

* **Bug Fixes**
  * Improved validation coverage so evidence-pack changes are checked consistently in local and CI workflows.

* **Documentation**
  * Updated setup and contribution docs to include the new required checks and clarify the evidence-pack workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->