### PR TITLE
[codex] Add protocol SDK helper flows

### DIFF
--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -47,6 +47,16 @@ The package root exports:
 - generated `TypedDict` and `Literal` model names under
   `jarvis_protocol.generated.openapi_types`
 - `protocol_error`
+- `create_read_headers`
+- `create_mutation_headers`
+- `create_non_work_session_mutation_headers`
+- `create_work_session_mutation_headers`
+- `get_operation_binding`
+- `create_operation_path`
+- `create_operation_envelope`
+- `create_jarvis_event`
+- `create_next_jarvis_event`
+- `create_evidence_manifest`
 - `validate_mutation_headers`
 - `validate_read_headers`
 - `validate_operation_headers`
@@ -56,6 +66,81 @@ The package root exports:
 - `canonicalize_protocol_value`
 - `hash_protocol_value`
 - `find_forbidden_host_private_field`
+
+## Protocol Helper Flow
+
+```python
+from jarvis_protocol import (
+    create_evidence_manifest,
+    create_next_jarvis_event,
+    create_operation_envelope,
+    create_work_session_mutation_headers,
+    validate_event_hash_chain,
+)
+
+headers = create_work_session_mutation_headers(
+    actor_id="actor-human-1",
+    authorization="HostAuth caller",
+    idempotency_key="idem-1",
+    request_timestamp="2026-06-16T10:00:00Z",
+    expected_work_session_revision=0,
+    previous_event_hash="hash:protocol-genesis",
+)
+
+operation = create_operation_envelope(
+    operation_id="appendJarvisEvent",
+    actor_id="actor-human-1",
+    headers=headers,
+    work_session_id="ws-1",
+    body_ref="records.jarvis_events.created",
+)
+
+event = create_next_jarvis_event(
+    id="event-created",
+    event_type="work_session.created",
+    work_session_id="ws-1",
+    actor_id="actor-human-1",
+    timestamp="2026-06-16T10:00:00Z",
+    payload={
+        "object_type": "work_session",
+        "object_id": "ws-1",
+        "action": "created",
+    },
+)
+
+validate_event_hash_chain([event])
+
+create_evidence_manifest(
+    id="evidence-1",
+    work_session={
+        "id": "ws-1",
+        "objective": "Create a governed protocol record.",
+        "status": "completed",
+        "last_event_hash": event["event_hash"],
+    },
+    events=[event],
+    generated_by_actor_id="actor-human-1",
+    generated_at="2026-06-16T10:01:00Z",
+    evidence_item_refs=[
+        {
+            "id": "evidence-item-1",
+            "work_session_id": "ws-1",
+            "source_event_refs": ["event-created"],
+            "captured_by_actor_id": "actor-human-1",
+            "evidence_type": "artifact",
+            "artifact_ref": "artifact:created-work",
+            "content_hash": "hash:created-work",
+            "trust_label": "verified",
+            "redaction_state": "none",
+            "captured_at": "2026-06-16T10:01:00Z",
+            "limitation_refs": [],
+        }
+    ],
+)
+```
+
+These helpers create protocol records and operation envelopes only. Hosts own
+transport, auth, storage, execution, and workflow.
 
 ## Local Validation
 

--- a/packages/python/src/jarvis_protocol/__init__.py
+++ b/packages/python/src/jarvis_protocol/__init__.py
@@ -9,6 +9,7 @@ from hashlib import sha256
 import json
 import re
 from typing import Any
+from urllib.parse import quote, unquote
 
 from .generated.openapi_types import *  # noqa: F403
 from .generated.openapi_types import __all__ as OPENAPI_TYPE_NAMES
