### PR TITLE
[codex] Fix Pages deployment artifact reruns

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -69,8 +69,11 @@ jobs:
       - name: Upload static site
         uses: actions/upload-pages-artifact@v3
         with:
+          name: github-pages-${{ github.run_attempt }}
           path: demo
 
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+        with:
+          artifact_name: github-pages-${{ github.run_attempt }}


### PR DESCRIPTION
## Summary

- fixes the GitHub Pages workflow so failed-job reruns do not create duplicate `github-pages` artifacts
- names the uploaded Pages artifact with `github.run_attempt`
- passes the same artifact name into `actions/deploy-pages`

## Root Cause

The merged docs-site deployment passed validation and uploaded the static site artifact, but `actions/deploy-pages@v4` failed with GitHub Pages deployment errors. Rerunning only failed jobs uploaded a second artifact named `github-pages` in the same workflow run. The deploy action then failed deterministically with:

```txt
Multiple artifacts named "github-pages" were unexpectedly found for this workflow run. Artifact count is 2.
```

This workflow fix makes each run attempt use a distinct artifact name while keeping upload and deploy in sync.

## Protocol Surface

- GitHub Pages workflow only
- no protocol docs, OpenAPI, conformance, SDK, examples, or site content changes

## Boundary Check

- [x] This change keeps Jarvis protocol-only.
- [x] This change does not add host runtime, UI backend, auth, storage, billing, model orchestration, tool execution, scoring, payment, deployment implementation, adapter, wrapper, or host workflow code.

## Compatibility Impact

- No protocol compatibility impact.

## Conformance Impact

- No conformance rule changes.

## Validation

- [x] YAML shape check for `.github/workflows/pages.yml`
- [x] `python3 scripts/check_docs_site.py`
- [x] `git diff --check`
- [x] `npm run check:protocol`
