### PR TITLE
[codex] Improve docs site foundation

### DIFF
--- a/demo/assets/styles.css
+++ b/demo/assets/styles.css
@@ -500,7 +500,8 @@ a {
 .example-grid,
 .package-grid,
 .reference-grid,
-.implementation-steps {
+.implementation-steps,
+.guide-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 12px;
@@ -550,12 +551,6 @@ a {
 
 .reference-grid p {
   margin-top: 8px;
-}
-
-.guide-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
 }
 
 .guide-grid a {

--- a/demo/assets/styles.css
+++ b/demo/assets/styles.css
@@ -136,8 +136,10 @@ a {
 .topnav a:focus-visible,
 .command:focus-visible,
 .doc-card a:focus-visible,
+.docs-map a:focus-visible,
 .link-table a:focus-visible,
 .example-grid a:focus-visible,
+.guide-grid a:focus-visible,
 .package-grid a:focus-visible,
 .brand:focus-visible {
   outline: 2px solid var(--mint);
@@ -309,10 +311,14 @@ a {
 .mission-panel,
 .simulator,
 .doc-card,
+.docs-map a,
 .spine-list article,
 .example-grid article,
 .package-grid article,
+.reference-grid article,
+.implementation-steps article,
 .boundary-strip article,
+.guide-grid a,
 .rail,
 .operating-stage,
 .sequence {
@@ -329,6 +335,53 @@ a {
   grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 14px;
   margin: 10px 0 14px;
+}
+
+.docs-map {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+  margin: 14px 0;
+}
+
+.docs-map a {
+  min-height: 190px;
+  display: grid;
+  align-content: start;
+  gap: 12px;
+  border-radius: 8px;
+  padding: 18px;
+  color: inherit;
+  text-decoration: none;
+}
+
+.docs-map a:hover {
+  border-color: rgb(120 247 180 / 62%);
+}
+
+.docs-map span,
+.implementation-steps span {
+  color: var(--mint);
+  font-size: 0.76rem;
+  font-weight: 950;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.docs-map strong {
+  color: var(--ink);
+  font-size: 1.08rem;
+  line-height: 1.28;
+}
+
+.docs-map p,
+.reference-grid li,
+.reference-grid p,
+.implementation-steps p,
+.guide-grid small {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.55;
 }
 
 .doc-card {
@@ -373,7 +426,8 @@ a {
 .doc-card a,
 .link-table a,
 .example-grid a,
-.package-grid a {
+.package-grid a,
+.guide-grid a {
   color: var(--mint);
   font-weight: 900;
   text-decoration: none;
@@ -382,7 +436,8 @@ a {
 .doc-card a:hover,
 .link-table a:hover,
 .example-grid a:hover,
-.package-grid a:hover {
+.package-grid a:hover,
+.guide-grid a:hover {
   color: var(--cyan);
 }
 
@@ -390,6 +445,10 @@ a {
 .spec-grid,
 .examples-section,
 .sdk-section,
+.openapi-section,
+.guides-section,
+.implementation-section,
+.release-section,
 .conformance-band {
   display: grid;
   gap: 18px;
@@ -406,7 +465,10 @@ a {
 .protocol-section,
 .spec-grid,
 .examples-section,
-.sdk-section {
+.sdk-section,
+.openapi-section,
+.guides-section,
+.implementation-section {
   grid-template-columns: minmax(360px, 0.56fr) minmax(0, 1fr);
   padding: 22px;
 }
@@ -427,9 +489,18 @@ a {
   max-width: 760px;
 }
 
+.inline-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 22px;
+}
+
 .spine-list,
 .example-grid,
-.package-grid {
+.package-grid,
+.reference-grid,
+.implementation-steps {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 12px;
@@ -437,7 +508,9 @@ a {
 
 .spine-list article,
 .example-grid article,
-.package-grid article {
+.package-grid article,
+.reference-grid article,
+.implementation-steps article {
   min-height: 145px;
   display: grid;
   align-content: start;
@@ -448,9 +521,82 @@ a {
 
 .spine-list strong,
 .example-grid h3,
-.package-grid h3 {
+.package-grid h3,
+.reference-grid h3,
+.implementation-steps h3 {
   color: var(--ink);
   font-size: 1.02rem;
+}
+
+.reference-grid article {
+  min-height: 250px;
+}
+
+.reference-grid ul {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.reference-grid li {
+  padding: 9px 11px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgb(255 255 255 / 4%);
+  overflow-wrap: anywhere;
+}
+
+.reference-grid p {
+  margin-top: 8px;
+}
+
+.guide-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.guide-grid a {
+  min-height: 124px;
+  display: grid;
+  align-content: center;
+  gap: 8px;
+  padding: 16px;
+  border-radius: 8px;
+}
+
+.guide-grid a:hover,
+.guide-grid a:focus-visible {
+  border-color: rgb(120 247 180 / 62%);
+  background:
+    linear-gradient(180deg, rgb(120 247 180 / 10%), rgb(255 255 255 / 3%)),
+    rgb(8 12 9 / 90%);
+}
+
+.guide-grid span {
+  color: var(--ink);
+  font-size: 1rem;
+}
+
+.release-section {
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  padding: 22px;
+}
+
+.release-section h2 {
+  margin: 10px 0 0;
+  font-size: clamp(1.8rem, 3vw, 3.1rem);
+  line-height: 1.05;
+}
+
+.release-section p {
+  max-width: 860px;
+  margin: 16px 0 0;
+  color: var(--muted);
+  line-height: 1.62;
 }
 .link-table {
   display: grid;
@@ -1123,6 +1269,10 @@ a {
   .spec-grid,
   .examples-section,
   .sdk-section,
+  .openapi-section,
+  .guides-section,
+  .implementation-section,
+  .release-section,
   .conformance-band {
     grid-template-columns: 1fr;
   }
@@ -1134,8 +1284,12 @@ a {
   .right-stack,
   .story-strip,
   .doc-grid,
+  .docs-map,
   .example-grid,
   .package-grid,
+  .reference-grid,
+  .guide-grid,
+  .implementation-steps,
   .boundary-strip {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -1166,7 +1320,16 @@ a {
   }
 
   .topnav {
+    width: 100%;
+    flex-wrap: nowrap;
     justify-content: flex-start;
+    overflow-x: auto;
+    padding-bottom: 4px;
+    scrollbar-width: thin;
+  }
+
+  .topnav a {
+    flex: 0 0 auto;
   }
 
   .status-chip {
@@ -1234,9 +1397,13 @@ a {
   .right-stack,
   .story-strip,
   .doc-grid,
+  .docs-map,
   .spine-list,
   .example-grid,
   .package-grid,
+  .reference-grid,
+  .guide-grid,
+  .implementation-steps,
   .boundary-strip,
   .phase-brief,
   .sequence ol {
@@ -1249,14 +1416,22 @@ a {
   .spec-grid,
   .examples-section,
   .sdk-section,
+  .openapi-section,
+  .guides-section,
+  .implementation-section,
+  .release-section,
   .conformance-band,
   .operating-stage,
   .sequence,
   .rail,
   .doc-card,
+  .docs-map a,
   .spine-list article,
   .example-grid article,
   .package-grid article,
+  .reference-grid article,
+  .guide-grid a,
+  .implementation-steps article,
   .boundary-strip article,
   .story-strip article {
     width: 100%;
@@ -1280,6 +1455,10 @@ a {
   .spec-grid,
   .examples-section,
   .sdk-section,
+  .openapi-section,
+  .guides-section,
+  .implementation-section,
+  .release-section,
   .conformance-band {
     padding: 10px;
   }

--- a/demo/index.html
+++ b/demo/index.html
@@ -24,11 +24,15 @@
         </a>
         <nav class="topnav" aria-label="Primary documentation links">
           <a href="#start">Start</a>
-          <a href="#protocol">Protocol</a>
           <a href="#spec">Spec</a>
-          <a href="#examples">Examples</a>
+          <a href="#openapi">OpenAPI</a>
           <a href="#conformance">Conformance</a>
+          <a href="#guides">Guides</a>
+          <a href="#examples">Examples</a>
           <a href="#sdk">SDK</a>
+          <a href="#implementation">Implementation</a>
+          <a href="#release">Release</a>
+          <a href="#boundary">Boundary</a>
           <a href="#walkthrough">Walkthrough</a>
         </nav>
         <span class="status-chip">v0.1.0</span>
@@ -62,6 +66,7 @@
             >
               Conformance Checklist
             </a>
+            <a class="command" href="#implementation">Implementation Path</a>
             <a class="command" href="#walkthrough-controls">Run Walkthrough</a>
             <a class="command ghost" href="https://github.com/Flow-Research/jarvis">
               GitHub
@@ -137,6 +142,29 @@
         </article>
       </section>
 
+      <section class="docs-map" aria-label="Documentation map">
+        <a href="#start">
+          <span>Start</span>
+          <strong>Understand Jarvis in 10 minutes.</strong>
+          <p>Read the thesis, boundary, core loop, and WorkSession record.</p>
+        </a>
+        <a href="#openapi">
+          <span>Build</span>
+          <strong>Use the OpenAPI binding and SDK helpers.</strong>
+          <p>Validate headers, records, event hashes, fixtures, and evidence exports.</p>
+        </a>
+        <a href="#conformance">
+          <span>Prove</span>
+          <strong>Run conformance before claiming compatibility.</strong>
+          <p>Compatible implementations prove behavior through records and fixtures.</p>
+        </a>
+        <a href="#boundary">
+          <span>Extend</span>
+          <strong>Keep host implementation outside Jarvis.</strong>
+          <p>Extensions add protocol fields. Extensions MUST NOT define runtime or workflow.</p>
+        </a>
+      </section>
+
       <section class="protocol-section" id="protocol" aria-labelledby="protocol-title">
         <div class="section-copy">
           <p class="kicker">Protocol model</p>
@@ -209,6 +237,74 @@
         </div>
       </section>
 
+      <section class="openapi-section" id="openapi" aria-labelledby="openapi-title">
+        <div class="section-copy">
+          <p class="kicker">OpenAPI 3.1 binding</p>
+          <h2 id="openapi-title">The machine-readable contract starts here.</h2>
+          <p>
+            OpenAPI defines Jarvis v0.1.0 operations, schemas, parameters,
+            headers, errors, and examples. Compatible implementations use the
+            binding to exchange portable protocol records without adopting a
+            Jarvis-owned runtime.
+          </p>
+          <div class="inline-actions">
+            <a
+              class="command primary"
+              href="https://raw.githubusercontent.com/Flow-Research/jarvis/main/docs/openapi/jarvis-openapi.yaml"
+            >
+              Raw OpenAPI YAML
+            </a>
+            <a
+              class="command"
+              href="https://github.com/Flow-Research/jarvis/blob/main/docs/openapi/README.md"
+            >
+              OpenAPI README
+            </a>
+          </div>
+        </div>
+        <div class="reference-grid" aria-label="OpenAPI reference summary">
+          <article>
+            <h3>WorkSession-scoped mutation headers</h3>
+            <ul>
+              <li>Jarvis-Protocol-Version</li>
+              <li>Jarvis-Actor-Id</li>
+              <li>Jarvis-Idempotency-Key</li>
+              <li>Jarvis-Request-Timestamp</li>
+              <li>Jarvis-Expected-WorkSession-Revision</li>
+              <li>Jarvis-Previous-Event-Hash</li>
+            </ul>
+            <p>
+              Worker registration, Actor registration, and OutcomeReport use the
+              non-WorkSession mutation header set and MUST NOT require fake
+              revision or previous-hash values.
+            </p>
+          </article>
+          <article>
+            <h3>Core protocol flow</h3>
+            <ul>
+              <li>create WorkSession</li>
+              <li>record PolicyDecision</li>
+              <li>create Request</li>
+              <li>record Review or Takeover</li>
+              <li>export EvidenceManifest</li>
+              <li>submit OutcomeReport</li>
+            </ul>
+            <p>The full operation matrix lives in the OpenAPI YAML.</p>
+          </article>
+          <article>
+            <h3>Error envelope</h3>
+            <ul>
+              <li>error_id</li>
+              <li>protocol_version</li>
+              <li>object_type</li>
+              <li>field</li>
+              <li>reason</li>
+              <li>remediation</li>
+            </ul>
+          </article>
+        </div>
+      </section>
+
       <section class="examples-section" id="examples" aria-labelledby="examples-title">
         <div class="section-copy">
           <p class="kicker">Examples</p>
@@ -240,6 +336,36 @@
             <p>Machine-checkable protocol records for existing-agent Review and Takeover loops, validated without host runtime code.</p>
             <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/examples/README.md">Open evidence packs</a>
           </article>
+        </div>
+      </section>
+
+      <section class="guides-section" id="guides" aria-labelledby="guides-title">
+        <div class="section-copy">
+          <p class="kicker">Implementer guides</p>
+          <h2 id="guides-title">Implement the protocol spine before adding product behavior.</h2>
+          <p>
+            Guides explain what compatible implementations store, emit,
+            validate, reject, export, and preserve. They do not define host UI,
+            runtime behavior, model routing, tool execution, or storage.
+          </p>
+        </div>
+        <div class="guide-grid" aria-label="Implementer guide links">
+          <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/examples/existing-agent-compatibility.md">
+            <span>Existing-agent compatibility</span>
+            <small>Map native agent work into Jarvis records without rewriting the agent.</small>
+          </a>
+          <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/12-request-protocol.md">
+            <span>Request, Review, Takeover</span>
+            <small>Use scoped blockers, human judgment, ApprovalScope, and takeover lock epochs.</small>
+          </a>
+          <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/13-contribution-evidence-learning.md">
+            <span>Evidence and Learning</span>
+            <small>Record contribution, export evidence, and carry governed learning forward.</small>
+          </a>
+          <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/15-openapi-communication-binding.md">
+            <span>Protocol errors</span>
+            <small>Return stable error ids and portable error envelopes.</small>
+          </a>
         </div>
       </section>
 
@@ -289,6 +415,75 @@ python3 scripts/check_example_evidence_packs.py</code></pre>
             <a href="https://github.com/Flow-Research/jarvis/blob/main/packages/cli/README.md">Read CLI package</a>
           </article>
         </div>
+      </section>
+
+      <section class="implementation-section" id="implementation" aria-labelledby="implementation-title">
+        <div class="section-copy">
+          <p class="kicker">Real implementation path</p>
+          <h2 id="implementation-title">Use an existing agent. Add Jarvis records around the work.</h2>
+          <p>
+            A host records native agent work as Jarvis protocol records. The
+            agent keeps native execution. The host records
+            Worker, Actor, WorkSession, PolicyDecision, Request, Review,
+            Takeover, Contribution, EvidenceManifest, LearningRecord, proposals,
+            and OutcomeReport records.
+          </p>
+          <div class="inline-actions">
+            <a
+              class="command primary"
+              href="https://github.com/Flow-Research/jarvis/blob/main/docs/examples/implementation-proof/native-coding-agent/README.md"
+            >
+              Read Implementation Proof
+            </a>
+            <a
+              class="command"
+              href="https://github.com/Flow-Research/jarvis/blob/main/scripts/check_implementation_proof.py"
+            >
+              Proof Validator
+            </a>
+          </div>
+        </div>
+        <div class="implementation-steps" aria-label="Implementation path steps">
+          <article>
+            <span>01</span>
+            <h3>Select a host surface</h3>
+            <p>Use a real coding-agent session, workspace app, or agent platform as host-owned execution.</p>
+          </article>
+          <article>
+            <span>02</span>
+            <h3>Add protocol recording</h3>
+            <p>Emit Jarvis records at WorkSession start, policy checks, requests, reviews, takeovers, contribution, evidence, and learning.</p>
+          </article>
+          <article>
+            <span>03</span>
+            <h3>Validate every record</h3>
+            <p>Run SDK helpers, conformance fixtures, event hash-chain checks, and EvidenceManifest export checks.</p>
+          </article>
+          <article>
+            <span>04</span>
+            <h3>Publish compatibility proof</h3>
+            <p>Export an evidence pack and implementation proof without claiming certification or official-host status.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="release-section" id="release" aria-labelledby="release-title">
+        <div>
+          <p class="kicker">Release status</p>
+          <h2 id="release-title">Jarvis v0.1.0 is Protocol Alpha.</h2>
+          <p>
+            Protocol Alpha defines the v0.1.0 contract and helper tooling. It
+            does not certify implementations, designate an official host, claim
+            production adoption, establish foundation governance, or create
+            long-term support.
+          </p>
+        </div>
+        <a
+          class="command primary"
+          href="https://github.com/Flow-Research/jarvis/blob/main/docs/releases/v0.1.0.md"
+        >
+          Read Release Notes
+        </a>
       </section>
 
       <section class="simulator" id="walkthrough" aria-label="Jarvis protocol walkthrough">
@@ -410,7 +605,7 @@ python3 scripts/check_example_evidence_packs.py</code></pre>
         </aside>
       </section>
 
-      <section class="boundary-strip" aria-label="Jarvis boundary summary">
+      <section class="boundary-strip" id="boundary" aria-label="Jarvis boundary summary">
         <article>
           <span>Jarvis owns</span>
           <p>protocol records, lifecycle rules, OpenAPI binding, errors, conformance, evidence, and governed learning.</p>

--- a/demo/index.html
+++ b/demo/index.html
@@ -274,9 +274,11 @@
               <li>Jarvis-Previous-Event-Hash</li>
             </ul>
             <p>
-              Worker registration, Actor registration, and OutcomeReport use the
-              non-WorkSession mutation header set and MUST NOT require fake
-              revision or previous-hash values.
+              Non-WorkSession mutation headers are Jarvis-Protocol-Version,
+              Jarvis-Actor-Id, Jarvis-Idempotency-Key, and
+              Jarvis-Request-Timestamp. Worker registration, Actor registration,
+              and OutcomeReport MUST NOT require fake revision or previous-hash
+              values.
             </p>
           </article>
           <article>


### PR DESCRIPTION
## Summary

- expands the static docs homepage into a clearer public documentation gateway
- adds first-class sections for OpenAPI, guides, implementation path, release status, and boundary
- tightens public wording around WorkSession-scoped mutation headers, non-WorkSession mutation header carve-outs, host-owned implementation, and compatibility proof limits
- improves docs-map navigation, guide-card focus states, and mobile nav overflow behavior

Closes #59

## Protocol Surface

- public docs site only
- OpenAPI, conformance, guides, examples, SDK helper, implementation-proof, release, and boundary entry points
- no protocol object, OpenAPI schema, fixture, SDK, or conformance-rule changes

## Boundary Check

- [x] This change keeps Jarvis protocol-only.
- [x] This change does not add host runtime, UI backend, auth, storage, billing, model orchestration, tool execution, scoring, payment, deployment, adapter, wrapper, or host workflow code.
- [x] The implementation section states that hosts record native agent work as Jarvis protocol records.

## Compatibility Impact

- No compatibility-breaking protocol change.
- Public readers get clearer routing into the existing v0.1.0 contract and implementation-proof material.

## Conformance Impact

- No conformance rule changes.
- The docs site now points more directly to conformance, compatibility, and implementation-proof records.

## Validation

- [x] `python3 scripts/check_docs_site.py`
- [x] `node --check demo/assets/app.js`
- [x] `python3 scripts/check_protocol_wording.py`
- [x] `git diff --check`
- [x] `npm run check:protocol`

## Reviewer Passes

- protocol boundary and wording reviewer: valid findings fixed
- documentation information architecture reviewer: valid findings fixed
- frontend/responsive reviewer: valid findings fixed
- conformance/security reviewer: no blockers after fixes
- CodeRabbit: valid findings fixed in `e7a7590`