@@ -195,6 +196,12 @@ ACTOR_BODY_FIELD_BY_OPERATION = {
 
 PROTOCOL_ERROR_IDS = set(SCHEMA_ENUMS.get("ProtocolErrorId", ()))
 
+DEFAULT_CANONICALIZATION = {
+    "serialization": "json-c14n",
+    "hash_method": "sha256",
+    "profile_ref": "canonicalization:v0.1",
+}
+
 
 @dataclass(frozen=True)
 class ValidationResult:
@@ -245,6 +252,427 @@ def _fail(error_id: str, options: Mapping[str, Any] | None = None) -> Validation
 
 def _pass() -> ValidationResult:
     return validation_result([])
+
+
+def _assert_valid(result: ValidationResult) -> None:
+    if not result.valid:
+        error = result.errors[0] if result.errors else protocol_error("invalid_export")
+        raise JarvisProtocolValidationError(error)
+
+
+def _helper_error(field: str, reason: str) -> JarvisProtocolValidationError:
+    return JarvisProtocolValidationError(
+        protocol_error(
+            "invalid_export",
+            {
+                "object_type": "ProtocolHelper",
+                "field": field,
+                "reason": reason,
+            },
+        )
+    )
+
+
+def _successful_status(binding: Mapping[str, Any]) -> int:
+    statuses = sorted(binding["statuses"])
+    for status in statuses:
+        if status < 400:
+            return status
+    return statuses[0]
+
+
+def _operation_work_session_scoped(binding: Mapping[str, Any]) -> bool:
+    return str(binding["path"]).startswith("/work-sessions")
+
+
+def _build_headers_for_operation(binding: Mapping[str, Any], options: Mapping[str, Any]) -> dict[str, Any]:
+    headers = options.get("headers")
+    if isinstance(headers, dict):
+        return dict(headers)
+    shared = {
+        "actor_id": options.get("actor_id"),
+        "authorization": options.get("authorization"),
+        "protocol_version": options.get("protocol_version", PROTOCOL_VERSION),
+        "validation_options": options.get("validation_options"),
+    }
+    if binding["method"] == "GET":
+        return create_read_headers(**shared)
+    if not _operation_work_session_scoped(binding):
+        return create_non_work_session_mutation_headers(
+            **shared,
+            idempotency_key=options.get("idempotency_key"),
+            request_timestamp=options.get("request_timestamp"),
+        )
+    return create_work_session_mutation_headers(
+        **shared,
+        idempotency_key=options.get("idempotency_key"),
+        request_timestamp=options.get("request_timestamp"),
+        expected_work_session_revision=options.get("expected_work_session_revision"),
+        previous_event_hash=options.get("previous_event_hash"),
+    )
+
+
+def _path_params_for_operation(options: Mapping[str, Any]) -> dict[str, Any]:
+    path_params = dict(options.get("path_params") or {})
+    path_params["worker_id"] = options.get("worker_id", path_params.get("worker_id"))
+    path_params["actor_id"] = options.get("target_actor_id", path_params.get("actor_id"))
+    path_params["work_session_id"] = options.get("work_session_id", path_params.get("work_session_id"))
+    return path_params
+
+
+def _last_event(events: Sequence[Mapping[str, Any]] | None) -> Mapping[str, Any] | None:
+    if not events:
+        return None
+    candidates = [
+        event
+        for event in events
+        if isinstance(event, dict) and _is_int(event.get("sequence"))
+    ]
+    if not candidates:
+        return None
+    return sorted(candidates, key=lambda event: event["sequence"], reverse=True)[0]
+
+
+def _last_event_for_work_session(
+    events: Sequence[Mapping[str, Any]] | None,
+    work_session_id: Any,
+) -> Mapping[str, Any] | None:
+    if not events:
+        return None
+    if not _is_nonempty_string(work_session_id):
+        raise _helper_error("work_session_id", "work_session_id is required when JarvisEvents are supplied.")
+    for event in events:
+        if isinstance(event, dict) and event.get("work_session_id") != work_session_id:
+            raise _helper_error("events.work_session_id", "JarvisEvents MUST belong to the target WorkSession.")
+    return _last_event(events)
+
+
+def _event_hash_for(event_without_hash: Mapping[str, Any], caller_hash: str | None) -> str:
+    computed_hash = hash_protocol_value(event_without_hash)
+    if caller_hash is not None and caller_hash != computed_hash:
+        raise JarvisProtocolValidationError(
+            protocol_error(
+                "invalid_event_hash",
+                {
+                    "object_type": "JarvisEvent",
+                    "field": "event_hash",
+                    "reason": "JarvisEvent.event_hash MUST match the canonical hash of the event body.",
+                },
+            )
+        )
+    return computed_hash
+
+
+def _invalid_evidence_root_error(field: str, reason: str) -> JarvisProtocolValidationError:
+    return JarvisProtocolValidationError(
+        protocol_error(
+            "invalid_evidence_export_state",
+            {
+                "object_type": "EvidenceManifest",
+                "field": field,
+                "reason": reason,
+            },
+        )
+    )
+
+
+def _assert_manifest_root(
+    work_session: Mapping[str, Any],
+    events: Sequence[Mapping[str, Any]] | None,
+    event_chain_root: str | None,
+) -> str:
+    work_session_hash = work_session.get("last_event_hash") if isinstance(work_session, dict) else None
+    if not _is_nonempty_string(work_session_hash):
+        raise _invalid_evidence_root_error(
+            "work_session.last_event_hash",
+            "EvidenceManifest export requires a terminal WorkSession last_event_hash.",
+        )
+    if event_chain_root is not None and event_chain_root != work_session_hash:
+        raise _invalid_evidence_root_error(
+            "event_chain_root",
+            "EvidenceManifest.event_chain_root MUST match WorkSession.last_event_hash.",
+        )
+    if events:
+        _assert_valid(validate_event_hash_chain(list(events)))
+        previous = _last_event_for_work_session(events, work_session.get("id"))
+        if previous is None or previous.get("event_hash") != work_session_hash:
+            raise _invalid_evidence_root_error(
+                "event_chain_root",
+                "EvidenceManifest event chain root MUST match the terminal WorkSession last_event_hash.",
+            )
+    return str(work_session_hash)
+
+
+def create_read_headers(
+    *,
+    actor_id: str,
+    authorization: str,
+    protocol_version: str = PROTOCOL_VERSION,
+    validation_options: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    headers = {
+        "Authorization": authorization,
+        "Jarvis-Protocol-Version": protocol_version,
+        "Jarvis-Actor-Id": actor_id,
+    }
+    _assert_valid(validate_read_headers(headers, validation_options))
+    return headers
+
+
+def create_non_work_session_mutation_headers(
+    *,
+    actor_id: str,
+    authorization: str,
+    idempotency_key: str,
+    request_timestamp: str,
+    protocol_version: str = PROTOCOL_VERSION,
+    validation_options: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    headers = {
+        "Authorization": authorization,
+        "Jarvis-Protocol-Version": protocol_version,
+        "Jarvis-Actor-Id": actor_id,
+        "Jarvis-Idempotency-Key": idempotency_key,
+        "Jarvis-Request-Timestamp": request_timestamp,
+    }
+    _assert_valid(
+        validate_mutation_headers(
+            headers,
+            {
+                **dict(validation_options or {}),
+                "work_session_scoped": False,
+            },
+        )
+    )
+    return headers
+
+
+def create_work_session_mutation_headers(
+    *,
+    actor_id: str,
+    authorization: str,
+    idempotency_key: str,
+    request_timestamp: str,
+    expected_work_session_revision: int,
+    previous_event_hash: str,
+    protocol_version: str = PROTOCOL_VERSION,
+    validation_options: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    headers = {
+        "Authorization": authorization,
+        "Jarvis-Protocol-Version": protocol_version,
+        "Jarvis-Actor-Id": actor_id,
+        "Jarvis-Idempotency-Key": idempotency_key,
+        "Jarvis-Request-Timestamp": request_timestamp,
+        "Jarvis-Expected-WorkSession-Revision": expected_work_session_revision,
+        "Jarvis-Previous-Event-Hash": previous_event_hash,
+    }
+    _assert_valid(validate_mutation_headers(headers, validation_options))
+    return headers
+
+
+def create_mutation_headers(*, work_session_scoped: bool = True, **options: Any) -> dict[str, Any]:
+    if not work_session_scoped:
+        return create_non_work_session_mutation_headers(**options)
+    return create_work_session_mutation_headers(**options)
+
+
+def get_operation_binding(operation_id: str) -> dict[str, Any]:
+    binding = OPERATION_BINDINGS_BY_ID.get(operation_id)
+    if not binding:
+        raise _helper_error("operation_id", "operation_id MUST exist in the Jarvis OpenAPI binding.")
+    return {
+        "method": binding["method"],
+        "path": binding["path"],
+        "statuses": sorted(binding["statuses"]),
+    }
+
+
+def create_operation_path(operation_id: str, path_params: Mapping[str, Any] | None = None) -> str:
+    binding = get_operation_binding(operation_id)
+    params = path_params or {}
+
+    def replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        value = params.get(key)
+        if not _is_nonempty_string(value):
+            raise _helper_error(f"path.{key}", f"{key} is required for {operation_id}.")
+        return quote(str(value), safe="")
+
+    return re.sub(r"\{([^/]+)\}", replace, binding["path"])
+
+
+def create_operation_envelope(
+    *,
+    operation_id: str,
+    actor_id: str,
+    authorization: str | None = None,
+    protocol_version: str = PROTOCOL_VERSION,
+    headers: Mapping[str, Any] | None = None,
+    path: str | None = None,
+    path_params: Mapping[str, Any] | None = None,
+    worker_id: str | None = None,
+    target_actor_id: str | None = None,
+    work_session_id: str | None = None,
+    idempotency_key: str | None = None,
+    request_timestamp: str | None = None,
+    expected_work_session_revision: int | None = None,
+    previous_event_hash: str | None = None,
+    expected_status: int | None = None,
+    expected_error_id: str | None = None,
+    expected_error_field: str | None = None,
+    body_ref: str | None = None,
+    attempted_takeover_lock_epoch: int | None = None,
+    validation_options: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    binding = OPERATION_BINDINGS_BY_ID.get(operation_id)
+    if not binding:
+        raise _helper_error("operation_id", "operation_id MUST exist in the Jarvis OpenAPI binding.")
+    options = {
+        "actor_id": actor_id,
+        "authorization": authorization,
+        "protocol_version": protocol_version,
+        "headers": dict(headers) if isinstance(headers, dict) else None,
+        "path_params": path_params,
+        "worker_id": worker_id,
+        "target_actor_id": target_actor_id,
+        "work_session_id": work_session_id,
+        "idempotency_key": idempotency_key,
+        "request_timestamp": request_timestamp,
+        "expected_work_session_revision": expected_work_session_revision,
+        "previous_event_hash": previous_event_hash,
+        "validation_options": validation_options,
+    }
+    operation = {
+        "operation_id": operation_id,
+        "method": binding["method"],
+        "path": path or create_operation_path(operation_id, _path_params_for_operation(options)),
+        "headers": _build_headers_for_operation(binding, options),
+        "actor_id": actor_id,
+        "expected_status": expected_status if expected_status is not None else _successful_status(binding),
+    }
+    path_values = _operation_path_values(operation)
+    if expected_error_id:
+        operation["expected_error_id"] = expected_error_id
+    if expected_error_field:
+        operation["expected_error_field"] = expected_error_field
+    if work_session_id or path_values.get("work_session_id"):
+        operation["work_session_id"] = work_session_id or path_values.get("work_session_id")
+    if body_ref:
+        operation["body_ref"] = body_ref
+    if attempted_takeover_lock_epoch is not None:
+        operation["attempted_takeover_lock_epoch"] = attempted_takeover_lock_epoch
+    binding_error = _operation_binding_error(operation)
+    if binding_error:
+        raise JarvisProtocolValidationError(binding_error)
+    _assert_valid(validate_operation_headers(operation, validation_options))
+    return operation
+
+
+def create_jarvis_event(
+    *,
+    id: str,
+    sequence: int,
+    event_type: str,
+    work_session_id: str,
+    actor_id: str,
+    timestamp: str,
+    payload: Mapping[str, Any],
+    previous_hash: str = "hash:protocol-genesis",
+    event_hash: str | None = None,
+    canonicalization: Mapping[str, Any] | None = None,
+    trace_context: Mapping[str, Any] | None = None,
+    actor_signature: str | None = None,
+    signing_key_ref: str | None = None,
+) -> dict[str, Any]:
+    hash_input = {
+        "id": id,
+        "sequence": sequence,
+        "type": event_type,
+        "work_session_id": work_session_id,
+        "actor_id": actor_id,
+        "timestamp": timestamp,
+        "payload": dict(payload),
+        "previous_hash": previous_hash,
+        "canonicalization": dict(canonicalization or DEFAULT_CANONICALIZATION),
+    }
+    if trace_context:
+        hash_input["trace_context"] = dict(trace_context)
+    event = {
+        **hash_input,
+        "event_hash": _event_hash_for(hash_input, event_hash),
+    }
+    if actor_signature:
+        event["actor_signature"] = actor_signature
+    if signing_key_ref:
+        event["signing_key_ref"] = signing_key_ref
+    _assert_valid(validate_protocol_record("JarvisEvent", event))
+    return event
+
+
+def create_next_jarvis_event(
+    *,
+    events: Sequence[Mapping[str, Any]] | None = None,
+    sequence: int | None = None,
+    previous_hash: str | None = None,
+    **event_options: Any,
+) -> dict[str, Any]:
+    previous = _last_event_for_work_session(events, event_options.get("work_session_id"))
+    return create_jarvis_event(
+        **event_options,
+        sequence=sequence if sequence is not None else (int(previous["sequence"]) + 1 if previous else 1),
+        previous_hash=previous_hash or (str(previous["event_hash"]) if previous else "hash:protocol-genesis"),
+    )
+
+
+def create_evidence_manifest(
+    *,
+    id: str,
+    work_session: Mapping[str, Any],
+    generated_by_actor_id: str,
+    generated_at: str,
+    objective: str | None = None,
+    work_session_id: str | None = None,
+    events: Sequence[Mapping[str, Any]] | None = None,
+    event_chain_root: str | None = None,
+    evidence_item_refs: Sequence[Mapping[str, Any]] | None = None,
+    policy_decision_refs: Sequence[str] | None = None,
+    request_refs: Sequence[str] | None = None,
+    review_refs: Sequence[str] | None = None,
+    takeover_refs: Sequence[str] | None = None,
+    contribution_refs: Sequence[str] | None = None,
+    artifact_refs: Sequence[str] | None = None,
+    limitation_refs: Sequence[str] | None = None,
+    redaction_refs: Sequence[str] | None = None,
+    export_profile: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    root = _assert_manifest_root(work_session, events, event_chain_root)
+    manifest = {
+        "id": id,
+        "work_session_id": work_session_id or work_session.get("id"),
+        "generated_by_actor_id": generated_by_actor_id,
+        "objective": objective or work_session.get("objective"),
+        "event_chain_root": root,
+        "evidence_item_refs": [dict(item) for item in (evidence_item_refs or [])],
+        "policy_decision_refs": list(policy_decision_refs or []),
+        "request_refs": list(request_refs or []),
+        "review_refs": list(review_refs or []),
+        "takeover_refs": list(takeover_refs or []),
+        "contribution_refs": list(contribution_refs or []),
+        "export_profile": dict(export_profile or {
+            "profile": "portable_evidence_manifest",
+            "version": PROTOCOL_VERSION,
+        }),
+        "generated_at": generated_at,
+    }
+    if artifact_refs is not None:
+        manifest["artifact_refs"] = list(artifact_refs)
+    if limitation_refs is not None:
+        manifest["limitation_refs"] = list(limitation_refs)
+    if redaction_refs is not None:
+        manifest["redaction_refs"] = list(redaction_refs)
+    _assert_valid(validate_evidence_manifest(manifest, {"work_session": work_session}))
+    return manifest
 
 
 def _is_plain_object(value: Any) -> bool:
@@ -356,6 +784,24 @@ def _operation_path_matches_template(template: str, path: Any) -> bool:
     return re.fullmatch("/".join(parts), path) is not None
 
 
+def _operation_path_values(operation: Mapping[str, Any] | None) -> dict[str, str]:
+    if not operation or not _is_nonempty_string(operation.get("path")):
+        return {}
+    binding = OPERATION_BINDINGS_BY_ID.get(operation.get("operation_id"))
+    if not binding:
+        return {}
+    template_segments = str(binding["path"]).split("/")
+    path_segments = str(operation["path"]).split("/")
+    if len(template_segments) != len(path_segments):
+        return {}
+    values = {}
+    for template_segment, path_segment in zip(template_segments, path_segments, strict=True):
+        match = re.fullmatch(r"\{([^/]+)\}", template_segment)
+        if match:
+            values[match.group(1)] = unquote(path_segment)
+    return values
+
+
 def _operation_binding_error(operation: Mapping[str, Any] | None) -> dict[str, Any] | None:
     operation_id = operation.get("operation_id") if operation else None
     binding = OPERATION_BINDINGS_BY_ID.get(operation_id)
@@ -393,6 +839,19 @@ def _operation_binding_error(operation: Mapping[str, Any] | None) -> dict[str, A
                 "object_type": "FixtureOperation",
                 "field": "expected_status",
                 "reason": "Fixture operation expected_status MUST match the Jarvis OpenAPI binding.",
+            },
+        )
+    path_values = _operation_path_values(operation)
+    if (
+        _is_nonempty_string(path_values.get("work_session_id"))
+        and operation.get("work_session_id") != path_values["work_session_id"]
+    ):
+        return protocol_error(
+            "path_body_id_mismatch",
+            {
+                "object_type": "FixtureOperation",
+                "field": "work_session_id",
+                "reason": "operation.work_session_id MUST match the concrete WorkSession path id.",
             },
         )
     return None
@@ -490,6 +949,19 @@ def _operation_body_binding_error(
     operation: Mapping[str, Any] | None,
     body: Mapping[str, Any] | None,
 ) -> dict[str, Any] | None:
+    path_values = _operation_path_values(operation)
+    if (
+        _is_nonempty_string(path_values.get("work_session_id"))
+        and isinstance(body, dict)
+        and body.get("work_session_id") != path_values["work_session_id"]
+    ):
+        return protocol_error(
+            "path_body_id_mismatch",
+            {
+                "field": "work_session_id",
+                "reason": "body.work_session_id MUST match the concrete WorkSession path id.",
+            },
+        )
     actor_body_field = ACTOR_BODY_FIELD_BY_OPERATION.get(operation.get("operation_id") if operation else None)
     if not actor_body_field or not isinstance(body, dict):
         return None
@@ -686,6 +1158,18 @@ def _evidence_manifest_export_error(
                 "reason": "EvidenceManifest source WorkSession id MUST match EvidenceManifest.work_session_id.",
             },
         )
+    if (
+        _is_nonempty_string(work_session.get("last_event_hash"))
+        and evidence_manifest.get("event_chain_root") != work_session.get("last_event_hash")
+    ):
+        return protocol_error(
+            "invalid_evidence_export_state",
+            {
+                "object_type": "EvidenceManifest",
+                "field": "event_chain_root",
+                "reason": "EvidenceManifest.event_chain_root MUST match WorkSession.last_event_hash.",
+            },
+        )
     return None
 
 
@@ -756,7 +1240,7 @@ def validate_schema_record(object_type: str, record: Any) -> ValidationResult:
             },
         )
     for field in SCHEMA_REQUIRED_FIELDS.get(object_type, ()):
-        if field not in record:
+        if field not in record or record[field] is None:
             return _fail(
                 "invalid_export",
                 {
@@ -1137,6 +1621,15 @@ def validate_evidence_manifest(
     if export_error:
         return validation_result([export_error])
     evidence_item_refs = evidence_manifest.get("evidence_item_refs")
+    if not isinstance(evidence_item_refs, list) or len(evidence_item_refs) == 0:
+        return _fail(
+            "invalid_export",
+            {
+                "object_type": "EvidenceManifest",
+                "field": "evidence_item_refs",
+                "reason": "EvidenceManifest.evidence_item_refs MUST contain at least one evidence item.",
+            },
+        )
     if isinstance(evidence_item_refs, list):
         for index, evidence_item_ref in enumerate(evidence_item_refs):
             item_result = validate_schema_record("EvidenceItemRef", evidence_item_ref)
@@ -1763,7 +2256,17 @@ __all__ += [
     "JarvisProtocolValidationError",
     "ValidationResult",
     "canonicalize_protocol_value",
+    "create_evidence_manifest",
+    "create_jarvis_event",
+    "create_mutation_headers",
+    "create_next_jarvis_event",
+    "create_non_work_session_mutation_headers",
+    "create_operation_envelope",
+    "create_operation_path",
+    "create_read_headers",
+    "create_work_session_mutation_headers",
     "find_forbidden_host_private_field",
+    "get_operation_binding",
     "hash_protocol_value",
     "protocol_error",
     "validate_approval_scope",

--- a/packages/python/tests/test_helpers.py
+++ b/packages/python/tests/test_helpers.py
@@ -5,8 +5,17 @@ import unittest
 
 from jarvis_protocol import (
     canonicalize_protocol_value,
+    create_evidence_manifest,
+    create_jarvis_event,
+    create_next_jarvis_event,
+    create_operation_envelope,
+    create_operation_path,
+    create_read_headers,
+    create_work_session_mutation_headers,
     find_forbidden_host_private_field,
+    get_operation_binding,
     hash_protocol_value,
+    JarvisProtocolValidationError,
     protocol_error,
     validate_approval_scope,
     validate_evidence_manifest,
@@ -17,6 +26,8 @@ from jarvis_protocol import (
     validate_protocol_record,
     validate_read_headers,
 )
+
+AUTHORIZATION = "HostAuth test"
 
 
 class HelperValidationTests(unittest.TestCase):
@@ -46,6 +57,271 @@ class HelperValidationTests(unittest.TestCase):
             {"now": datetime(2026, 6, 16, 10, 0, 0, tzinfo=timezone.utc)},
         )
         self.assertTrue(accepted.valid, accepted.errors)
+
+    def test_header_helpers_create_valid_read_and_work_session_mutation_headers(self) -> None:
+        read_headers = create_read_headers(
+            actor_id="actor-human-test",
+            authorization=AUTHORIZATION,
+        )
+        self.assertEqual(
+            read_headers,
+            {
+                "Authorization": AUTHORIZATION,
+                "Jarvis-Protocol-Version": "v0.1",
+                "Jarvis-Actor-Id": "actor-human-test",
+            },
+        )
+        self.assertTrue(validate_read_headers(read_headers).valid)
+
+        mutation_headers = create_work_session_mutation_headers(
+            actor_id="actor-human-test",
+            authorization=AUTHORIZATION,
+            idempotency_key="idem-test",
+            request_timestamp="2026-06-16T10:00:00Z",
+            expected_work_session_revision=0,
+            previous_event_hash="hash:protocol-genesis",
+        )
+        self.assertTrue(validate_mutation_headers(mutation_headers).valid)
+
+    def test_operation_helper_binds_openapi_method_path_status_headers_and_actor(self) -> None:
+        self.assertEqual(
+            get_operation_binding("exportEvidenceManifest"),
+            {
+                "method": "GET",
+                "path": "/work-sessions/{work_session_id}/export",
+                "statuses": [200, 400],
+            },
+        )
+        self.assertEqual(
+            create_operation_path("exportEvidenceManifest", {"work_session_id": "ws-test"}),
+            "/work-sessions/ws-test/export",
+        )
+        operation = create_operation_envelope(
+            operation_id="exportEvidenceManifest",
+            actor_id="actor-human-test",
+            authorization=AUTHORIZATION,
+            work_session_id="ws-test",
+        )
+        self.assertEqual(
+            operation,
+            {
+                "operation_id": "exportEvidenceManifest",
+                "method": "GET",
+                "path": "/work-sessions/ws-test/export",
+                "headers": {
+                    "Authorization": AUTHORIZATION,
+                    "Jarvis-Protocol-Version": "v0.1",
+                    "Jarvis-Actor-Id": "actor-human-test",
+                },
+                "actor_id": "actor-human-test",
+                "expected_status": 200,
+                "work_session_id": "ws-test",
+            },
+        )
+        self.assertTrue(validate_operation_headers(operation).valid)
+
+    def test_event_and_evidence_manifest_helpers_build_valid_protocol_records(self) -> None:
+        created = create_next_jarvis_event(
+            id="event-created",
+            event_type="work_session.created",
+            work_session_id="ws-test",
+            actor_id="actor-human-test",
+            timestamp="2026-06-16T10:00:00Z",
+            payload={
+                "object_type": "work_session",
+                "object_id": "ws-test",
+                "action": "created",
+            },
+        )
+        completed = create_next_jarvis_event(
+            events=[created],
+            id="event-completed",
+            event_type="work_session.completed",
+            work_session_id="ws-test",
+            actor_id="actor-human-test",
+            timestamp="2026-06-16T10:10:00Z",
+            payload={
+                "object_type": "work_session",
+                "object_id": "ws-test",
+                "action": "completed",
+            },
+        )
+        self.assertEqual(created["sequence"], 1)
+        self.assertEqual(completed["sequence"], 2)
+        self.assertEqual(completed["previous_hash"], created["event_hash"])
+        self.assertTrue(validate_event_hash_chain([created, completed]).valid)
+
+        work_session = {
+            "id": "ws-test",
+            "objective": "Prove helper-created protocol records.",
+            "status": "completed",
+            "last_event_hash": completed["event_hash"],
+        }
+        manifest = create_evidence_manifest(
+            id="evidence-test",
+            work_session=work_session,
+            events=[created, completed],
+            generated_by_actor_id="actor-human-test",
+            generated_at="2026-06-16T10:11:00Z",
+            evidence_item_refs=[
+                {
+                    "id": "evidence-item-test",
+                    "work_session_id": "ws-test",
+                    "source_event_refs": ["event-completed"],
+                    "captured_by_actor_id": "actor-human-test",
+                    "evidence_type": "artifact",
+                    "artifact_ref": "artifact:test",
+                    "content_hash": "hash:content",
+                    "trust_label": "verified",
+                    "redaction_state": "none",
+                    "captured_at": "2026-06-16T10:10:00Z",
+                    "limitation_refs": [],
+                }
+            ],
+        )
+        self.assertEqual(manifest["event_chain_root"], completed["event_hash"])
+        self.assertTrue(validate_evidence_manifest(manifest, {"work_session": work_session}).valid)
+
+    def test_event_helper_computes_hash_before_optional_signature_metadata(self) -> None:
+        base = {
+            "id": "event-signed",
+            "sequence": 1,
+            "event_type": "work_session.created",
+            "work_session_id": "ws-test",
+            "actor_id": "actor-human-test",
+            "timestamp": "2026-06-16T10:00:00Z",
+            "payload": {
+                "object_type": "work_session",
+                "object_id": "ws-test",
+                "action": "created",
+            },
+        }
+        unsigned = create_jarvis_event(**base)
+        signed = create_jarvis_event(
+            **base,
+            actor_signature="signature:test",
+            signing_key_ref="signing-key:test",
+        )
+        self.assertEqual(signed["event_hash"], unsigned["event_hash"])
+        self.assertEqual(signed["actor_signature"], "signature:test")
+
+    def test_event_helper_rejects_mismatched_caller_supplied_event_hash(self) -> None:
+        with self.assertRaises(JarvisProtocolValidationError) as context:
+            create_jarvis_event(
+                id="event-bad-hash",
+                sequence=1,
+                event_type="work_session.created",
+                work_session_id="ws-test",
+                actor_id="actor-human-test",
+                timestamp="2026-06-16T10:00:00Z",
+                payload={
+                    "object_type": "work_session",
+                    "object_id": "ws-test",
+                    "action": "created",
+                },
+                event_hash="hash:not-the-canonical-event",
+            )
+        self.assertEqual(context.exception.error["error_id"], "invalid_event_hash")
+
+    def test_next_event_helper_rejects_cross_work_session_event_linkage(self) -> None:
+        other = create_next_jarvis_event(
+            id="event-other",
+            event_type="work_session.created",
+            work_session_id="ws-other",
+            actor_id="actor-human-test",
+            timestamp="2026-06-16T10:00:00Z",
+            payload={
+                "object_type": "work_session",
+                "object_id": "ws-other",
+                "action": "created",
+            },
+        )
+        with self.assertRaises(JarvisProtocolValidationError) as context:
+            create_next_jarvis_event(
+                events=[other],
+                id="event-wrong-link",
+                event_type="work_session.completed",
+                work_session_id="ws-test",
+                actor_id="actor-human-test",
+                timestamp="2026-06-16T10:10:00Z",
+                payload={
+                    "object_type": "work_session",
+                    "object_id": "ws-test",
+                    "action": "completed",
+                },
+            )
+        self.assertEqual(context.exception.error["error_id"], "invalid_export")
+
+    def test_operation_helper_rejects_concrete_path_work_session_mismatch(self) -> None:
+        with self.assertRaises(JarvisProtocolValidationError) as context:
+            create_operation_envelope(
+                operation_id="appendJarvisEvent",
+                actor_id="actor-human-test",
+                authorization=AUTHORIZATION,
+                path="/work-sessions/ws-other/events",
+                work_session_id="ws-test",
+                idempotency_key="idem-test",
+                request_timestamp="2026-06-16T10:00:00Z",
+                expected_work_session_revision=0,
+                previous_event_hash="hash:protocol-genesis",
+                body_ref="records.jarvis_events.created",
+            )
+        self.assertEqual(context.exception.error["error_id"], "path_body_id_mismatch")
+
+    def test_evidence_manifest_helper_rejects_empty_refs_and_root_drift(self) -> None:
+        event = create_next_jarvis_event(
+            id="event-root",
+            event_type="work_session.completed",
+            work_session_id="ws-test",
+            actor_id="actor-human-test",
+            timestamp="2026-06-16T10:10:00Z",
+            payload={
+                "object_type": "work_session",
+                "object_id": "ws-test",
+                "action": "completed",
+            },
+        )
+        work_session = {
+            "id": "ws-test",
+            "objective": "Reject malformed manifest helpers.",
+            "status": "completed",
+            "last_event_hash": event["event_hash"],
+        }
+        with self.assertRaises(JarvisProtocolValidationError) as empty_context:
+            create_evidence_manifest(
+                id="evidence-empty",
+                work_session=work_session,
+                events=[event],
+                generated_by_actor_id="actor-human-test",
+                generated_at="2026-06-16T10:11:00Z",
+            )
+        self.assertEqual(empty_context.exception.error["error_id"], "invalid_export")
+
+        with self.assertRaises(JarvisProtocolValidationError) as drift_context:
+            create_evidence_manifest(
+                id="evidence-root-drift",
+                work_session=work_session,
+                events=[event],
+                event_chain_root="hash:wrong-root",
+                generated_by_actor_id="actor-human-test",
+                generated_at="2026-06-16T10:11:00Z",
+                evidence_item_refs=[
+                    {
+                        "id": "evidence-item-test",
+                        "work_session_id": "ws-test",
+                        "source_event_refs": ["event-root"],
+                        "captured_by_actor_id": "actor-human-test",
+                        "evidence_type": "artifact",
+                        "artifact_ref": "artifact:test",
+                        "content_hash": "hash:content",
+                        "trust_label": "verified",
+                        "redaction_state": "none",
+                        "captured_at": "2026-06-16T10:10:00Z",
+                        "limitation_refs": [],
+                    }
+                ],
+            )
+        self.assertEqual(drift_context.exception.error["error_id"], "invalid_evidence_export_state")
 
     def test_non_work_session_mutation_headers_do_not_require_revision_hash(self) -> None:
         result = validate_mutation_headers(
@@ -323,6 +599,20 @@ class HelperValidationTests(unittest.TestCase):
         self.assertFalse(wrong_source.valid)
         self.assertEqual(wrong_source.errors[0]["error_id"], "invalid_evidence_export_state")
         self.assertEqual(wrong_source.errors[0]["field"], "work_session_id")
+
+        root_drift = validate_evidence_manifest(
+            {**manifest, "event_chain_root": "hash:wrong-root"},
+            {
+                "work_session": {
+                    "id": "ws-test",
+                    "status": "completed",
+                    "last_event_hash": "hash:root",
+                }
+            },
+        )
+        self.assertFalse(root_drift.valid)
+        self.assertEqual(root_drift.errors[0]["error_id"], "invalid_evidence_export_state")
+        self.assertEqual(root_drift.errors[0]["field"], "event_chain_root")
 
     def test_protocol_error_helper_emits_openapi_error_envelope(self) -> None:
         error = protocol_error(

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -41,6 +41,16 @@ Rejected surfaces:
 The package exports:
 
 - OpenAPI-derived TypeScript declarations for every v0.1 component schema
+- `createReadHeaders`
+- `createMutationHeaders`
+- `createNonWorkSessionMutationHeaders`
+- `createWorkSessionMutationHeaders`
+- `getOperationBinding`
+- `createOperationPath`
+- `createOperationEnvelope`
+- `createJarvisEvent`
+- `createNextJarvisEvent`
+- `createEvidenceManifest`
 - `validateMutationHeaders`
 - `validateReadHeaders`
 - `validateProtocolRecord`
@@ -62,6 +72,81 @@ The package exports:
 The package also exports `./package.json` and `./fixtures/v0.1/*` subpaths so
 compatible implementations can read package metadata and v0.1 fixture snapshots
 from the installed package.
+
+## Protocol Helper Flow
+
+```js
+import {
+  createEvidenceManifest,
+  createNextJarvisEvent,
+  createOperationEnvelope,
+  createWorkSessionMutationHeaders,
+  validateEventHashChain,
+} from "@jarvis-protocol/sdk";
+
+const headers = createWorkSessionMutationHeaders({
+  actorId: "actor-human-1",
+  authorization: "HostAuth caller",
+  idempotencyKey: "idem-1",
+  requestTimestamp: "2026-06-16T10:00:00Z",
+  expectedWorkSessionRevision: 0,
+  previousEventHash: "hash:protocol-genesis",
+});
+
+const operation = createOperationEnvelope({
+  operationId: "appendJarvisEvent",
+  actorId: "actor-human-1",
+  headers,
+  workSessionId: "ws-1",
+  bodyRef: "records.jarvis_events.created",
+});
+
+const event = createNextJarvisEvent({
+  id: "event-created",
+  type: "work_session.created",
+  workSessionId: "ws-1",
+  actorId: "actor-human-1",
+  timestamp: "2026-06-16T10:00:00Z",
+  payload: {
+    object_type: "work_session",
+    object_id: "ws-1",
+    action: "created",
+  },
+});
+
+validateEventHashChain([event]);
+
+createEvidenceManifest({
+  id: "evidence-1",
+  workSession: {
+    id: "ws-1",
+    objective: "Create a governed protocol record.",
+    status: "completed",
+    last_event_hash: event.event_hash,
+  },
+  events: [event],
+  generatedByActorId: "actor-human-1",
+  generatedAt: "2026-06-16T10:01:00Z",
+  evidenceItemRefs: [
+    {
+      id: "evidence-item-1",
+      work_session_id: "ws-1",
+      source_event_refs: ["event-created"],
+      captured_by_actor_id: "actor-human-1",
+      evidence_type: "artifact",
+      artifact_ref: "artifact:created-work",
+      content_hash: "hash:created-work",
+      trust_label: "verified",
+      redaction_state: "none",
+      captured_at: "2026-06-16T10:01:00Z",
+      limitation_refs: [],
+    },
+  ],
+});
+```
+
+These helpers create protocol records and operation envelopes only. Hosts own
+transport, auth, storage, execution, and workflow.
 
 ## Local Checks
 

--- a/packages/typescript/src/index.d.ts
+++ b/packages/typescript/src/index.d.ts
@@ -41,6 +41,38 @@ export interface HeaderValidationOptions {
   maxFutureSkewMs?: number;
 }
 
+export interface BaseHeaderOptions {
+  actorId: string;
+  authorization: string;
+  protocolVersion?: string;
+  validationOptions?: HeaderValidationOptions;
+}
+
+export interface MutationHeaderBaseOptions extends BaseHeaderOptions {
+  idempotencyKey: string;
+  requestTimestamp: string;
+}
+
+export interface NonWorkSessionMutationHeaderOptions extends MutationHeaderBaseOptions {
+  workSessionScoped?: false;
+}
+
+export interface WorkSessionMutationHeaderOptions extends MutationHeaderBaseOptions {
+  workSessionScoped?: true;
+  expectedWorkSessionRevision: number;
+  previousEventHash: string;
+}
+
+export type MutationHeaderOptions =
+  | NonWorkSessionMutationHeaderOptions
+  | WorkSessionMutationHeaderOptions;
+
+export interface OperationBinding {
+  method: string;
+  path: string;
+  statuses: number[];
+}
+
 export interface FixtureOperation {
   operation_id: string;
   method: string;
@@ -53,6 +85,71 @@ export interface FixtureOperation {
   work_session_id?: string;
   body_ref?: string;
   attempted_takeover_lock_epoch?: number;
+}
+
+export interface OperationEnvelopeOptions {
+  operationId: string;
+  actorId: string;
+  authorization?: string;
+  protocolVersion?: string;
+  headers?: Record<string, unknown>;
+  path?: string;
+  pathParams?: Record<string, string>;
+  workerId?: string;
+  targetActorId?: string;
+  workSessionId?: string;
+  idempotencyKey?: string;
+  requestTimestamp?: string;
+  expectedWorkSessionRevision?: number;
+  previousEventHash?: string;
+  expectedStatus?: number;
+  expectedErrorId?: ProtocolErrorId;
+  expectedErrorField?: string;
+  bodyRef?: string;
+  attemptedTakeoverLockEpoch?: number;
+  validationOptions?: HeaderValidationOptions;
+}
+
+export interface JarvisEventOptions {
+  id: string;
+  sequence: number;
+  type: string;
+  workSessionId: string;
+  actorId: string;
+  timestamp: string;
+  payload: JarvisEvent["payload"];
+  previousHash?: string;
+  eventHash?: string;
+  canonicalization?: JarvisEvent["canonicalization"];
+  traceContext?: JarvisEvent["trace_context"];
+  actorSignature?: string;
+  signingKeyRef?: string;
+}
+
+export interface NextJarvisEventOptions extends Omit<JarvisEventOptions, "sequence"> {
+  events?: JarvisEvent[];
+  sequence?: number;
+}
+
+export interface EvidenceManifestOptions {
+  id: string;
+  workSession: WorkSession;
+  generatedByActorId: string;
+  generatedAt: string;
+  objective?: string;
+  workSessionId?: string;
+  events?: JarvisEvent[];
+  eventChainRoot?: string;
+  evidenceItemRefs?: EvidenceManifest["evidence_item_refs"];
+  policyDecisionRefs?: string[];
+  requestRefs?: string[];
+  reviewRefs?: string[];
+  takeoverRefs?: string[];
+  contributionRefs?: string[];
+  artifactRefs?: string[];
+  limitationRefs?: string[];
+  redactionRefs?: string[];
+  exportProfile?: EvidenceManifest["export_profile"];
 }
 
 export interface ConformanceFixture {
@@ -95,6 +192,34 @@ export declare function protocolError(
 
 export declare function validationResult(errors: ProtocolError[]): ValidationResult;
 
+export declare function createReadHeaders(
+  options: BaseHeaderOptions,
+): Record<string, unknown>;
+
+export declare function createNonWorkSessionMutationHeaders(
+  options: NonWorkSessionMutationHeaderOptions,
+): Record<string, unknown>;
+
+export declare function createWorkSessionMutationHeaders(
+  options: WorkSessionMutationHeaderOptions,
+): Record<string, unknown>;
+
+export declare function createMutationHeaders(
+  options: MutationHeaderOptions | NonWorkSessionMutationHeaderOptions,
+): Record<string, unknown>;
+
+export declare function getOperationBinding(operationId: string): OperationBinding;
+export declare function createOperationPath(
+  operationId: string,
+  pathParams?: Record<string, string>,
+): string;
+export declare function createOperationEnvelope(
+  options: OperationEnvelopeOptions,
+): FixtureOperation;
+export declare function createJarvisEvent(options: JarvisEventOptions): JarvisEvent;
+export declare function createNextJarvisEvent(options: NextJarvisEventOptions): JarvisEvent;
+export declare function createEvidenceManifest(options: EvidenceManifestOptions): EvidenceManifest;
+
 export declare function findForbiddenHostPrivateField(
   value: unknown,
   basePath?: string,
@@ -120,7 +245,10 @@ export declare function validateReadHeaders(
   options?: HeaderValidationOptions,
 ): ValidationResult;
 
-export declare function validateOperationHeaders(operation: FixtureOperation): ValidationResult;
+export declare function validateOperationHeaders(
+  operation: FixtureOperation,
+  options?: HeaderValidationOptions,
+): ValidationResult;
 export declare function validateRequest(request: Request): ValidationResult;
 export declare function validateApprovalScope(
   approvalScope: ApprovalScope,

--- a/packages/typescript/src/index.js
+++ b/packages/typescript/src/index.js
@@ -193,6 +193,12 @@ const ACTOR_BODY_FIELD_BY_OPERATION = Object.freeze({
 
 const PROTOCOL_ERROR_IDS = new Set(SCHEMA_ENUMS.ProtocolErrorId ?? []);
 
+const DEFAULT_CANONICALIZATION = Object.freeze({
+  serialization: "json-c14n",
+  hash_method: "sha256",
+  profile_ref: "canonicalization:v0.1",
+});
+
 export class JarvisProtocolValidationError extends Error {
   constructor(error) {
     super(error.reason);
@@ -237,6 +243,318 @@ function fail(errorId, options = {}) {
 
 function pass() {
   return validationResult([]);
+}
+
+function assertValid(result) {
+  if (!result.valid) {
+    throw new JarvisProtocolValidationError(
+      result.errors[0] ?? protocolError("invalid_export"),
+    );
+  }
+}
+
+function helperError(field, reason) {
+  return new JarvisProtocolValidationError(protocolError("invalid_export", {
+    objectType: "ProtocolHelper",
+    field,
+    reason,
+  }));
+}
+
+function successfulStatus(binding) {
+  return [...binding.statuses].sort((left, right) => left - right).find((status) => status < 400);
+}
+
+function operationWorkSessionScoped(binding) {
+  return binding.path.startsWith("/work-sessions");
+}
+
+function buildHeadersForOperation(binding, options) {
+  if (options.headers) {
+    return options.headers;
+  }
+  const shared = {
+    actorId: options.actorId,
+    authorization: options.authorization,
+    protocolVersion: options.protocolVersion,
+    validationOptions: options.validationOptions,
+  };
+  if (binding.method === "GET") {
+    return createReadHeaders(shared);
+  }
+  if (!operationWorkSessionScoped(binding)) {
+    return createNonWorkSessionMutationHeaders({
+      ...shared,
+      idempotencyKey: options.idempotencyKey,
+      requestTimestamp: options.requestTimestamp,
+    });
+  }
+  return createWorkSessionMutationHeaders({
+    ...shared,
+    idempotencyKey: options.idempotencyKey,
+    requestTimestamp: options.requestTimestamp,
+    expectedWorkSessionRevision: options.expectedWorkSessionRevision,
+    previousEventHash: options.previousEventHash,
+  });
+}
+
+function pathParamsForOperation(options) {
+  return {
+    ...(options.pathParams ?? {}),
+    worker_id: options.workerId ?? options.pathParams?.worker_id,
+    actor_id: options.targetActorId ?? options.pathParams?.actor_id,
+    work_session_id: options.workSessionId ?? options.pathParams?.work_session_id,
+  };
+}
+
+function invalidEventHashError(field, reason) {
+  return new JarvisProtocolValidationError(protocolError("invalid_event_hash", {
+    objectType: "JarvisEvent",
+    field,
+    reason,
+  }));
+}
+
+function invalidEvidenceRootError(field, reason) {
+  return new JarvisProtocolValidationError(protocolError("invalid_evidence_export_state", {
+    objectType: "EvidenceManifest",
+    field,
+    reason,
+  }));
+}
+
+function lastEventForWorkSession(events, workSessionId) {
+  if (!Array.isArray(events) || events.length === 0) {
+    return null;
+  }
+  if (!isNonEmptyString(workSessionId)) {
+    throw helperError("work_session_id", "work_session_id is required when JarvisEvents are supplied.");
+  }
+  const mismatch = events.find((event) => {
+    return isPlainObject(event) && event.work_session_id !== workSessionId;
+  });
+  if (mismatch) {
+    throw helperError("events.work_session_id", "JarvisEvents MUST belong to the target WorkSession.");
+  }
+  return [...events]
+    .filter((event) => isPlainObject(event) && isInteger(event.sequence))
+    .sort((left, right) => right.sequence - left.sequence)[0] ?? null;
+}
+
+function eventHashFor(eventWithoutHash, callerHash) {
+  const computedHash = hashProtocolValue(eventWithoutHash);
+  if (callerHash !== undefined && callerHash !== computedHash) {
+    throw invalidEventHashError(
+      "event_hash",
+      "JarvisEvent.event_hash MUST match the canonical hash of the event body.",
+    );
+  }
+  return computedHash;
+}
+
+function assertManifestRoot(workSession, events, eventChainRoot) {
+  const workSessionHash = workSession?.last_event_hash;
+  if (!isNonEmptyString(workSessionHash)) {
+    throw invalidEvidenceRootError(
+      "work_session.last_event_hash",
+      "EvidenceManifest export requires a terminal WorkSession last_event_hash.",
+    );
+  }
+  if (eventChainRoot !== undefined && eventChainRoot !== workSessionHash) {
+    throw invalidEvidenceRootError(
+      "event_chain_root",
+      "EvidenceManifest.event_chain_root MUST match WorkSession.last_event_hash.",
+    );
+  }
+  if (Array.isArray(events) && events.length > 0) {
+    assertValid(validateEventHashChain(events));
+    const previous = lastEventForWorkSession(events, workSession?.id);
+    if (previous?.event_hash !== workSessionHash) {
+      throw invalidEvidenceRootError(
+        "event_chain_root",
+        "EvidenceManifest event chain root MUST match the terminal WorkSession last_event_hash.",
+      );
+    }
+  }
+  return workSessionHash;
+}
+
+export function createReadHeaders(options = {}) {
+  const headers = {
+    Authorization: options.authorization,
+    "Jarvis-Protocol-Version": options.protocolVersion ?? PROTOCOL_VERSION,
+    "Jarvis-Actor-Id": options.actorId,
+  };
+  assertValid(validateReadHeaders(headers, options.validationOptions));
+  return headers;
+}
+
+export function createNonWorkSessionMutationHeaders(options = {}) {
+  const headers = {
+    Authorization: options.authorization,
+    "Jarvis-Protocol-Version": options.protocolVersion ?? PROTOCOL_VERSION,
+    "Jarvis-Actor-Id": options.actorId,
+    "Jarvis-Idempotency-Key": options.idempotencyKey,
+    "Jarvis-Request-Timestamp": options.requestTimestamp,
+  };
+  assertValid(validateMutationHeaders(headers, {
+    ...(options.validationOptions ?? {}),
+    workSessionScoped: false,
+  }));
+  return headers;
+}
+
+export function createWorkSessionMutationHeaders(options = {}) {
+  const headers = {
+    Authorization: options.authorization,
+    "Jarvis-Protocol-Version": options.protocolVersion ?? PROTOCOL_VERSION,
+    "Jarvis-Actor-Id": options.actorId,
+    "Jarvis-Idempotency-Key": options.idempotencyKey,
+    "Jarvis-Request-Timestamp": options.requestTimestamp,
+    "Jarvis-Expected-WorkSession-Revision": options.expectedWorkSessionRevision,
+    "Jarvis-Previous-Event-Hash": options.previousEventHash,
+  };
+  assertValid(validateMutationHeaders(headers, options.validationOptions));
+  return headers;
+}
+
+export function createMutationHeaders(options = {}) {
+  if (options.workSessionScoped === false) {
+    return createNonWorkSessionMutationHeaders(options);
+  }
+  return createWorkSessionMutationHeaders(options);
+}
+
+export function getOperationBinding(operationId) {
+  const binding = OPERATION_BINDINGS_BY_ID[operationId];
+  if (!binding) {
+    throw helperError("operation_id", "operation_id MUST exist in the Jarvis OpenAPI binding.");
+  }
+  return {
+    method: binding.method,
+    path: binding.path,
+    statuses: [...binding.statuses].sort((left, right) => left - right),
+  };
+}
+
+export function createOperationPath(operationId, pathParams = {}) {
+  const binding = getOperationBinding(operationId);
+  return binding.path.replace(/\{([^/]+)\}/g, (_match, key) => {
+    const value = pathParams[key];
+    if (!isNonEmptyString(value)) {
+      throw helperError(`path.${key}`, `${key} is required for ${operationId}.`);
+    }
+    return encodeURIComponent(value);
+  });
+}
+
+export function createOperationEnvelope(options = {}) {
+  const operationId = options.operationId;
+  const binding = getOperationBinding(operationId);
+  const path = options.path ?? createOperationPath(operationId, pathParamsForOperation(options));
+  const headers = buildHeadersForOperation(OPERATION_BINDINGS_BY_ID[operationId], options);
+  const pathValues = operationPathValues({ operation_id: operationId, path });
+  const operation = {
+    operation_id: operationId,
+    method: binding.method,
+    path,
+    headers,
+    actor_id: options.actorId,
+    expected_status: options.expectedStatus ?? successfulStatus(OPERATION_BINDINGS_BY_ID[operationId]),
+  };
+  if (options.expectedErrorId) {
+    operation.expected_error_id = options.expectedErrorId;
+  }
+  if (options.expectedErrorField) {
+    operation.expected_error_field = options.expectedErrorField;
+  }
+  if (options.workSessionId ?? pathValues.work_session_id) {
+    operation.work_session_id = options.workSessionId ?? pathValues.work_session_id;
+  }
+  if (options.bodyRef) {
+    operation.body_ref = options.bodyRef;
+  }
+  if (options.attemptedTakeoverLockEpoch !== undefined) {
+    operation.attempted_takeover_lock_epoch = options.attemptedTakeoverLockEpoch;
+  }
+  const bindingError = operationBindingError(operation);
+  if (bindingError) {
+    throw new JarvisProtocolValidationError(bindingError);
+  }
+  assertValid(validateOperationHeaders(operation, options.validationOptions));
+  return operation;
+}
+
+export function createJarvisEvent(options = {}) {
+  const hashInput = {
+    id: options.id,
+    sequence: options.sequence,
+    type: options.type,
+    work_session_id: options.workSessionId,
+    actor_id: options.actorId,
+    timestamp: options.timestamp,
+    payload: options.payload,
+    previous_hash: options.previousHash ?? "hash:protocol-genesis",
+    canonicalization: options.canonicalization ?? DEFAULT_CANONICALIZATION,
+  };
+  if (options.traceContext) {
+    hashInput.trace_context = options.traceContext;
+  }
+  const event = {
+    ...hashInput,
+    event_hash: eventHashFor(hashInput, options.eventHash),
+  };
+  if (options.actorSignature) {
+    event.actor_signature = options.actorSignature;
+  }
+  if (options.signingKeyRef) {
+    event.signing_key_ref = options.signingKeyRef;
+  }
+  assertValid(validateProtocolRecord("JarvisEvent", event));
+  return event;
+}
+
+export function createNextJarvisEvent(options = {}) {
+  const previous = lastEventForWorkSession(options.events ?? [], options.workSessionId);
+  return createJarvisEvent({
+    ...options,
+    sequence: options.sequence ?? (previous ? previous.sequence + 1 : 1),
+    previousHash: options.previousHash ?? (previous ? previous.event_hash : "hash:protocol-genesis"),
+  });
+}
+
+export function createEvidenceManifest(options = {}) {
+  const workSession = options.workSession;
+  const root = assertManifestRoot(workSession, options.events ?? [], options.eventChainRoot);
+  const manifest = {
+    id: options.id,
+    work_session_id: options.workSessionId ?? workSession?.id,
+    generated_by_actor_id: options.generatedByActorId,
+    objective: options.objective ?? workSession?.objective,
+    event_chain_root: root,
+    evidence_item_refs: options.evidenceItemRefs ?? [],
+    policy_decision_refs: options.policyDecisionRefs ?? [],
+    request_refs: options.requestRefs ?? [],
+    review_refs: options.reviewRefs ?? [],
+    takeover_refs: options.takeoverRefs ?? [],
+    contribution_refs: options.contributionRefs ?? [],
+    export_profile: options.exportProfile ?? {
+      profile: "portable_evidence_manifest",
+      version: PROTOCOL_VERSION,
+    },
+    generated_at: options.generatedAt,
+  };
+  if (options.artifactRefs) {
+    manifest.artifact_refs = options.artifactRefs;
+  }
+  if (options.limitationRefs) {
+    manifest.limitation_refs = options.limitationRefs;
+  }
+  if (options.redactionRefs) {
+    manifest.redaction_refs = options.redactionRefs;
+  }
+  assertValid(validateEvidenceManifest(manifest, { workSession }));
+  return manifest;
 }
 
 function isPlainObject(value) {
@@ -337,6 +655,26 @@ function operationPathMatchesTemplate(template, path) {
   return new RegExp(pattern).test(path);
 }
 
+function operationPathValues(operation) {
+  const binding = OPERATION_BINDINGS_BY_ID[operation?.operation_id];
+  if (!binding || !isNonEmptyString(operation?.path)) {
+    return {};
+  }
+  const templateSegments = binding.path.split("/");
+  const pathSegments = operation.path.split("/");
+  if (templateSegments.length !== pathSegments.length) {
+    return {};
+  }
+  const values = {};
+  for (let index = 0; index < templateSegments.length; index += 1) {
+    const match = templateSegments[index].match(/^\{([^/]+)\}$/);
+    if (match) {
+      values[match[1]] = decodeURIComponent(pathSegments[index]);
+    }
+  }
+  return values;
+}
+
 function operationBindingError(operation) {
   const operationId = operation?.operation_id;
   const binding = OPERATION_BINDINGS_BY_ID[operationId];
@@ -366,6 +704,17 @@ function operationBindingError(operation) {
       objectType: "FixtureOperation",
       field: "expected_status",
       reason: "Fixture operation expected_status MUST match the Jarvis OpenAPI binding.",
+    });
+  }
+  const pathValues = operationPathValues(operation);
+  if (
+    isNonEmptyString(pathValues.work_session_id)
+    && operation.work_session_id !== pathValues.work_session_id
+  ) {
+    return protocolError("path_body_id_mismatch", {
+      objectType: "FixtureOperation",
+      field: "work_session_id",
+      reason: "operation.work_session_id MUST match the concrete WorkSession path id.",
     });
   }
   return null;
@@ -438,6 +787,17 @@ function evidenceManifestSourceWorkSession(fixture, evidenceManifest, operation)
 }
 
 function operationBodyBindingError(operation, body) {
+  const pathValues = operationPathValues(operation);
+  if (
+    isNonEmptyString(pathValues.work_session_id)
+    && isPlainObject(body)
+    && body.work_session_id !== pathValues.work_session_id
+  ) {
+    return protocolError("path_body_id_mismatch", {
+      field: "work_session_id",
+      reason: "body.work_session_id MUST match the concrete WorkSession path id.",
+    });
+  }
   const actorBodyField = ACTOR_BODY_FIELD_BY_OPERATION[operation?.operation_id];
   if (!actorBodyField || !isPlainObject(body)) {
     return null;
@@ -562,6 +922,13 @@ function evidenceManifestExportError(evidenceManifest, workSession) {
       reason: "EvidenceManifest source WorkSession id MUST match EvidenceManifest.work_session_id.",
     });
   }
+  if (workSession?.last_event_hash && evidenceManifest?.event_chain_root !== workSession.last_event_hash) {
+    return protocolError("invalid_evidence_export_state", {
+      objectType: "EvidenceManifest",
+      field: "event_chain_root",
+      reason: "EvidenceManifest.event_chain_root MUST match WorkSession.last_event_hash.",
+    });
+  }
   return null;
 }
 
@@ -614,7 +981,7 @@ export function validateSchemaRecord(objectType, record) {
   }
   const required = SCHEMA_REQUIRED_FIELDS[objectType] ?? [];
   for (const field of required) {
-    if (!(field in record)) {
+    if (!(field in record) || record[field] === undefined || record[field] === null) {
       return fail("invalid_export", {
         objectType,
         field,
@@ -683,7 +1050,7 @@ export function validateHeaders(headers, options = {}) {
   }
   const requiredHeaders = options.requiredHeaders ?? WORKSESSION_MUTATION_HEADERS;
   for (const header of requiredHeaders) {
-    if (!(header in headers)) {
+    if (!(header in headers) || headers[header] === undefined || headers[header] === null) {
       return fail(MISSING_HEADER_ERROR_IDS[header] ?? "invalid_export", {
         field: `headers.${header}`,
         reason: `${header} is required.`,
@@ -747,13 +1114,13 @@ export function validateHeaders(headers, options = {}) {
   return pass();
 }
 
-export function validateOperationHeaders(operation) {
+export function validateOperationHeaders(operation, options = {}) {
   const method = operationMethod(operation);
   const path = operationPath(operation);
   const workSessionScoped = path.startsWith("/work-sessions");
   const headerResult = method === "GET"
-    ? validateReadHeaders(operation?.headers)
-    : validateMutationHeaders(operation?.headers, { workSessionScoped });
+    ? validateReadHeaders(operation?.headers, options)
+    : validateMutationHeaders(operation?.headers, { ...options, workSessionScoped });
   if (!headerResult.valid) {
     return headerResult;
   }
@@ -915,6 +1282,13 @@ export function validateEvidenceManifest(evidenceManifest, options = {}) {
   const exportError = evidenceManifestExportError(evidenceManifest, options.workSession);
   if (exportError) {
     return validationResult([exportError]);
+  }
+  if (!Array.isArray(evidenceManifest.evidence_item_refs) || evidenceManifest.evidence_item_refs.length === 0) {
+    return fail("invalid_export", {
+      objectType: "EvidenceManifest",
+      field: "evidence_item_refs",
+      reason: "EvidenceManifest.evidence_item_refs MUST contain at least one evidence item.",
+    });
   }
   if (Array.isArray(evidenceManifest.evidence_item_refs)) {
     for (let index = 0; index < evidenceManifest.evidence_item_refs.length; index += 1) {

--- a/packages/typescript/src/index.js
+++ b/packages/typescript/src/index.js
@@ -437,6 +437,12 @@ export function getOperationBinding(operationId) {
   };
 }
 
+function encodePathParam(value) {
+  return encodeURIComponent(value).replace(/[!'()*]/g, (char) => {
+    return `%${char.charCodeAt(0).toString(16).toUpperCase()}`;
+  });
+}
+
 export function createOperationPath(operationId, pathParams = {}) {
   const binding = getOperationBinding(operationId);
   return binding.path.replace(/\{([^/]+)\}/g, (_match, key) => {
@@ -444,7 +450,7 @@ export function createOperationPath(operationId, pathParams = {}) {
     if (!isNonEmptyString(value)) {
       throw helperError(`path.${key}`, `${key} is required for ${operationId}.`);
     }
-    return encodeURIComponent(value);
+    return encodePathParam(value);
   });
 }
 

--- a/packages/typescript/tests/helpers.test.js
+++ b/packages/typescript/tests/helpers.test.js
@@ -84,6 +84,10 @@ test("operation helper binds OpenAPI method path status headers and actor", () =
     createOperationPath("exportEvidenceManifest", { work_session_id: "ws-test" }),
     "/work-sessions/ws-test/export",
   );
+  assert.equal(
+    createOperationPath("exportEvidenceManifest", { work_session_id: "ws-!'()*" }),
+    "/work-sessions/ws-%21%27%28%29%2A/export",
+  );
 
   const operation = createOperationEnvelope({
     operationId: "exportEvidenceManifest",
@@ -104,6 +108,26 @@ test("operation helper binds OpenAPI method path status headers and actor", () =
     expected_status: 200,
     work_session_id: "ws-test",
   });
+  assert.equal(validateOperationHeaders(operation).valid, true);
+});
+
+test("operation helper preserves caller-provided headers", () => {
+  const headers = createWorkSessionMutationHeaders({
+    actorId: "actor-human-test",
+    authorization: AUTHORIZATION,
+    idempotencyKey: "idem-test",
+    requestTimestamp: "2026-06-16T10:00:00Z",
+    expectedWorkSessionRevision: 0,
+    previousEventHash: "hash:protocol-genesis",
+  });
+  const operation = createOperationEnvelope({
+    operationId: "appendJarvisEvent",
+    actorId: "actor-human-test",
+    headers,
+    workSessionId: "ws-test",
+    bodyRef: "records.jarvis_events.created",
+  });
+  assert.equal(operation.headers, headers);
   assert.equal(validateOperationHeaders(operation).valid, true);
 });
 

--- a/packages/typescript/tests/helpers.test.js
+++ b/packages/typescript/tests/helpers.test.js
@@ -3,8 +3,17 @@ import test from "node:test";
 
 import {
   canonicalizeProtocolValue,
+  createEvidenceManifest,
+  createJarvisEvent,
+  createNextJarvisEvent,
+  createOperationEnvelope,
+  createOperationPath,
+  createReadHeaders,
+  createWorkSessionMutationHeaders,
   findForbiddenHostPrivateField,
+  getOperationBinding,
   hashProtocolValue,
+  JarvisProtocolValidationError,
   protocolError,
   validateEvidenceManifest,
   validateEventHashChain,
@@ -15,6 +24,8 @@ import {
   validateProtocolRecord,
   validateReadHeaders,
 } from "../src/index.js";
+
+const AUTHORIZATION = "HostAuth test";
 
 test("mutation headers enforce WorkSession-scoped zero-trust requirements", () => {
   const missing = validateMutationHeaders({
@@ -39,6 +50,281 @@ test("mutation headers enforce WorkSession-scoped zero-trust requirements", () =
   assert.equal(accepted.valid, true);
 });
 
+test("header helpers create valid read and WorkSession mutation headers", () => {
+  const readHeaders = createReadHeaders({
+    actorId: "actor-human-test",
+    authorization: AUTHORIZATION,
+  });
+  assert.deepEqual(readHeaders, {
+    Authorization: AUTHORIZATION,
+    "Jarvis-Protocol-Version": "v0.1",
+    "Jarvis-Actor-Id": "actor-human-test",
+  });
+  assert.equal(validateReadHeaders(readHeaders).valid, true);
+
+  const mutationHeaders = createWorkSessionMutationHeaders({
+    actorId: "actor-human-test",
+    authorization: AUTHORIZATION,
+    idempotencyKey: "idem-test",
+    requestTimestamp: "2026-06-16T10:00:00Z",
+    expectedWorkSessionRevision: 0,
+    previousEventHash: "hash:protocol-genesis",
+  });
+  assert.equal(validateMutationHeaders(mutationHeaders).valid, true);
+});
+
+test("operation helper binds OpenAPI method path status headers and actor", () => {
+  const binding = getOperationBinding("exportEvidenceManifest");
+  assert.deepEqual(binding, {
+    method: "GET",
+    path: "/work-sessions/{work_session_id}/export",
+    statuses: [200, 400],
+  });
+  assert.equal(
+    createOperationPath("exportEvidenceManifest", { work_session_id: "ws-test" }),
+    "/work-sessions/ws-test/export",
+  );
+
+  const operation = createOperationEnvelope({
+    operationId: "exportEvidenceManifest",
+    actorId: "actor-human-test",
+    authorization: AUTHORIZATION,
+    workSessionId: "ws-test",
+  });
+  assert.deepEqual(operation, {
+    operation_id: "exportEvidenceManifest",
+    method: "GET",
+    path: "/work-sessions/ws-test/export",
+    headers: {
+      Authorization: AUTHORIZATION,
+      "Jarvis-Protocol-Version": "v0.1",
+      "Jarvis-Actor-Id": "actor-human-test",
+    },
+    actor_id: "actor-human-test",
+    expected_status: 200,
+    work_session_id: "ws-test",
+  });
+  assert.equal(validateOperationHeaders(operation).valid, true);
+});
+
+test("event and EvidenceManifest helpers build records accepted by validators", () => {
+  const created = createNextJarvisEvent({
+    id: "event-created",
+    type: "work_session.created",
+    workSessionId: "ws-test",
+    actorId: "actor-human-test",
+    timestamp: "2026-06-16T10:00:00Z",
+    payload: {
+      object_type: "work_session",
+      object_id: "ws-test",
+      action: "created",
+    },
+  });
+  const completed = createNextJarvisEvent({
+    events: [created],
+    id: "event-completed",
+    type: "work_session.completed",
+    workSessionId: "ws-test",
+    actorId: "actor-human-test",
+    timestamp: "2026-06-16T10:10:00Z",
+    payload: {
+      object_type: "work_session",
+      object_id: "ws-test",
+      action: "completed",
+    },
+  });
+  assert.equal(created.sequence, 1);
+  assert.equal(completed.sequence, 2);
+  assert.equal(completed.previous_hash, created.event_hash);
+  assert.equal(validateEventHashChain([created, completed]).valid, true);
+
+  const workSession = {
+    id: "ws-test",
+    objective: "Prove helper-created protocol records.",
+    status: "completed",
+    last_event_hash: completed.event_hash,
+  };
+  const manifest = createEvidenceManifest({
+    id: "evidence-test",
+    workSession,
+    events: [created, completed],
+    generatedByActorId: "actor-human-test",
+    generatedAt: "2026-06-16T10:11:00Z",
+    evidenceItemRefs: [
+      {
+        id: "evidence-item-test",
+        work_session_id: "ws-test",
+        source_event_refs: ["event-completed"],
+        captured_by_actor_id: "actor-human-test",
+        evidence_type: "artifact",
+        artifact_ref: "artifact:test",
+        content_hash: "hash:content",
+        trust_label: "verified",
+        redaction_state: "none",
+        captured_at: "2026-06-16T10:10:00Z",
+        limitation_refs: [],
+      },
+    ],
+  });
+  assert.equal(manifest.event_chain_root, completed.event_hash);
+  assert.equal(validateEvidenceManifest(manifest, { workSession }).valid, true);
+});
+
+test("event helper computes hash before optional signature metadata", () => {
+  const base = {
+    id: "event-signed",
+    sequence: 1,
+    type: "work_session.created",
+    workSessionId: "ws-test",
+    actorId: "actor-human-test",
+    timestamp: "2026-06-16T10:00:00Z",
+    payload: {
+      object_type: "work_session",
+      object_id: "ws-test",
+      action: "created",
+    },
+  };
+  const unsigned = createJarvisEvent(base);
+  const signed = createJarvisEvent({
+    ...base,
+    actorSignature: "signature:test",
+    signingKeyRef: "signing-key:test",
+  });
+  assert.equal(signed.event_hash, unsigned.event_hash);
+  assert.equal(signed.actor_signature, "signature:test");
+});
+
+test("event helper rejects mismatched caller-supplied event hash", () => {
+  assert.throws(
+    () => createJarvisEvent({
+      id: "event-bad-hash",
+      sequence: 1,
+      type: "work_session.created",
+      workSessionId: "ws-test",
+      actorId: "actor-human-test",
+      timestamp: "2026-06-16T10:00:00Z",
+      payload: {
+        object_type: "work_session",
+        object_id: "ws-test",
+        action: "created",
+      },
+      eventHash: "hash:not-the-canonical-event",
+    }),
+    (error) => error instanceof JarvisProtocolValidationError
+      && error.error.error_id === "invalid_event_hash",
+  );
+});
+
+test("next event helper rejects cross-WorkSession event linkage", () => {
+  const other = createNextJarvisEvent({
+    id: "event-other",
+    type: "work_session.created",
+    workSessionId: "ws-other",
+    actorId: "actor-human-test",
+    timestamp: "2026-06-16T10:00:00Z",
+    payload: {
+      object_type: "work_session",
+      object_id: "ws-other",
+      action: "created",
+    },
+  });
+  assert.throws(
+    () => createNextJarvisEvent({
+      events: [other],
+      id: "event-wrong-link",
+      type: "work_session.completed",
+      workSessionId: "ws-test",
+      actorId: "actor-human-test",
+      timestamp: "2026-06-16T10:10:00Z",
+      payload: {
+        object_type: "work_session",
+        object_id: "ws-test",
+        action: "completed",
+      },
+    }),
+    (error) => error instanceof JarvisProtocolValidationError
+      && error.error.error_id === "invalid_export",
+  );
+});
+
+test("operation helper rejects concrete path WorkSession mismatch", () => {
+  assert.throws(
+    () => createOperationEnvelope({
+      operationId: "appendJarvisEvent",
+      actorId: "actor-human-test",
+      authorization: AUTHORIZATION,
+      path: "/work-sessions/ws-other/events",
+      workSessionId: "ws-test",
+      idempotencyKey: "idem-test",
+      requestTimestamp: "2026-06-16T10:00:00Z",
+      expectedWorkSessionRevision: 0,
+      previousEventHash: "hash:protocol-genesis",
+      bodyRef: "records.jarvis_events.created",
+    }),
+    (error) => error instanceof JarvisProtocolValidationError
+      && error.error.error_id === "path_body_id_mismatch",
+  );
+});
+
+test("EvidenceManifest helper rejects empty refs and root drift", () => {
+  const event = createNextJarvisEvent({
+    id: "event-root",
+    type: "work_session.completed",
+    workSessionId: "ws-test",
+    actorId: "actor-human-test",
+    timestamp: "2026-06-16T10:10:00Z",
+    payload: {
+      object_type: "work_session",
+      object_id: "ws-test",
+      action: "completed",
+    },
+  });
+  const workSession = {
+    id: "ws-test",
+    objective: "Reject malformed manifest helpers.",
+    status: "completed",
+    last_event_hash: event.event_hash,
+  };
+  assert.throws(
+    () => createEvidenceManifest({
+      id: "evidence-empty",
+      workSession,
+      events: [event],
+      generatedByActorId: "actor-human-test",
+      generatedAt: "2026-06-16T10:11:00Z",
+    }),
+    (error) => error instanceof JarvisProtocolValidationError
+      && error.error.error_id === "invalid_export",
+  );
+  assert.throws(
+    () => createEvidenceManifest({
+      id: "evidence-root-drift",
+      workSession,
+      events: [event],
+      eventChainRoot: "hash:wrong-root",
+      generatedByActorId: "actor-human-test",
+      generatedAt: "2026-06-16T10:11:00Z",
+      evidenceItemRefs: [
+        {
+          id: "evidence-item-test",
+          work_session_id: "ws-test",
+          source_event_refs: ["event-root"],
+          captured_by_actor_id: "actor-human-test",
+          evidence_type: "artifact",
+          artifact_ref: "artifact:test",
+          content_hash: "hash:content",
+          trust_label: "verified",
+          redaction_state: "none",
+          captured_at: "2026-06-16T10:10:00Z",
+          limitation_refs: [],
+        },
+      ],
+    }),
+    (error) => error instanceof JarvisProtocolValidationError
+      && error.error.error_id === "invalid_evidence_export_state",
+  );
+});
+
 test("required identity and replay headers reject empty values", () => {
   const result = validateMutationHeaders({
     Authorization: " ",
@@ -51,6 +337,28 @@ test("required identity and replay headers reject empty values", () => {
   });
   assert.equal(result.valid, false);
   assert.equal(result.errors[0].field, "headers.Authorization");
+});
+
+test("required mutation headers reject undefined values", () => {
+  const baseHeaders = {
+    Authorization: "HostAuth test",
+    "Jarvis-Protocol-Version": "v0.1",
+    "Jarvis-Actor-Id": "actor-test",
+    "Jarvis-Idempotency-Key": "idem-test",
+    "Jarvis-Request-Timestamp": "2026-06-16T10:00:00Z",
+    "Jarvis-Expected-WorkSession-Revision": 0,
+    "Jarvis-Previous-Event-Hash": "hash:protocol-genesis",
+  };
+  for (const [header, errorId] of [
+    ["Jarvis-Request-Timestamp", "missing_request_timestamp"],
+    ["Jarvis-Expected-WorkSession-Revision", "missing_expected_work_session_revision"],
+    ["Jarvis-Previous-Event-Hash", "missing_previous_event_hash"],
+  ]) {
+    const headers = { ...baseHeaders, [header]: undefined };
+    const result = validateMutationHeaders(headers);
+    assert.equal(result.valid, false, header);
+    assert.equal(result.errors[0].error_id, errorId);
+  }
 });
 
 test("ApprovalScope requires review timestamp when review context is present", () => {
@@ -236,6 +544,16 @@ test("EvidenceManifest export requires terminal WorkSession source", () => {
   assert.equal(wrongSource.valid, false);
   assert.equal(wrongSource.errors[0].error_id, "invalid_evidence_export_state");
   assert.equal(wrongSource.errors[0].field, "work_session_id");
+
+  const rootDrift = validateEvidenceManifest(
+    { ...manifest, event_chain_root: "hash:wrong-root" },
+    {
+      workSession: { id: "ws-test", status: "completed", last_event_hash: "hash:root" },
+    },
+  );
+  assert.equal(rootDrift.valid, false);
+  assert.equal(rootDrift.errors[0].error_id, "invalid_evidence_export_state");
+  assert.equal(rootDrift.errors[0].field, "event_chain_root");
 });
 
 test("protocol error helper emits the OpenAPI error envelope", () => {


### PR DESCRIPTION
## Summary

- Add protocol-only helper constructors for TypeScript and Python SDK packages.
- Create read, non-WorkSession mutation, and WorkSession mutation headers with validation.
- Add operation binding/path/envelope helpers, JarvisEvent builders, and EvidenceManifest builders.
- Tighten SDK validation for required values, concrete path/body WorkSession matching, EvidenceManifest root integrity, and evidence item presence.
- Add end-to-end tests proving helper-created protocol records validate without adding host runtime behavior.

## Protocol Surface

- TypeScript SDK root exports helper constructors for headers, operation paths/envelopes, JarvisEvents, and EvidenceManifests.
- Python SDK root exports matching helper constructors for headers, operation paths/envelopes, JarvisEvents, and EvidenceManifests.
- SDK validators enforce required header values, path/body WorkSession ID matching, canonical event hash rules, non-empty EvidenceManifest evidence refs, and EvidenceManifest root consistency with `WorkSession.last_event_hash`.

## Boundary Check

- [x] This change keeps Jarvis protocol-only.
- [x] This change does not add host runtime, UI, auth, storage, billing, model orchestration, tool execution, scoring, payment, deployment, adapter, or wrapper code.

## Compatibility Impact

- Compatible implementations can construct protocol records through SDK helpers instead of hand-building headers, operation envelopes, events, and evidence manifests.
- Existing validators and fixture snapshots remain available.
- The SDK rejects malformed helper-created records earlier; hosts still own transport, auth, storage, execution, and workflow.

## Conformance Impact

- Adds helper tests for canonical event hashing, signature metadata exclusion, WorkSession-scoped event linkage, path/body WorkSession ID matching, EvidenceManifest root consistency, and evidence ref presence.
- Adds coverage for caller-provided operation headers and strict TypeScript path encoding parity with Python.

## Validation

- [x] `npm --workspace @jarvis-protocol/sdk test`
- [x] `npm run test:python`
- [x] `node --check packages/typescript/src/index.js && python3 -m py_compile packages/python/src/jarvis_protocol/__init__.py`
- [x] `npm run test:cli`
- [x] `npm run check:protocol`
- [x] `git diff --check`

## Review Notes

Internal reviewer findings were addressed before opening this PR:

- event hashes must match canonical event body hashes
- signature metadata is excluded from event hash computation
- next-event helpers reject cross-WorkSession linkage
- EvidenceManifest helper and validator reject root drift from `WorkSession.last_event_hash`
- EvidenceManifest requires at least one evidence item
- operation envelopes reject concrete WorkSession path/body mismatch
- required mutation headers reject undefined/null values

CodeRabbit findings addressed after review:

- TypeScript path encoding now percent-encodes `!'()*` to match Python `quote(..., safe="")`
- TypeScript tests cover `createOperationEnvelope` with caller-provided headers