### PR TITLE
[codex] Fix Pages evidence pack dependencies

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,7 +34,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install Python dependencies
-        run: python -m pip install pyyaml==6.0.1
+        run: python -m pip install pyyaml==6.0.1 typing_extensions==4.15.0
 
       - name: Validate conformance fixtures
         run: python3 scripts/check_conformance_fixtures.py


### PR DESCRIPTION
## Summary

- Add the missing pinned `typing_extensions` dependency to the GitHub Pages workflow.

## Root Cause

The Pages deploy workflow ran `scripts/check_example_evidence_packs.py`, which imports the Python protocol helper package. The generated Python types require `typing_extensions`, but the Pages workflow installed only `pyyaml`.

## Boundary Check

- This change is CI-only.
- It does not change Jarvis protocol contracts, records, examples, SDK behavior, or docs-site content.

## Validation

- `python3 scripts/check_example_evidence_packs.py`
- `python3 scripts/check_conformance_fixtures.py`
- `python3 scripts/check_openapi_contract.py`
- `python3 scripts/check_markdown_links.py`
- `python3 scripts/check_docs_site.py`
- `python3 scripts/check_protocol_wording.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the deployment workflow to install an additional Python dependency during setup, helping keep the site publishing process compatible with current tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->