### PR TITLE
[codex] Add docs site protocol specification pages

### DIFF
--- a/demo/assets/styles.css
+++ b/demo/assets/styles.css
@@ -593,6 +593,180 @@ a {
   color: var(--muted);
   line-height: 1.62;
 }
+
+.spec-hero,
+.spec-side,
+.spec-panel,
+.rule-card,
+.field-card {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background:
+    linear-gradient(180deg, rgb(255 255 255 / 5%), rgb(255 255 255 / 2%)),
+    rgb(8 12 9 / 82%);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(18px);
+}
+
+.spec-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 18px;
+  align-items: end;
+  margin-top: 34px;
+  padding: 26px;
+}
+
+.spec-hero h1 {
+  max-width: 1060px;
+  margin: 12px 0 0;
+  font-size: clamp(2.4rem, 5vw, 5.2rem);
+  line-height: 0.98;
+  letter-spacing: 0;
+}
+
+.spec-hero p {
+  max-width: 880px;
+  margin: 18px 0 0;
+  color: #c8d3c8;
+  line-height: 1.68;
+}
+
+.spec-layout {
+  display: grid;
+  grid-template-columns: 300px minmax(0, 1fr);
+  gap: 14px;
+  align-items: start;
+  margin-top: 14px;
+}
+
+.spec-side {
+  position: sticky;
+  top: 14px;
+  max-height: calc(100vh - 28px);
+  display: grid;
+  gap: 8px;
+  overflow-y: auto;
+  padding: 14px;
+}
+
+.spec-side a {
+  min-height: 42px;
+  display: flex;
+  align-items: center;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: #c8d3c8;
+  padding: 0 12px;
+  text-decoration: none;
+  font-size: 0.86rem;
+  font-weight: 850;
+}
+
+.spec-side a:hover,
+.spec-side a:focus-visible,
+.spec-side a[aria-current="page"] {
+  border-color: rgb(120 247 180 / 62%);
+  background: rgb(120 247 180 / 9%);
+  color: var(--ink);
+}
+
+.spec-side a:focus-visible {
+  outline: 2px solid var(--mint);
+  outline-offset: 3px;
+}
+
+.spec-main {
+  display: grid;
+  gap: 14px;
+  min-width: 0;
+}
+
+.spec-panel {
+  padding: 22px;
+}
+
+.spec-panel h2 {
+  margin: 0;
+  font-size: clamp(1.55rem, 2.3vw, 2.6rem);
+  line-height: 1.08;
+}
+
+.spec-panel h3 {
+  margin: 0;
+  color: var(--ink);
+  font-size: 1.04rem;
+}
+
+.spec-panel p,
+.spec-panel li,
+.rule-card p,
+.field-card p {
+  color: var(--muted);
+  line-height: 1.62;
+}
+
+.spec-panel p {
+  margin: 14px 0 0;
+}
+
+.spec-panel ul {
+  display: grid;
+  gap: 8px;
+  margin: 14px 0 0;
+  padding-left: 20px;
+}
+
+.rule-grid,
+.field-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.rule-card,
+.field-card {
+  min-height: 130px;
+  padding: 16px;
+}
+
+.field-card code,
+.rule-card code,
+.spec-panel code {
+  color: var(--bone);
+  overflow-wrap: anywhere;
+}
+
+.source-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.source-list a {
+  min-height: 38px;
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--mint);
+  padding: 0 12px;
+  text-decoration: none;
+  font-weight: 900;
+}
+
+.source-list a:hover,
+.source-list a:focus-visible {
+  border-color: rgb(120 247 180 / 62%);
+  color: var(--cyan);
+}
+
+.source-list a:focus-visible {
+  outline: 2px solid var(--mint);
+  outline-offset: 3px;
+}
 .link-table {
   display: grid;
   gap: 10px;
@@ -1268,6 +1442,8 @@ a {
   .guides-section,
   .implementation-section,
   .release-section,
+  .spec-hero,
+  .spec-layout,
   .conformance-band {
     grid-template-columns: 1fr;
   }
@@ -1286,6 +1462,11 @@ a {
   .guide-grid,
   .implementation-steps,
   .boundary-strip {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .spec-side {
+    position: static;
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
@@ -1415,6 +1596,8 @@ a {
   .guides-section,
   .implementation-section,
   .release-section,
+  .spec-hero,
+  .spec-layout,
   .conformance-band,
   .operating-stage,
   .sequence,
@@ -1433,6 +1616,17 @@ a {
     max-width: 100%;
     min-width: 0;
     overflow: hidden;
+  }
+
+  .spec-main,
+  .spec-panel,
+  .spec-side,
+  .rule-card,
+  .field-card {
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    overflow-wrap: anywhere;
   }
 
   .mission-grid div,
@@ -1454,8 +1648,21 @@ a {
   .guides-section,
   .implementation-section,
   .release-section,
+  .spec-hero,
+  .spec-panel,
+  .spec-side,
   .conformance-band {
     padding: 10px;
+  }
+
+  .spec-hero h1 {
+    font-size: clamp(2rem, 9vw, 2.8rem);
+  }
+
+  .spec-side,
+  .rule-grid,
+  .field-grid {
+    grid-template-columns: 1fr;
   }
 
   .section-copy h2,

--- a/demo/index.html
+++ b/demo/index.html
@@ -54,8 +54,11 @@
             calls, tool execution, monitoring, deployment, and host workflow.
           </p>
           <div class="hero-actions" aria-label="Documentation entry links">
+            <a class="command primary" href="./spec/">
+              Read v0.1 Spec
+            </a>
             <a
-              class="command primary"
+              class="command"
               href="https://raw.githubusercontent.com/Flow-Research/jarvis/main/docs/openapi/jarvis-openapi.yaml"
             >
               OpenAPI Spec
@@ -105,13 +108,11 @@
           <span>01</span>
           <h2>Read the protocol spine</h2>
           <p>
-            Start with the core objects and Request protocol. They define the
-            human-agent pair, WorkSession, policy gate, review loop, evidence,
-            and governed learning.
+            Start with the v0.1 specification pages. They define the
+            human-agent pair, WorkSession, policy gate, control plane, evidence,
+            governed learning, and zero-trust rules.
           </p>
-          <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/11-core-protocol-objects.md">
-            Core objects
-          </a>
+          <a href="./spec/">Open v0.1 specification</a>
         </article>
         <article class="doc-card">
           <span>02</span>
@@ -190,7 +191,7 @@
             <p>Every AgentWorker action that affects a WorkSession records policy state before acceptance.</p>
           </article>
           <article>
-            <strong>Request, Review, Takeover</strong>
+            <strong>Request, Review, ApprovalScope, and Takeover</strong>
             <p>Blocked scope routes to human judgment; authority stays bounded and attributable.</p>
           </article>
           <article>
@@ -210,29 +211,57 @@
           <h2 id="spec-title">Read the contract from the same paths implementers use.</h2>
         </div>
         <div class="link-table" aria-label="Specification links">
+          <a href="./spec/">
+            <span>Introduction</span>
+            <small>Protocol thesis, ownership boundary, and implementation path</small>
+          </a>
+          <a href="./spec/terminology.html">
+            <span>Terminology</span>
+            <small>Worker, Actor, HumanWorker, AgentWorker, Host, and core terms</small>
+          </a>
+          <a href="./spec/protocol-objects.html">
+            <span>Protocol Objects</span>
+            <small>Required fields for the v0.1 object surface</small>
+          </a>
+          <a href="./spec/worksession-lifecycle.html">
+            <span>WorkSession Lifecycle</span>
+            <small>Session states, JarvisEvent chain, and export readiness</small>
+          </a>
+          <a href="./spec/policy-decision.html">
+            <span>Policy and PolicyDecision</span>
+            <small>Human-defined policy and required decision records</small>
+          </a>
+          <a href="./spec/request-review-takeover.html">
+            <span>Request, Review, ApprovalScope, and Takeover</span>
+            <small>Scoped deferral, ApprovalScope, human judgment, and lock epochs</small>
+          </a>
+          <a href="./spec/contribution-evidence.html">
+            <span>Contribution and EvidenceManifest</span>
+            <small>Attribution, EvidenceManifest export, and rejection rules</small>
+          </a>
+          <a href="./spec/learning-proposals.html">
+            <span>LearningRecord, MemoryProposal, and SkillProposal</span>
+            <small>LearningRecord, MemoryProposal, SkillProposal, and review gates</small>
+          </a>
+          <a href="./spec/outcome-report.html">
+            <span>OutcomeReport</span>
+            <small>External feedback ingress and terminal-source requirements</small>
+          </a>
+          <a href="./spec/versioning-extensions.html">
+            <span>Versioning and Extensions</span>
+            <small>Version negotiation, capabilities, namespaces, and extension limits</small>
+          </a>
+          <a href="./spec/security-zero-trust.html">
+            <span>Security and Zero Trust</span>
+            <small>Mutation headers, Actor authority, revision, hash, and export safety</small>
+          </a>
           <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/14-protocol-lock.md">
-            <span>Protocol Lock</span>
+            <span>Source: Protocol Lock</span>
             <small>Locked v0.1 protocol decisions and boundaries</small>
           </a>
           <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/15-openapi-communication-binding.md">
-            <span>Communication Binding</span>
+            <span>Source: Communication Binding</span>
             <small>HTTP operations, headers, versioning, and error envelope</small>
-          </a>
-          <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/12-request-protocol.md">
-            <span>Request Protocol</span>
-            <small>Scoped deferral, Review, Takeover, and anti-livelock rules</small>
-          </a>
-          <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/13-contribution-evidence-learning.md">
-            <span>Evidence + Learning</span>
-            <small>Contribution, EvidenceManifest, LearningRecord, and proposals</small>
-          </a>
-          <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/examples/protocol-records.md">
-            <span>Protocol Records</span>
-            <small>Concrete v0.1 record examples</small>
-          </a>
-          <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/releases/v0.1.0.md">
-            <span>Release Notes</span>
-            <small>Protocol Alpha release scope and limits</small>
           </a>
         </div>
       </section>
@@ -357,7 +386,7 @@
             <small>Map native agent work into Jarvis records without rewriting the agent.</small>
           </a>
           <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/12-request-protocol.md">
-            <span>Request, Review, Takeover</span>
+            <span>Request, Review, ApprovalScope, and Takeover</span>
             <small>Use scoped blockers, human judgment, ApprovalScope, and takeover lock epochs.</small>
           </a>
           <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/13-contribution-evidence-learning.md">

--- a/demo/spec/contribution-evidence.html
+++ b/demo/spec/contribution-evidence.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Contribution and EvidenceManifest | Jarvis v0.1</title>
+    <meta name="description" content="Jarvis v0.1 Contribution and EvidenceManifestManifest rules." />
+    <link rel="icon" href="../assets/favicon.svg?v=spec1" type="image/svg+xml" />
+    <link rel="stylesheet" href="../assets/styles.css?v=spec1" />
+  </head>
+  <body>
+    <main class="shell spec-page">
+      <header class="topbar"><a class="brand" href="../"><span class="brand-mark">J</span><span><strong>Jarvis</strong><small>v0.1 specification</small></span></a><nav class="topnav" aria-label="Specification navigation"><a href="../">Home</a><a href="./">Spec</a><a href="../#openapi">OpenAPI</a><a href="../#conformance">Conformance</a><a href="../#boundary">Boundary</a></nav><span class="status-chip">v0.1</span></header>
+      <section class="spec-hero"><div><p class="kicker">Contribution and EvidenceManifest</p><h1>Useful work leaves portable proof.</h1><p>Jarvis records who contributed, which events support the work, and what evidence leaves the host as a portable EvidenceManifest.</p></div></section>
+      <section class="spec-layout">
+        <nav class="spec-side" aria-label="Specification pages"><a href="./">Introduction</a><a href="./terminology.html">Terminology</a><a href="./protocol-objects.html">Protocol objects</a><a href="./worksession-lifecycle.html">WorkSession lifecycle</a><a href="./policy-decision.html">Policy and PolicyDecision</a><a href="./request-review-takeover.html">Request, Review, ApprovalScope, and Takeover</a><a href="./contribution-evidence.html" aria-current="page">Contribution and EvidenceManifest</a><a href="./learning-proposals.html">LearningRecord, MemoryProposal, and SkillProposal</a><a href="./outcome-report.html">OutcomeReport</a><a href="./versioning-extensions.html">Versioning and extensions</a><a href="./security-zero-trust.html">Security and zero trust</a></nav>
+        <div class="spec-main">
+          <article class="spec-panel">
+            <h2>Contribution</h2>
+            <p>Contribution records who did what. Shared Contribution preserves the individual HumanWorker and AgentWorker contributor refs.</p>
+            <div class="field-grid">
+              <div class="field-card"><h3>Required fields</h3><p><code>id</code>, <code>work_session_id</code>, <code>contributor_refs</code>, <code>contributor_type</code>, <code>contribution_type</code>, <code>event_refs</code>, <code>created_at</code></p></div>
+              <div class="field-card"><h3>Required contributor refs</h3><p>Each contributor ref carries <code>worker_id</code>, <code>actor_id</code>, and <code>contribution_role</code>.</p></div>
+            </div>
+          </article>
+          <article class="spec-panel">
+            <h2>EvidenceManifest</h2>
+            <p>EvidenceManifest exports portable proof from a valid WorkSession state. It references the event chain and protocol-visible decisions, requests, reviews, takeovers, contributions, artifacts, limitations, and evidence items.</p>
+            <p>EvidenceManifest required fields are <code>id</code>, <code>work_session_id</code>, <code>generated_by_actor_id</code>, <code>objective</code>, <code>event_chain_root</code>, <code>evidence_item_refs</code>, <code>policy_decision_refs</code>, <code>request_refs</code>, <code>review_refs</code>, <code>takeover_refs</code>, <code>contribution_refs</code>, <code>export_profile</code>, and <code>generated_at</code>.</p>
+            <div class="rule-grid">
+              <div class="rule-card"><h3>Export includes</h3><p><code>event_chain_root</code>, <code>evidence_item_refs</code>, <code>policy_decision_refs</code>, <code>request_refs</code>, <code>review_refs</code>, <code>takeover_refs</code>, and <code>contribution_refs</code>.</p></div>
+              <div class="rule-card"><h3>EvidenceItemRef includes</h3><p><code>source_event_refs</code>, <code>captured_by_actor_id</code>, <code>evidence_type</code>, <code>artifact_ref</code>, <code>content_hash</code>, <code>trust_label</code>, <code>redaction_state</code>, and <code>captured_at</code>.</p></div>
+            </div>
+          </article>
+          <article class="spec-panel">
+            <h2>Rejection rules</h2>
+            <ul>
+              <li>The protocol rejects missing Contribution Actor.</li>
+              <li>The protocol rejects shared Contribution without individual contributor refs.</li>
+              <li>The protocol rejects EvidenceManifest export from invalid WorkSession states.</li>
+              <li>The protocol rejects EvidenceManifest mutation after sealing.</li>
+              <li>The protocol rejects forbidden export fields, including credentials, secrets, raw runtime state, host-only database ids, deployment details, billing data, private scores, UI state, raw auth tokens, provider secrets, session cookies, and private keys.</li>
+            </ul>
+            <div class="source-list"><a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/13-contribution-evidence-learning.md">Source: evidence and learning</a><a href="https://github.com/Flow-Research/jarvis/blob/main/docs/conformance/failure-modes.md">Source: failure modes</a></div>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/demo/spec/index.html
+++ b/demo/spec/index.html
@@ -1,0 +1,139 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Jarvis Specification | v0.1</title>
+    <meta
+      name="description"
+      content="Jarvis v0.1 protocol specification pages for HumanWorker and AgentWorker collaboration, WorkSessions, Requests, Reviews, Evidence, and shared learning."
+    />
+    <link rel="icon" href="../assets/favicon.svg?v=spec1" type="image/svg+xml" />
+    <link rel="stylesheet" href="../assets/styles.css?v=spec1" />
+  </head>
+  <body>
+    <main class="shell spec-page">
+      <header class="topbar" aria-label="Jarvis specification header">
+        <a class="brand" href="../" aria-label="Jarvis documentation home">
+          <span class="brand-mark">J</span>
+          <span>
+            <strong>Jarvis</strong>
+            <small>v0.1 specification</small>
+          </span>
+        </a>
+        <nav class="topnav" aria-label="Specification navigation">
+          <a href="../">Home</a>
+          <a href="./" aria-current="page">Spec</a>
+          <a href="../#openapi">OpenAPI</a>
+          <a href="../#conformance">Conformance</a>
+          <a href="../#boundary">Boundary</a>
+        </nav>
+        <span class="status-chip">v0.1</span>
+      </header>
+
+      <section class="spec-hero" id="top">
+        <div>
+          <p class="kicker">Protocol specification</p>
+          <h1>Jarvis v0.1 protocol specification</h1>
+          <p>
+            Jarvis defines the portable collaboration and learning-loop
+            contracts for HumanWorkers and AgentWorkers. Hosts own
+            implementation. Compatible implementations use these pages with the
+            OpenAPI binding and source protocol docs.
+          </p>
+        </div>
+        <a class="command primary" href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/14-protocol-lock.md">
+          Source Lock
+        </a>
+      </section>
+
+      <section class="spec-layout">
+        <nav class="spec-side" aria-label="Specification pages">
+          <a href="./" aria-current="page">Introduction</a>
+          <a href="./terminology.html">Terminology</a>
+          <a href="./protocol-objects.html">Protocol objects</a>
+          <a href="./worksession-lifecycle.html">WorkSession lifecycle</a>
+          <a href="./policy-decision.html">Policy and PolicyDecision</a>
+          <a href="./request-review-takeover.html">Request, Review, ApprovalScope, and Takeover</a>
+          <a href="./contribution-evidence.html">Contribution and EvidenceManifest</a>
+          <a href="./learning-proposals.html">LearningRecord, MemoryProposal, and SkillProposal</a>
+          <a href="./outcome-report.html">OutcomeReport</a>
+          <a href="./versioning-extensions.html">Versioning and extensions</a>
+          <a href="./security-zero-trust.html">Security and zero trust</a>
+        </nav>
+
+        <div class="spec-main">
+          <article class="spec-panel">
+            <h2>What Jarvis defines</h2>
+            <p>
+              Jarvis defines how a HumanWorker and an AgentWorker collaborate
+              inside a WorkSession under human-defined Policy. The protocol
+              records PolicyDecision, Request, Review, ApprovalScope, and Takeover, Contribution,
+              EvidenceManifest, LearningRecord, MemoryProposal, SkillProposal,
+              and OutcomeReport records.
+            </p>
+            <div class="rule-grid">
+              <div class="rule-card">
+                <h3>Jarvis owns protocol contracts</h3>
+                <p>Jarvis owns object shape, lifecycle rules, mutation gates, portable evidence, errors, and conformance expectations.</p>
+              </div>
+              <div class="rule-card">
+                <h3>Hosts own implementation</h3>
+                <p>Hosts own UI, identity, auth, storage, model calls, tool execution, monitoring, deployment, and host workflow.</p>
+              </div>
+              <div class="rule-card">
+                <h3>OpenAPI is the machine binding</h3>
+                <p>OpenAPI 3.1 defines operations, schemas, parameters, required headers, security scheme, errors, and examples.</p>
+              </div>
+              <div class="rule-card">
+                <h3>Conformance is record based</h3>
+                <p>Compatible implementations prove behavior through protocol records, event hashes, fixtures, and export checks.</p>
+              </div>
+            </div>
+          </article>
+
+          <article class="spec-panel">
+            <h2>Required reading path</h2>
+            <div class="field-grid">
+              <div class="field-card">
+                <h3>1. Learn terms</h3>
+                <p>Use the terminology page to map workers, actors, events, policy, evidence, and learning.</p>
+                <p><a href="./terminology.html">Open terminology</a></p>
+              </div>
+              <div class="field-card">
+                <h3>2. Learn objects</h3>
+                <p>Use the protocol objects page to see required fields and forbidden host-private fields.</p>
+                <p><a href="./protocol-objects.html">Open protocol objects</a></p>
+              </div>
+              <div class="field-card">
+                <h3>3. Learn control flow</h3>
+                <p>Use WorkSession, PolicyDecision, Request, Review, and Takeover pages to understand accepted state.</p>
+                <p><a href="./request-review-takeover.html">Open control plane</a></p>
+              </div>
+              <div class="field-card">
+                <h3>4. Learn proof and learning</h3>
+                <p>Use Contribution, EvidenceManifest, LearningRecord, MemoryProposal, SkillProposal, and OutcomeReport pages.</p>
+                <p><a href="./contribution-evidence.html">Open evidence</a></p>
+              </div>
+            </div>
+          </article>
+
+          <article class="spec-panel">
+            <h2>Source contract</h2>
+            <p>
+              These website pages explain the v0.1 protocol contract. The
+              source protocol docs and OpenAPI file remain the authoritative
+              machine and text references for implementers.
+            </p>
+            <div class="source-list">
+              <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/11-core-protocol-objects.md">Core objects</a>
+              <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/12-request-protocol.md">Request protocol</a>
+              <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/13-contribution-evidence-learning.md">Evidence and learning</a>
+              <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/15-openapi-communication-binding.md">OpenAPI binding</a>
+            </div>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/demo/spec/learning-proposals.html
+++ b/demo/spec/learning-proposals.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>LearningRecord, MemoryProposal, and SkillProposal | Jarvis v0.1</title>
+    <meta name="description" content="Jarvis v0.1 LearningRecord, MemoryProposal, and SkillProposal rules." />
+    <link rel="icon" href="../assets/favicon.svg?v=spec1" type="image/svg+xml" />
+    <link rel="stylesheet" href="../assets/styles.css?v=spec1" />
+  </head>
+  <body>
+    <main class="shell spec-page">
+      <header class="topbar"><a class="brand" href="../"><span class="brand-mark">J</span><span><strong>Jarvis</strong><small>v0.1 specification</small></span></a><nav class="topnav" aria-label="Specification navigation"><a href="../">Home</a><a href="./">Spec</a><a href="../#openapi">OpenAPI</a><a href="../#conformance">Conformance</a><a href="../#boundary">Boundary</a></nav><span class="status-chip">v0.1</span></header>
+      <section class="spec-hero"><div><p class="kicker">LearningRecord, MemoryProposal, and SkillProposal</p><h1>Learning is governed before it changes future work.</h1><p>Jarvis records human, agent, and pair learning. MemoryProposal and SkillProposal keep future behavior changes attributable, reviewed, and bounded.</p></div></section>
+      <section class="spec-layout">
+        <nav class="spec-side" aria-label="Specification pages"><a href="./">Introduction</a><a href="./terminology.html">Terminology</a><a href="./protocol-objects.html">Protocol objects</a><a href="./worksession-lifecycle.html">WorkSession lifecycle</a><a href="./policy-decision.html">Policy and PolicyDecision</a><a href="./request-review-takeover.html">Request, Review, ApprovalScope, and Takeover</a><a href="./contribution-evidence.html">Contribution and EvidenceManifest</a><a href="./learning-proposals.html" aria-current="page">LearningRecord, MemoryProposal, and SkillProposal</a><a href="./outcome-report.html">OutcomeReport</a><a href="./versioning-extensions.html">Versioning and extensions</a><a href="./security-zero-trust.html">Security and zero trust</a></nav>
+        <div class="spec-main">
+          <article class="spec-panel">
+            <h2>LearningRecord</h2>
+            <p>LearningRecord records what improved because of the WorkSession or an accepted OutcomeReport.</p>
+            <div class="field-grid">
+              <div class="field-card"><h3>Required fields</h3><p><code>id</code>, <code>work_session_id</code>, <code>created_by_actor_id</code>, <code>subject_type</code>, <code>subject_ref</code>, <code>lesson_type</code>, <code>source_event_refs</code>, <code>review_state</code>, <code>scope</code>, <code>created_at</code></p></div>
+              <div class="field-card"><h3>Subject types</h3><p><code>human</code>, <code>agent</code>, and <code>pair</code>. Learning belongs to the worker or team that actually learned.</p></div>
+            </div>
+          </article>
+          <article class="spec-panel">
+            <h2>MemoryProposal</h2>
+            <p>MemoryProposal records a proposed durable memory change. It does not silently write memory.</p>
+            <p>MemoryProposal required fields are <code>id</code>, <code>work_session_id</code>, <code>proposed_by_actor_id</code>, <code>proposed_for</code>, <code>memory_scope</code>, <code>memory_type</code>, <code>content</code>, <code>provenance</code>, <code>confidence</code>, <code>review_required</code>, <code>status</code>, and <code>created_at</code>.</p>
+            <ul>
+              <li><code>review_required</code> records whether human review is required before durable memory effect.</li>
+              <li><code>review_refs</code> is required when status is <code>accepted</code>.</li>
+              <li>The protocol rejects model-derived or tool-derived self-confirmation.</li>
+              <li>The protocol rejects silent memory mutation.</li>
+            </ul>
+          </article>
+          <article class="spec-panel">
+            <h2>SkillProposal</h2>
+            <p>SkillProposal records a reusable way of working, including trigger conditions, procedure, review checks, failure cases, provenance, and status.</p>
+            <p>SkillProposal required fields are <code>id</code>, <code>work_session_id</code>, <code>proposed_by_actor_id</code>, <code>proposed_for</code>, <code>skill_scope</code>, <code>skill_name</code>, <code>trigger_conditions</code>, <code>procedure</code>, <code>review_checks</code>, <code>failure_cases</code>, <code>provenance</code>, <code>status</code>, and <code>created_at</code>.</p>
+            <ul>
+              <li><code>review_refs</code> is required when status is <code>accepted</code>.</li>
+              <li>SkillProposal cannot activate without review.</li>
+              <li>SkillProposal cannot expand tool access without Policy review.</li>
+              <li>The protocol rejects silent skill activation and unreviewed tool grants.</li>
+            </ul>
+          </article>
+          <article class="spec-panel">
+            <h2>Compatibility expectations</h2>
+            <div class="rule-grid">
+              <div class="rule-card"><h3>Learning source</h3><p>LearningRecord references source events. OutcomeReport references LearningRecord without appending to a sealed WorkSession event log.</p></div>
+              <div class="rule-card"><h3>Future behavior</h3><p>MemoryProposal and SkillProposal become durable only through governed review state.</p></div>
+            </div>
+            <div class="source-list"><a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/13-contribution-evidence-learning.md">Source: learning rules</a><a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/11-core-protocol-objects.md">Source: proposal fields</a></div>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/demo/spec/outcome-report.html
+++ b/demo/spec/outcome-report.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>OutcomeReport | Jarvis v0.1</title>
+    <meta name="description" content="Jarvis v0.1 OutcomeReport extension object rules." />
+    <link rel="icon" href="../assets/favicon.svg?v=spec1" type="image/svg+xml" />
+    <link rel="stylesheet" href="../assets/styles.css?v=spec1" />
+  </head>
+  <body>
+    <main class="shell spec-page">
+      <header class="topbar"><a class="brand" href="../"><span class="brand-mark">J</span><span><strong>Jarvis</strong><small>v0.1 specification</small></span></a><nav class="topnav" aria-label="Specification navigation"><a href="../">Home</a><a href="./">Spec</a><a href="../#openapi">OpenAPI</a><a href="../#conformance">Conformance</a><a href="../#boundary">Boundary</a></nav><span class="status-chip">v0.1</span></header>
+      <section class="spec-hero"><div><p class="kicker">OutcomeReport</p><h1>Post-session feedback enters without mutating sealed work.</h1><p>OutcomeReport is a v0.1 extension protocol object for attributable feedback after a WorkSession reaches a terminal state.</p></div></section>
+      <section class="spec-layout">
+        <nav class="spec-side" aria-label="Specification pages"><a href="./">Introduction</a><a href="./terminology.html">Terminology</a><a href="./protocol-objects.html">Protocol objects</a><a href="./worksession-lifecycle.html">WorkSession lifecycle</a><a href="./policy-decision.html">Policy and PolicyDecision</a><a href="./request-review-takeover.html">Request, Review, ApprovalScope, and Takeover</a><a href="./contribution-evidence.html">Contribution and EvidenceManifest</a><a href="./learning-proposals.html">LearningRecord, MemoryProposal, and SkillProposal</a><a href="./outcome-report.html" aria-current="page">OutcomeReport</a><a href="./versioning-extensions.html">Versioning and extensions</a><a href="./security-zero-trust.html">Security and zero trust</a></nav>
+        <div class="spec-main">
+          <article class="spec-panel">
+            <h2>Required fields</h2>
+            <p><code>id</code>, <code>work_session_id</code>, <code>source_ref</code>, <code>reporter_ref</code>, <code>accepted_by_actor_id</code>, <code>outcome</code>, <code>learning_record_refs</code>, and <code>received_at</code>.</p>
+            <p><code>source_ref</code> identifies a terminal source: completed, failed, cancelled, or closed WorkSession, WorkSession export, external task record, evaluation record, or portable work reference whose outcome is being reported.</p>
+          </article>
+          <article class="spec-panel">
+            <h2>Rules</h2>
+            <ul>
+              <li>OutcomeReport arrives after a WorkSession is completed, failed, cancelled, or closed.</li>
+              <li>OutcomeReport does not mutate the sealed WorkSession.</li>
+              <li>OutcomeReport does not mutate the sealed EvidenceManifest.</li>
+              <li>OutcomeReport MUST reference at least one governed LearningRecord through <code>learning_record_refs</code>.</li>
+              <li>OutcomeReport uses the non-WorkSession mutation header set.</li>
+            </ul>
+          </article>
+          <article class="spec-panel">
+            <h2>Boundaries</h2>
+            <div class="rule-grid">
+              <div class="rule-card"><h3>Jarvis owns</h3><p>Jarvis owns the feedback ingress record, source link, accepted Actor, outcome enum, LearningRecord refs, and rejection rules.</p></div>
+              <div class="rule-card"><h3>Jarvis does not own</h3><p>OutcomeReport is not evaluation logic, scoring, payment, settlement, routing, or marketplace behavior.</p></div>
+            </div>
+          </article>
+          <article class="spec-panel">
+            <h2>Rejection rules</h2>
+            <ul>
+              <li>The protocol rejects OutcomeReport without LearningRecord reference.</li>
+              <li>The protocol rejects OutcomeReport when <code>source_ref</code> points to a mutable source WorkSession.</li>
+              <li>The protocol rejects sealed WorkSession mutation and sealed EvidenceManifest mutation.</li>
+            </ul>
+            <div class="source-list"><a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/13-contribution-evidence-learning.md">Source: OutcomeReport rules</a><a href="https://github.com/Flow-Research/jarvis/blob/main/docs/conformance/failure-modes.md">Source: failure modes</a></div>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/demo/spec/policy-decision.html
+++ b/demo/spec/policy-decision.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Policy and PolicyDecision | Jarvis v0.1</title>
+    <meta name="description" content="Jarvis v0.1 Policy and PolicyDecision rules for governed AgentWorker action." />
+    <link rel="icon" href="../assets/favicon.svg?v=spec1" type="image/svg+xml" />
+    <link rel="stylesheet" href="../assets/styles.css?v=spec1" />
+  </head>
+  <body>
+    <main class="shell spec-page">
+      <header class="topbar"><a class="brand" href="../"><span class="brand-mark">J</span><span><strong>Jarvis</strong><small>v0.1 specification</small></span></a><nav class="topnav" aria-label="Specification navigation"><a href="../">Home</a><a href="./">Spec</a><a href="../#openapi">OpenAPI</a><a href="../#conformance">Conformance</a><a href="../#boundary">Boundary</a></nav><span class="status-chip">v0.1</span></header>
+      <section class="spec-hero"><div><p class="kicker">Policy and PolicyDecision</p><h1>Policy gates accepted agent action.</h1><p>Jarvis records human-defined policy and requires PolicyDecision before an AgentWorker action that affects a WorkSession becomes protocol state.</p></div></section>
+      <section class="spec-layout">
+        <nav class="spec-side" aria-label="Specification pages"><a href="./">Introduction</a><a href="./terminology.html">Terminology</a><a href="./protocol-objects.html">Protocol objects</a><a href="./worksession-lifecycle.html">WorkSession lifecycle</a><a href="./policy-decision.html" aria-current="page">Policy and PolicyDecision</a><a href="./request-review-takeover.html">Request, Review, ApprovalScope, and Takeover</a><a href="./contribution-evidence.html">Contribution and EvidenceManifest</a><a href="./learning-proposals.html">LearningRecord, MemoryProposal, and SkillProposal</a><a href="./outcome-report.html">OutcomeReport</a><a href="./versioning-extensions.html">Versioning and extensions</a><a href="./security-zero-trust.html">Security and zero trust</a></nav>
+        <div class="spec-main">
+          <article class="spec-panel">
+            <h2>Policy records</h2>
+            <p>Policy records define the human-owned boundary for AgentWorker autonomy.</p>
+            <div class="field-grid">
+              <div class="field-card"><h3>Required fields</h3><p><code>id</code>, <code>owner_worker_id</code>, <code>created_by_actor_id</code>, <code>autonomy_level</code>, <code>allowed_actions</code>, <code>denied_actions</code>, <code>review_required_actions</code>, <code>risk_classes</code>, <code>escalation_rules</code>, <code>created_at</code></p></div>
+              <div class="field-card"><h3>Optional protocol context</h3><p><code>tool_grants</code>, <code>memory_grants</code>, <code>external_send_rules</code>, <code>request_limits</code>, and <code>extensions</code></p></div>
+            </div>
+          </article>
+          <article class="spec-panel">
+            <h2>PolicyDecision records</h2>
+            <p>PolicyDecision records why a requested AgentWorker action is allowed, denied, narrowed, or sent for human review.</p>
+            <p>PolicyDecision required fields are <code>id</code>, <code>work_session_id</code>, <code>actor_id</code>, <code>policy_id</code>, <code>requested_action</code>, <code>normalized_action_hash</code>, <code>risk_class</code>, <code>result</code>, <code>reason</code>, and <code>created_at</code>.</p>
+            <div class="rule-grid">
+              <div class="rule-card"><h3>allow</h3><p>The AgentWorker action fits Policy and becomes eligible for accepted protocol state after mutation checks pass.</p></div>
+              <div class="rule-card"><h3>deny</h3><p>The AgentWorker action stays blocked. Denial creates or references a Request.</p></div>
+              <div class="rule-card"><h3>narrow</h3><p>The action is allowed only inside a smaller bounded scope.</p></div>
+              <div class="rule-card"><h3>review_required</h3><p>The action requires HumanWorker input through Request, Review, or Takeover before the blocked scope continues.</p></div>
+            </div>
+          </article>
+          <article class="spec-panel">
+            <h2>Compatibility expectations</h2>
+            <ul>
+              <li>Compatible implementations MUST record PolicyDecision before accepted AgentWorker action state.</li>
+              <li>Actor-bearing mutation bodies MUST match <code>Jarvis-Actor-Id</code>.</li>
+              <li>The protocol rejects missing PolicyDecision before accepted AgentWorker action state.</li>
+              <li>The protocol rejects hidden policy traces, provider secrets, database ids, runtime decision objects, and credentials in portable records.</li>
+            </ul>
+            <div class="source-list"><a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/03-autonomy-policy.md">Source: autonomy policy</a><a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/11-core-protocol-objects.md">Source: field lock</a><a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/15-openapi-communication-binding.md">Source: OpenAPI binding</a></div>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/demo/spec/protocol-objects.html
+++ b/demo/spec/protocol-objects.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Protocol Objects | Jarvis v0.1</title>
+    <meta name="description" content="Jarvis v0.1 protocol objects and required fields." />
+    <link rel="icon" href="../assets/favicon.svg?v=spec1" type="image/svg+xml" />
+    <link rel="stylesheet" href="../assets/styles.css?v=spec1" />
+  </head>
+  <body>
+    <main class="shell spec-page">
+      <header class="topbar"><a class="brand" href="../"><span class="brand-mark">J</span><span><strong>Jarvis</strong><small>v0.1 specification</small></span></a><nav class="topnav" aria-label="Specification navigation"><a href="../">Home</a><a href="./">Spec</a><a href="../#openapi">OpenAPI</a><a href="../#conformance">Conformance</a><a href="../#boundary">Boundary</a></nav><span class="status-chip">v0.1</span></header>
+      <section class="spec-hero"><div><p class="kicker">Protocol objects</p><h1>Objects define portable collaboration state.</h1><p>Compatible implementations MUST preserve required fields, reject forbidden host-private fields, and keep object names aligned with OpenAPI.</p></div></section>
+      <section class="spec-layout">
+        <nav class="spec-side" aria-label="Specification pages">
+          <a href="./">Introduction</a><a href="./terminology.html">Terminology</a><a href="./protocol-objects.html" aria-current="page">Protocol objects</a><a href="./worksession-lifecycle.html">WorkSession lifecycle</a><a href="./policy-decision.html">Policy and PolicyDecision</a><a href="./request-review-takeover.html">Request, Review, ApprovalScope, and Takeover</a><a href="./contribution-evidence.html">Contribution and EvidenceManifest</a><a href="./learning-proposals.html">LearningRecord, MemoryProposal, and SkillProposal</a><a href="./outcome-report.html">OutcomeReport</a><a href="./versioning-extensions.html">Versioning and extensions</a><a href="./security-zero-trust.html">Security and zero trust</a>
+        </nav>
+        <div class="spec-main">
+          <article class="spec-panel">
+            <h2>Participant objects</h2>
+            <div class="field-grid">
+              <div class="field-card"><h3>Worker</h3><p><code>id</code>, <code>type</code>, <code>role</code>, <code>authority_scope</code>, <code>accountability_scope</code></p></div>
+              <div class="field-card"><h3>Actor</h3><p><code>id</code>, <code>worker_id</code>, <code>type</code>, <code>event_authority</code>, <code>contribution_scope</code>, <code>created_at</code></p></div>
+              <div class="field-card"><h3>HumanWorker</h3><p><code>worker_id</code>, <code>actor_id</code>, <code>role</code>, <code>policy_authority</code>, <code>review_authority</code></p></div>
+              <div class="field-card"><h3>AgentWorker</h3><p><code>worker_id</code>, <code>actor_id</code>, <code>agent_ref</code>, <code>role</code>, <code>capability_refs</code>, <code>autonomy_level</code>, <code>operating_constraints</code></p></div>
+            </div>
+          </article>
+          <article class="spec-panel">
+            <h2>Session, event, and policy objects</h2>
+            <div class="field-grid">
+              <div class="field-card"><h3>WorkSession</h3><p><code>id</code>, <code>protocol_version</code>, <code>created_by_actor_id</code>, <code>objective</code>, <code>human_worker_id</code>, <code>agent_worker_id</code>, <code>policy_id</code>, <code>status</code>, <code>revision</code>, <code>last_event_hash</code>, <code>event_log_ref</code>, <code>created_at</code>, <code>updated_at</code></p></div>
+              <div class="field-card"><h3>JarvisEvent</h3><p><code>id</code>, <code>sequence</code>, <code>type</code>, <code>work_session_id</code>, <code>actor_id</code>, <code>timestamp</code>, <code>payload</code>, <code>previous_hash</code>, <code>event_hash</code>, <code>canonicalization</code></p></div>
+              <div class="field-card"><h3>Policy</h3><p><code>id</code>, <code>owner_worker_id</code>, <code>created_by_actor_id</code>, <code>autonomy_level</code>, <code>allowed_actions</code>, <code>denied_actions</code>, <code>review_required_actions</code>, <code>risk_classes</code>, <code>escalation_rules</code>, <code>created_at</code></p></div>
+              <div class="field-card"><h3>PolicyDecision</h3><p><code>id</code>, <code>work_session_id</code>, <code>actor_id</code>, <code>policy_id</code>, <code>requested_action</code>, <code>normalized_action_hash</code>, <code>risk_class</code>, <code>result</code>, <code>reason</code>, <code>created_at</code></p></div>
+            </div>
+          </article>
+          <article class="spec-panel">
+            <h2>Control-plane objects</h2>
+            <div class="field-grid">
+              <div class="field-card"><h3>Request</h3><p><code>id</code>, <code>protocol_version</code>, <code>work_session_id</code>, <code>requester_actor_id</code>, <code>requester_worker_id</code>, <code>target_human_worker_id</code>, <code>policy_decision_id</code>, <code>type</code>, <code>blocking_scope</code>, <code>reason_code</code>, <code>reason_summary</code>, <code>requested_action</code>, <code>requested_outcome</code>, <code>risk_class</code>, <code>human_decision_needed</code>, <code>options</code>, <code>default_if_no_response</code>, <code>status</code>, <code>created_at</code>, <code>expires_at</code></p></div>
+              <div class="field-card"><h3>Review</h3><p><code>id</code>, <code>work_session_id</code>, <code>reviewer_actor_id</code>, <code>reviewer_worker_id</code>, <code>target_ref</code>, <code>decision</code>, <code>created_at</code></p></div>
+              <div class="field-card"><h3>ApprovalScope</h3><p><code>request_id</code>, <code>review_id</code>, <code>policy_decision_id</code>, <code>request_revision</code>, <code>request_event_hash</code>, <code>normalized_action_hash</code>, <code>approved_action</code>, <code>allowed_scope</code>, <code>denied_scope</code>, <code>expires_at</code>, <code>max_uses</code>, <code>applies_to_work_session_id</code>, <code>applies_to_actor_id</code></p></div>
+              <div class="field-card"><h3>Takeover</h3><p><code>id</code>, <code>work_session_id</code>, <code>requested_by_actor_id</code>, <code>controlling_actor_id</code>, <code>affected_scope</code>, <code>reason</code>, <code>lock_epoch</code>, <code>state</code>, <code>created_at</code></p></div>
+            </div>
+          </article>
+          <article class="spec-panel">
+            <h2>Evidence and learning objects</h2>
+            <div class="field-grid">
+              <div class="field-card"><h3>Contribution</h3><p><code>id</code>, <code>work_session_id</code>, <code>contributor_refs</code>, <code>contributor_type</code>, <code>contribution_type</code>, <code>event_refs</code>, <code>created_at</code></p></div>
+              <div class="field-card"><h3>EvidenceManifest</h3><p><code>id</code>, <code>work_session_id</code>, <code>generated_by_actor_id</code>, <code>objective</code>, <code>event_chain_root</code>, <code>evidence_item_refs</code>, <code>policy_decision_refs</code>, <code>request_refs</code>, <code>review_refs</code>, <code>takeover_refs</code>, <code>contribution_refs</code>, <code>export_profile</code>, <code>generated_at</code></p></div>
+              <div class="field-card"><h3>LearningRecord</h3><p><code>id</code>, <code>work_session_id</code>, <code>created_by_actor_id</code>, <code>subject_type</code>, <code>subject_ref</code>, <code>lesson_type</code>, <code>source_event_refs</code>, <code>review_state</code>, <code>scope</code>, <code>created_at</code></p></div>
+              <div class="field-card"><h3>MemoryProposal</h3><p><code>id</code>, <code>work_session_id</code>, <code>proposed_by_actor_id</code>, <code>proposed_for</code>, <code>memory_scope</code>, <code>memory_type</code>, <code>content</code>, <code>provenance</code>, <code>confidence</code>, <code>review_required</code>, <code>status</code>, <code>created_at</code></p></div>
+              <div class="field-card"><h3>SkillProposal</h3><p><code>id</code>, <code>work_session_id</code>, <code>proposed_by_actor_id</code>, <code>proposed_for</code>, <code>skill_scope</code>, <code>skill_name</code>, <code>trigger_conditions</code>, <code>procedure</code>, <code>review_checks</code>, <code>failure_cases</code>, <code>provenance</code>, <code>status</code>, <code>created_at</code></p></div>
+              <div class="field-card"><h3>OutcomeReport</h3><p><code>id</code>, <code>work_session_id</code>, <code>source_ref</code>, <code>reporter_ref</code>, <code>accepted_by_actor_id</code>, <code>outcome</code>, <code>learning_record_refs</code>, <code>received_at</code></p></div>
+            </div>
+          </article>
+          <article class="spec-panel">
+            <h2>Forbidden host-private fields</h2>
+            <p>The protocol rejects portable records that carry credentials, raw auth tokens, provider secrets, private keys, host-only database ids, runtime process ids, deployment details, billing data, private scores, UI state, raw runtime state, or unredacted secret values.</p>
+            <div class="source-list"><a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/11-core-protocol-objects.md">Source: core object field lock</a><a href="https://raw.githubusercontent.com/Flow-Research/jarvis/main/docs/openapi/jarvis-openapi.yaml">OpenAPI YAML</a></div>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/demo/spec/request-review-takeover.html
+++ b/demo/spec/request-review-takeover.html
@@ -72,7 +72,7 @@
               <li>Resumed Takeover requires <code>reconciliation_refs</code>, <code>resumed_by_actor_id</code>, and <code>resolved_at</code>.</li>
               <li>The protocol rejects stale Takeover continuation and missing Takeover reconciliation.</li>
             </ul>
-            <p>Allowed transitions are <code>requested -> locked</code>, <code>requested -> closed</code>, <code>locked -> human_active</code>, <code>locked -> reconciliation_required</code>, <code>locked -> closed</code>, <code>human_active -> reconciliation_required</code>, <code>human_active -> closed</code>, <code>reconciliation_required -> resumed</code>, <code>reconciliation_required -> closed</code>, and <code>resumed -> closed</code>.</p>
+            <p>Allowed transitions are <code>requested -&gt; locked</code>, <code>requested -&gt; closed</code>, <code>locked -&gt; human_active</code>, <code>locked -&gt; reconciliation_required</code>, <code>locked -&gt; closed</code>, <code>human_active -&gt; reconciliation_required</code>, <code>human_active -&gt; closed</code>, <code>reconciliation_required -&gt; resumed</code>, <code>reconciliation_required -&gt; closed</code>, and <code>resumed -&gt; closed</code>.</p>
             <div class="source-list"><a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/12-request-protocol.md">Source: request protocol</a><a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/11-core-protocol-objects.md">Source: field lock</a></div>
           </article>
         </div>

--- a/demo/spec/request-review-takeover.html
+++ b/demo/spec/request-review-takeover.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Request, Review, ApprovalScope, and Takeover | Jarvis v0.1</title>
+    <meta name="description" content="Jarvis v0.1 Request, Review, ApprovalScope, and Takeover control-plane rules." />
+    <link rel="icon" href="../assets/favicon.svg?v=spec1" type="image/svg+xml" />
+    <link rel="stylesheet" href="../assets/styles.css?v=spec1" />
+  </head>
+  <body>
+    <main class="shell spec-page">
+      <header class="topbar"><a class="brand" href="../"><span class="brand-mark">J</span><span><strong>Jarvis</strong><small>v0.1 specification</small></span></a><nav class="topnav" aria-label="Specification navigation"><a href="../">Home</a><a href="./">Spec</a><a href="../#openapi">OpenAPI</a><a href="../#conformance">Conformance</a><a href="../#boundary">Boundary</a></nav><span class="status-chip">v0.1</span></header>
+      <section class="spec-hero"><div><p class="kicker">Control plane</p><h1>Request is scoped deferral, not chat.</h1><p>Request blocks a declared scope when AgentWorker cannot continue safely without HumanWorker input. Review or Takeover resolves the blocked scope.</p></div></section>
+      <section class="spec-layout">
+        <nav class="spec-side" aria-label="Specification pages"><a href="./">Introduction</a><a href="./terminology.html">Terminology</a><a href="./protocol-objects.html">Protocol objects</a><a href="./worksession-lifecycle.html">WorkSession lifecycle</a><a href="./policy-decision.html">Policy and PolicyDecision</a><a href="./request-review-takeover.html" aria-current="page">Request, Review, ApprovalScope, and Takeover</a><a href="./contribution-evidence.html">Contribution and EvidenceManifest</a><a href="./learning-proposals.html">LearningRecord, MemoryProposal, and SkillProposal</a><a href="./outcome-report.html">OutcomeReport</a><a href="./versioning-extensions.html">Versioning and extensions</a><a href="./security-zero-trust.html">Security and zero trust</a></nav>
+        <div class="spec-main">
+          <article class="spec-panel">
+            <h2>Required fields</h2>
+            <div class="field-grid">
+              <div class="field-card"><h3>Request</h3><p><code>id</code>, <code>protocol_version</code>, <code>work_session_id</code>, <code>requester_actor_id</code>, <code>requester_worker_id</code>, <code>target_human_worker_id</code>, <code>policy_decision_id</code>, <code>type</code>, <code>blocking_scope</code>, <code>reason_code</code>, <code>reason_summary</code>, <code>requested_action</code>, <code>requested_outcome</code>, <code>risk_class</code>, <code>human_decision_needed</code>, <code>options</code>, <code>default_if_no_response</code>, <code>status</code>, <code>created_at</code>, and <code>expires_at</code></p></div>
+              <div class="field-card"><h3>Review</h3><p><code>id</code>, <code>work_session_id</code>, <code>reviewer_actor_id</code>, <code>reviewer_worker_id</code>, <code>target_ref</code>, <code>decision</code>, and <code>created_at</code></p></div>
+              <div class="field-card"><h3>Takeover</h3><p><code>id</code>, <code>work_session_id</code>, <code>requested_by_actor_id</code>, <code>controlling_actor_id</code>, <code>affected_scope</code>, <code>reason</code>, <code>lock_epoch</code>, <code>state</code>, and <code>created_at</code></p></div>
+              <div class="field-card"><h3>ApprovalScope</h3><p><code>request_id</code>, <code>review_id</code>, <code>policy_decision_id</code>, <code>request_revision</code>, <code>request_event_hash</code>, <code>normalized_action_hash</code>, <code>approved_action</code>, <code>allowed_scope</code>, <code>denied_scope</code>, <code>expires_at</code>, <code>max_uses</code>, <code>applies_to_work_session_id</code>, and <code>applies_to_actor_id</code></p></div>
+            </div>
+          </article>
+          <article class="spec-panel">
+            <h2>Request rules</h2>
+            <ul>
+              <li>Request is created when AgentWorker needs HumanWorker permission, context, judgment, review, correction, or takeover before safely continuing a specific scope.</li>
+              <li>Request blocks only its declared <code>blocking_scope</code> unless the scope is the full WorkSession.</li>
+              <li>Request records <code>policy_decision_id</code>, risk, options, selected outcome, expiry, and safe fallback.</li>
+              <li>Request is not chat, notification, or authority.</li>
+              <li>The protocol rejects unresolved Request when the blocked scope continues.</li>
+            </ul>
+          </article>
+          <article class="spec-panel">
+            <h2>Request lifecycle</h2>
+            <div class="rule-grid">
+              <div class="rule-card"><h3>pending</h3><p>Request exists and blocks its declared scope.</p></div>
+              <div class="rule-card"><h3>acknowledged</h3><p>HumanWorker has seen the Request without resolving it.</p></div>
+              <div class="rule-card"><h3>approved, denied, narrowed, answered</h3><p>Review records human judgment and resolves the Request outcome.</p></div>
+              <div class="rule-card"><h3>needs_revision</h3><p>HumanWorker requires the AgentWorker to revise the plan, request, artifact, or output.</p></div>
+              <div class="rule-card"><h3>takeover</h3><p>HumanWorker assumes direct control through Takeover.</p></div>
+              <div class="rule-card"><h3>expired, cancelled, superseded</h3><p>The safe fallback, cancellation, or replacement rule resolves the Request state.</p></div>
+            </div>
+          </article>
+          <article class="spec-panel">
+            <h2>Request resolver refs</h2>
+            <ul>
+              <li><code>resolved_by_review_id</code> is required when Request status is <code>approved</code>, <code>denied</code>, <code>narrowed</code>, <code>answered</code>, or <code>needs_revision</code>.</li>
+              <li><code>resolved_by_takeover_id</code> is required when Request status is <code>takeover</code>.</li>
+              <li><code>closed_by_event_ref</code> is required when Request status is <code>expired</code>, <code>cancelled</code>, or <code>superseded</code>.</li>
+              <li><code>superseded_by_request_id</code> is required when Request status is <code>superseded</code>.</li>
+              <li>The protocol rejects missing resolver refs with <code>missing_review_resolution</code>, <code>missing_takeover_resolution</code>, <code>missing_jarvis_event</code>, or <code>missing_superseding_request</code>.</li>
+            </ul>
+          </article>
+          <article class="spec-panel">
+            <h2>Review and ApprovalScope</h2>
+            <p>Review records human judgment. ApprovalScope is required when Review approves or narrows a Request.</p>
+            <div class="field-grid">
+              <div class="field-card"><h3>Review decisions</h3><p><code>approve</code>, <code>deny</code>, <code>narrow</code>, <code>answer</code>, <code>correct</code>, <code>takeover</code>, <code>needs_revision</code></p></div>
+              <div class="field-card"><h3>ApprovalScope binds</h3><p><code>request_id</code>, <code>review_id</code>, <code>policy_decision_id</code>, <code>request_revision</code>, <code>request_event_hash</code>, <code>normalized_action_hash</code>, <code>approved_action</code>, <code>allowed_scope</code>, <code>denied_scope</code>, <code>expires_at</code>, <code>max_uses</code>, <code>applies_to_work_session_id</code>, and <code>applies_to_actor_id</code></p></div>
+            </div>
+          </article>
+          <article class="spec-panel">
+            <h2>Takeover rules</h2>
+            <ul>
+              <li>Takeover records direct human control over the affected scope.</li>
+              <li>Takeover states are <code>requested</code>, <code>locked</code>, <code>human_active</code>, <code>reconciliation_required</code>, <code>resumed</code>, and <code>closed</code>.</li>
+              <li>Takeover uses <code>lock_epoch</code> to reject stale autonomous continuation.</li>
+              <li>Resumed Takeover requires <code>reconciliation_refs</code>, <code>resumed_by_actor_id</code>, and <code>resolved_at</code>.</li>
+              <li>The protocol rejects stale Takeover continuation and missing Takeover reconciliation.</li>
+            </ul>
+            <p>Allowed transitions are <code>requested -> locked</code>, <code>requested -> closed</code>, <code>locked -> human_active</code>, <code>locked -> reconciliation_required</code>, <code>locked -> closed</code>, <code>human_active -> reconciliation_required</code>, <code>human_active -> closed</code>, <code>reconciliation_required -> resumed</code>, <code>reconciliation_required -> closed</code>, and <code>resumed -> closed</code>.</p>
+            <div class="source-list"><a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/12-request-protocol.md">Source: request protocol</a><a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/11-core-protocol-objects.md">Source: field lock</a></div>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/demo/spec/security-zero-trust.html
+++ b/demo/spec/security-zero-trust.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Security and Zero Trust | Jarvis v0.1</title>
+    <meta name="description" content="Jarvis v0.1 security, mutation headers, Actor authority, revision, previous hash, and export safety rules." />
+    <link rel="icon" href="../assets/favicon.svg?v=spec1" type="image/svg+xml" />
+    <link rel="stylesheet" href="../assets/styles.css?v=spec1" />
+  </head>
+  <body>
+    <main class="shell spec-page">
+      <header class="topbar"><a class="brand" href="../"><span class="brand-mark">J</span><span><strong>Jarvis</strong><small>v0.1 specification</small></span></a><nav class="topnav" aria-label="Specification navigation"><a href="../">Home</a><a href="./">Spec</a><a href="../#openapi">OpenAPI</a><a href="../#conformance">Conformance</a><a href="../#boundary">Boundary</a></nav><span class="status-chip">v0.1</span></header>
+      <section class="spec-hero"><div><p class="kicker">Security and zero trust</p><h1>Every accepted mutation proves authority and state.</h1><p>Jarvis starts from zero trust. Compatible implementations verify headers, Actor authority, revision, previous event hash, idempotency, timestamp, and export safety.</p></div></section>
+      <section class="spec-layout">
+        <nav class="spec-side" aria-label="Specification pages"><a href="./">Introduction</a><a href="./terminology.html">Terminology</a><a href="./protocol-objects.html">Protocol objects</a><a href="./worksession-lifecycle.html">WorkSession lifecycle</a><a href="./policy-decision.html">Policy and PolicyDecision</a><a href="./request-review-takeover.html">Request, Review, ApprovalScope, and Takeover</a><a href="./contribution-evidence.html">Contribution and EvidenceManifest</a><a href="./learning-proposals.html">LearningRecord, MemoryProposal, and SkillProposal</a><a href="./outcome-report.html">OutcomeReport</a><a href="./versioning-extensions.html">Versioning and extensions</a><a href="./security-zero-trust.html" aria-current="page">Security and zero trust</a></nav>
+        <div class="spec-main">
+          <article class="spec-panel">
+            <h2>WorkSession-scoped mutation headers</h2>
+            <p>Every WorkSession-scoped mutating operation requires host authentication and these protocol headers:</p>
+            <ul>
+              <li><code>Jarvis-Protocol-Version</code></li>
+              <li><code>Jarvis-Actor-Id</code></li>
+              <li><code>Jarvis-Idempotency-Key</code></li>
+              <li><code>Jarvis-Request-Timestamp</code></li>
+              <li><code>Jarvis-Expected-WorkSession-Revision</code></li>
+              <li><code>Jarvis-Previous-Event-Hash</code></li>
+            </ul>
+          </article>
+          <article class="spec-panel">
+            <h2>WorkSession genesis rule</h2>
+            <p><code>createWorkSession</code> is the genesis WorkSession mutation. Compatible implementations MUST require <code>Jarvis-Expected-WorkSession-Revision</code> set to <code>0</code> and <code>Jarvis-Previous-Event-Hash</code> set to <code>hash:protocol-genesis</code>.</p>
+            <p>The accepted WorkSession snapshot starts as <code>active</code> at revision <code>1</code> with first event type <code>work_session.created</code>.</p>
+          </article>
+          <article class="spec-panel">
+            <h2>Non-WorkSession mutation headers</h2>
+            <p>Worker registration, Actor registration, and OutcomeReport submission require host authentication and the non-WorkSession mutation header set:</p>
+            <ul>
+              <li><code>Jarvis-Protocol-Version</code></li>
+              <li><code>Jarvis-Actor-Id</code></li>
+              <li><code>Jarvis-Idempotency-Key</code></li>
+              <li><code>Jarvis-Request-Timestamp</code></li>
+            </ul>
+            <p>They MUST NOT require fake WorkSession revision or previous event hash values.</p>
+          </article>
+          <article class="spec-panel">
+            <h2>Read and export headers</h2>
+            <p>WorkSession-scoped read operations and EvidenceManifest export reads require host authentication, <code>Jarvis-Protocol-Version</code>, and <code>Jarvis-Actor-Id</code>.</p>
+            <p>Read and export operations MUST NOT require mutation-only idempotency, expected revision, or previous event hash headers.</p>
+          </article>
+          <article class="spec-panel">
+            <h2>Accepted state checks</h2>
+            <div class="rule-grid">
+              <div class="rule-card"><h3>Actor</h3><p>Every accepted state change records the Actor and verifies authority.</p></div>
+              <div class="rule-card"><h3>Body match</h3><p>Actor-bearing mutation bodies match <code>Jarvis-Actor-Id</code>.</p></div>
+              <div class="rule-card"><h3>Revision</h3><p>WorkSession-scoped mutation checks the current revision against <code>Jarvis-Expected-WorkSession-Revision</code>.</p></div>
+              <div class="rule-card"><h3>Hash chain</h3><p>WorkSession-scoped mutation links to <code>Jarvis-Previous-Event-Hash</code>.</p></div>
+            </div>
+          </article>
+          <article class="spec-panel">
+            <h2>Rejection rules</h2>
+            <ul>
+              <li>The protocol rejects missing protocol version, Actor, idempotency key, timestamp, expected revision, or previous event hash when required.</li>
+              <li>The protocol rejects stale request timestamp, stale WorkSession revision, previous event hash mismatch, unauthorized Actor, and Actor mismatch.</li>
+              <li>The protocol rejects forbidden host-private fields in portable records and exports.</li>
+              <li>The protocol rejects sealed WorkSession and EvidenceManifest mutation.</li>
+            </ul>
+            <div class="source-list"><a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/15-openapi-communication-binding.md">Source: security binding</a><a href="https://github.com/Flow-Research/jarvis/blob/main/docs/conformance/checklist.md">Source: conformance checklist</a></div>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/demo/spec/terminology.html
+++ b/demo/spec/terminology.html
@@ -1,0 +1,93 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Terminology | Jarvis v0.1</title>
+    <meta name="description" content="Jarvis v0.1 terminology for HumanWorker, AgentWorker, WorkSession, Policy, Request, Review, Evidence, and Learning." />
+    <link rel="icon" href="../assets/favicon.svg?v=spec1" type="image/svg+xml" />
+    <link rel="stylesheet" href="../assets/styles.css?v=spec1" />
+  </head>
+  <body>
+    <main class="shell spec-page">
+      <header class="topbar" aria-label="Jarvis specification header">
+        <a class="brand" href="../"><span class="brand-mark">J</span><span><strong>Jarvis</strong><small>v0.1 specification</small></span></a>
+        <nav class="topnav" aria-label="Specification navigation">
+          <a href="../">Home</a>
+          <a href="./">Spec</a>
+          <a href="../#openapi">OpenAPI</a>
+          <a href="../#conformance">Conformance</a>
+          <a href="../#boundary">Boundary</a>
+        </nav>
+        <span class="status-chip">v0.1</span>
+      </header>
+
+      <section class="spec-hero">
+        <div>
+          <p class="kicker">Terminology</p>
+          <h1>Protocol terms have fixed meaning.</h1>
+          <p>Jarvis uses worker, actor, session, policy, request, review, evidence, and learning terms to describe portable human-agent collaboration records.</p>
+        </div>
+      </section>
+
+      <section class="spec-layout">
+        <nav class="spec-side" aria-label="Specification pages">
+          <a href="./">Introduction</a>
+          <a href="./terminology.html" aria-current="page">Terminology</a>
+          <a href="./protocol-objects.html">Protocol objects</a>
+          <a href="./worksession-lifecycle.html">WorkSession lifecycle</a>
+          <a href="./policy-decision.html">Policy and PolicyDecision</a>
+          <a href="./request-review-takeover.html">Request, Review, ApprovalScope, and Takeover</a>
+          <a href="./contribution-evidence.html">Contribution and EvidenceManifest</a>
+          <a href="./learning-proposals.html">LearningRecord, MemoryProposal, and SkillProposal</a>
+          <a href="./outcome-report.html">OutcomeReport</a>
+          <a href="./versioning-extensions.html">Versioning and extensions</a>
+          <a href="./security-zero-trust.html">Security and zero trust</a>
+        </nav>
+
+        <div class="spec-main">
+          <article class="spec-panel">
+            <h2>Core terms</h2>
+            <div class="field-grid">
+              <div class="field-card"><h3>Worker</h3><p>A protocol participant. Worker records identify who or what participates and the authority and accountability attached to that participant.</p></div>
+              <div class="field-card"><h3>Actor</h3><p>An acting identity for protocol events and contributions. Actor records bind accepted state to authority and contribution scope.</p></div>
+              <div class="field-card"><h3>HumanWorker</h3><p>The accountable human participant. HumanWorker owns direction, policy authority, review authority, correction, and takeover judgment.</p></div>
+              <div class="field-card"><h3>AgentWorker</h3><p>The agent participant. AgentWorker contributes planning, research, drafting, evidence collection, and governed improvement proposals through host-owned execution.</p></div>
+              <div class="field-card"><h3>Host</h3><p>The implementation environment. Hosts own UI, identity, auth, storage, execution, tools, models, monitoring, deployment, and workflow.</p></div>
+              <div class="field-card"><h3>Compatible implementation</h3><p>A host or external system that produces, validates, rejects, exports, and preserves Jarvis-compatible protocol records.</p></div>
+            </div>
+          </article>
+
+          <article class="spec-panel">
+            <h2>Work terms</h2>
+            <div class="rule-grid">
+              <div class="rule-card"><h3>WorkSession</h3><p>The durable record of a focused unit of human-agent work. WorkSession is the source of truth for protocol state.</p></div>
+              <div class="rule-card"><h3>JarvisEvent</h3><p>An append-only event with sequence, Actor, timestamp, payload, previous hash, and event hash.</p></div>
+              <div class="rule-card"><h3>Policy</h3><p>The human-owned boundary for autonomous AgentWorker action.</p></div>
+              <div class="rule-card"><h3>PolicyDecision</h3><p>The protocol record that explains why an AgentWorker action is allowed, denied, narrowed, or sent for human review.</p></div>
+            </div>
+          </article>
+
+          <article class="spec-panel">
+            <h2>Control and proof terms</h2>
+            <ul>
+              <li><code>Request</code> records scoped deferral when AgentWorker cannot continue safely without human input.</li>
+              <li><code>Review</code> records human judgment over a Request, artifact, action, contribution, evidence item, or outcome.</li>
+              <li><code>ApprovalScope</code> bounds Review-approved continuation to a specific request, action, Actor, WorkSession, expiry, and max use count.</li>
+              <li><code>Takeover</code> records direct human control over a scope and blocks stale autonomous continuation with a lock epoch.</li>
+              <li><code>Contribution</code> records who did what and preserves individual refs for shared work.</li>
+              <li><code>EvidenceManifest</code> exports portable proof without host-private fields.</li>
+              <li><code>LearningRecord</code> records what the human, agent, or pair learned from source events.</li>
+              <li><code>MemoryProposal</code> and <code>SkillProposal</code> keep future behavior changes governed.</li>
+              <li><code>OutcomeReport</code> carries post-session feedback into governed LearningRecords without mutating sealed records.</li>
+            </ul>
+            <div class="source-list">
+              <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/11-core-protocol-objects.md">Source: core objects</a>
+              <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/12-request-protocol.md">Source: request protocol</a>
+            </div>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/demo/spec/versioning-extensions.html
+++ b/demo/spec/versioning-extensions.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Versioning and Extensions | Jarvis v0.1</title>
+    <meta name="description" content="Jarvis v0.1 version negotiation, capability negotiation, and extension rules." />
+    <link rel="icon" href="../assets/favicon.svg?v=spec1" type="image/svg+xml" />
+    <link rel="stylesheet" href="../assets/styles.css?v=spec1" />
+  </head>
+  <body>
+    <main class="shell spec-page">
+      <header class="topbar"><a class="brand" href="../"><span class="brand-mark">J</span><span><strong>Jarvis</strong><small>v0.1 specification</small></span></a><nav class="topnav" aria-label="Specification navigation"><a href="../">Home</a><a href="./">Spec</a><a href="../#openapi">OpenAPI</a><a href="../#conformance">Conformance</a><a href="../#boundary">Boundary</a></nav><span class="status-chip">v0.1</span></header>
+      <section class="spec-hero"><div><p class="kicker">Versioning and extensions</p><h1>Compatibility requires explicit version and capability checks.</h1><p>Jarvis v0.1 uses OpenAPI 3.1 as the machine binding and rejects silent downgrade, unsupported required capability, and extension core-field override.</p></div></section>
+      <section class="spec-layout">
+        <nav class="spec-side" aria-label="Specification pages"><a href="./">Introduction</a><a href="./terminology.html">Terminology</a><a href="./protocol-objects.html">Protocol objects</a><a href="./worksession-lifecycle.html">WorkSession lifecycle</a><a href="./policy-decision.html">Policy and PolicyDecision</a><a href="./request-review-takeover.html">Request, Review, ApprovalScope, and Takeover</a><a href="./contribution-evidence.html">Contribution and EvidenceManifest</a><a href="./learning-proposals.html">LearningRecord, MemoryProposal, and SkillProposal</a><a href="./outcome-report.html">OutcomeReport</a><a href="./versioning-extensions.html" aria-current="page">Versioning and extensions</a><a href="./security-zero-trust.html">Security and zero trust</a></nav>
+        <div class="spec-main">
+          <article class="spec-panel">
+            <h2>Version rules</h2>
+            <ul>
+              <li><code>Jarvis-Protocol-Version</code> identifies the protocol line.</li>
+              <li>OpenAPI <code>info.version</code> identifies the OpenAPI artifact version.</li>
+              <li>Compatible implementations MUST NOT silently downgrade a request.</li>
+              <li>Unsupported protocol version rejects as <code>unsupported_protocol_version</code>.</li>
+            </ul>
+          </article>
+          <article class="spec-panel">
+            <h2>Capability negotiation</h2>
+            <p><code>Jarvis-Required-Capabilities</code> binds a request to capabilities the caller requires. Compatible minor version proceeds only when required capabilities match.</p>
+            <div class="rule-grid">
+              <div class="rule-card"><h3>Supported capability</h3><p>The implementation proceeds only when the capability is supported and the operation allows capability negotiation.</p></div>
+              <div class="rule-card"><h3>Unsupported capability</h3><p>The protocol rejects unsupported required capability as <code>unsupported_capability</code>.</p></div>
+            </div>
+          </article>
+          <article class="spec-panel">
+            <h2>Extension rules</h2>
+            <ul>
+              <li>Extensions add protocol-visible fields only under valid extension namespaces.</li>
+              <li>Extensions MUST NOT override core protocol fields.</li>
+              <li>Extensions MUST NOT define runtime, workflow, UI, auth, storage, model calls, tool execution, billing, scoring, payment, or deployment behavior.</li>
+              <li>Invalid extension namespace rejects as <code>invalid_extension_namespace</code>.</li>
+              <li>Extension core field override rejects as <code>extension_core_field_override</code>.</li>
+            </ul>
+            <div class="source-list"><a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/15-openapi-communication-binding.md">Source: OpenAPI binding</a><a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/14-protocol-lock.md">Source: protocol lock</a></div>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/demo/spec/worksession-lifecycle.html
+++ b/demo/spec/worksession-lifecycle.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>WorkSession Lifecycle | Jarvis v0.1</title>
+    <meta name="description" content="Jarvis v0.1 WorkSession lifecycle, event chain, terminal states, and export rules." />
+    <link rel="icon" href="../assets/favicon.svg?v=spec1" type="image/svg+xml" />
+    <link rel="stylesheet" href="../assets/styles.css?v=spec1" />
+  </head>
+  <body>
+    <main class="shell spec-page">
+      <header class="topbar"><a class="brand" href="../"><span class="brand-mark">J</span><span><strong>Jarvis</strong><small>v0.1 specification</small></span></a><nav class="topnav" aria-label="Specification navigation"><a href="../">Home</a><a href="./">Spec</a><a href="../#openapi">OpenAPI</a><a href="../#conformance">Conformance</a><a href="../#boundary">Boundary</a></nav><span class="status-chip">v0.1</span></header>
+      <section class="spec-hero"><div><p class="kicker">WorkSession lifecycle</p><h1>WorkSession is the source of truth.</h1><p>A WorkSession records the focused unit of human-agent collaboration, its event chain, revision, policy, requests, reviews, contributions, evidence, and learning.</p></div></section>
+      <section class="spec-layout">
+        <nav class="spec-side" aria-label="Specification pages"><a href="./">Introduction</a><a href="./terminology.html">Terminology</a><a href="./protocol-objects.html">Protocol objects</a><a href="./worksession-lifecycle.html" aria-current="page">WorkSession lifecycle</a><a href="./policy-decision.html">Policy and PolicyDecision</a><a href="./request-review-takeover.html">Request, Review, ApprovalScope, and Takeover</a><a href="./contribution-evidence.html">Contribution and EvidenceManifest</a><a href="./learning-proposals.html">LearningRecord, MemoryProposal, and SkillProposal</a><a href="./outcome-report.html">OutcomeReport</a><a href="./versioning-extensions.html">Versioning and extensions</a><a href="./security-zero-trust.html">Security and zero trust</a></nav>
+        <div class="spec-main">
+          <article class="spec-panel">
+            <h2>Lifecycle states</h2>
+            <div class="rule-grid">
+              <div class="rule-card"><h3>active</h3><p>The accepted WorkSession starts as <code>active</code> at revision <code>1</code> after the genesis mutation records <code>work_session.created</code>.</p></div>
+              <div class="rule-card"><h3>waiting_on_human</h3><p>A Request blocks a declared scope while unrelated safe branches remain available inside Policy.</p></div>
+              <div class="rule-card"><h3>takeover</h3><p>HumanWorker controls the affected scope through a Takeover record and lock epoch.</p></div>
+              <div class="rule-card"><h3>reconciling</h3><p>The WorkSession records reconciliation after Takeover before autonomous continuation resumes.</p></div>
+              <div class="rule-card"><h3>completed, failed, cancelled</h3><p>Terminal outcome states allow final EvidenceManifest export when export requirements pass.</p></div>
+              <div class="rule-card"><h3>closed</h3><p><code>closed</code> is the sealed archival state. The protocol rejects mutation after <code>closed</code>.</p></div>
+            </div>
+          </article>
+          <article class="spec-panel">
+            <h2>Event chain rules</h2>
+            <ul>
+              <li>Every accepted WorkSession-scoped state change records the Actor.</li>
+              <li>Every accepted WorkSession-scoped mutation verifies Actor authority.</li>
+              <li>Every accepted WorkSession-scoped mutation checks the current WorkSession revision.</li>
+              <li>Every accepted WorkSession-scoped mutation links to the previous event hash.</li>
+              <li>Every JarvisEvent carries <code>sequence</code>, <code>previous_hash</code>, <code>event_hash</code>, and <code>canonicalization</code>.</li>
+              <li>The protocol rejects stale revision, previous event hash mismatch, missing Actor, and unauthorized Actor.</li>
+            </ul>
+          </article>
+          <article class="spec-panel">
+            <h2>Export rules</h2>
+            <p>EvidenceManifest export happens only from valid WorkSession states. Export includes protocol evidence and excludes host-private fields.</p>
+            <div class="field-grid">
+              <div class="field-card"><h3>Export includes</h3><p>policy decisions, requests, reviews, takeovers, contributions, artifacts, evidence items, limitations, and event-chain refs.</p></div>
+              <div class="field-card"><h3>Export rejects</h3><p>credentials, secrets, raw runtime state, host-only database ids, deployment details, billing data, private scores, UI state, raw auth tokens, provider secrets, session cookies, and private keys.</p></div>
+            </div>
+            <div class="source-list"><a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/04-work-sessions.md">Source: WorkSessions</a><a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/11-core-protocol-objects.md">Source: core objects</a></div>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/scripts/check_docs_site.py
+++ b/scripts/check_docs_site.py
@@ -9,7 +9,6 @@ import sys
 
 ROOT = Path(__file__).resolve().parents[1]
 SITE_ROOT = ROOT / "demo"
-INDEX = SITE_ROOT / "index.html"
 RAW_PREFIX = "/Flow-Research/jarvis/main/"
 BLOB_PREFIX = "/Flow-Research/jarvis/blob/main/"
 
@@ -33,11 +32,26 @@ def clean_ref(value: str) -> str:
     return value.split("?", 1)[0].split("#", 1)[0]
 
 
-def local_target_exists(value: str) -> bool:
+def parse_html(path: Path) -> SiteParser:
+    parser = SiteParser()
+    parser.feed(path.read_text(encoding="utf-8"))
+    return parser
+
+
+def local_target(value: str, source: Path) -> Path:
+    target = clean_ref(value)
+    resolved = (source.parent / target).resolve()
+    if resolved.is_dir():
+        return resolved / "index.html"
+    return resolved
+
+
+def local_target_exists(value: str, source: Path) -> bool:
     target = clean_ref(value)
     if not target:
         return True
-    return (SITE_ROOT / target).resolve().is_relative_to(SITE_ROOT) and (SITE_ROOT / target).resolve().exists()
+    resolved = local_target(value, source)
+    return resolved.is_relative_to(SITE_ROOT) and resolved.exists()
 
 
 def github_target_exists(value: str) -> bool:
@@ -54,27 +68,37 @@ def github_target_exists(value: str) -> bool:
 
 
 def main() -> int:
-    parser = SiteParser()
-    parser.feed(INDEX.read_text(encoding="utf-8"))
+    html_files = sorted(SITE_ROOT.rglob("*.html"))
+    parsed = {path: parse_html(path) for path in html_files}
     failures: list[str] = []
 
-    for attr, value in parser.refs:
-        if value.startswith("#"):
-            fragment = value[1:]
-            if fragment and fragment not in parser.ids:
-                failures.append(f"{INDEX.relative_to(ROOT)}: missing fragment target {value}")
-            continue
-        if value.startswith("./"):
-            if not local_target_exists(value):
-                failures.append(f"{INDEX.relative_to(ROOT)}: broken local {attr}: {value}")
-            continue
-        if value.startswith("https://"):
-            if not github_target_exists(value):
-                failures.append(f"{INDEX.relative_to(ROOT)}: unsupported or broken external {attr}: {value}")
-            continue
-        if value.startswith("mailto:"):
-            continue
-        failures.append(f"{INDEX.relative_to(ROOT)}: unsupported {attr}: {value}")
+    for path, parser in parsed.items():
+        for attr, value in parser.refs:
+            if value.startswith("#"):
+                fragment = value[1:]
+                if fragment and fragment not in parser.ids:
+                    failures.append(f"{path.relative_to(ROOT)}: missing fragment target {value}")
+                continue
+            if value.startswith("https://"):
+                if not github_target_exists(value):
+                    failures.append(f"{path.relative_to(ROOT)}: unsupported or broken external {attr}: {value}")
+                continue
+            if value.startswith("mailto:"):
+                continue
+
+            if not local_target_exists(value, path):
+                failures.append(f"{path.relative_to(ROOT)}: broken local {attr}: {value}")
+                continue
+
+            parsed_ref = clean_ref(value)
+            fragment = value.split("#", 1)[1] if "#" in value else ""
+            target = local_target(parsed_ref, path) if parsed_ref else path
+            if fragment and target.suffix == ".html":
+                target_parser = parsed.get(target)
+                if target_parser is None:
+                    failures.append(f"{path.relative_to(ROOT)}: unparsed HTML target {value}")
+                elif fragment not in target_parser.ids:
+                    failures.append(f"{path.relative_to(ROOT)}: missing target fragment {value}")
 
     if failures:
         print("\n".join(failures))

--- a/scripts/check_protocol_wording.py
+++ b/scripts/check_protocol_wording.py
@@ -7,7 +7,11 @@ import sys
 
 
 ROOT = Path(__file__).resolve().parents[1]
-FILES = [*ROOT.glob("*.md"), *ROOT.joinpath("docs").rglob("*.md")]
+FILES = [
+    *ROOT.glob("*.md"),
+    *ROOT.joinpath("docs").rglob("*.md"),
+    *ROOT.joinpath("demo").rglob("*.html"),
+]
 NORMATIVE_TERMS = {"MUST", "MUST NOT", "SHOULD", "SHOULD NOT", "MAY"}
 NORMATIVE_TERM_PATTERN = re.compile(
     r"`(?:MUST|MUST NOT|SHOULD|SHOULD NOT|MAY)`"


### PR DESCRIPTION
## Summary

Adds public v0.1 protocol specification pages under `demo/spec/` and wires the docs home page to the new spec surface. The pages cover terminology, protocol objects, WorkSession lifecycle, PolicyDecision, Request/Review/ApprovalScope/Takeover, Contribution/EvidenceManifest, governed learning proposals, OutcomeReport, versioning/extensions, and zero-trust mutation rules.

Closes #60.

## Protocol Surface

- Adds static specification pages with source links back to protocol docs and OpenAPI.
- Keeps Jarvis protocol-only: no host runtime, adapter, wrapper, workflow, auth, storage, model, or tool execution behavior is added.
- Expands docs-site validation to crawl all HTML pages and validate local fragments, directory index links, GitHub source links, and assets.
- Expands the protocol wording guard to include public HTML docs.

## Review

- Protocol boundary and wording reviewer: no content drift found; tooling gap fixed by scanning HTML.
- Spec coverage reviewer: lifecycle, genesis, resolver refs, Takeover transitions, exact labels, and required fields tightened.
- Security/conformance reviewer: read/export headers, terminal OutcomeReport source wording, PolicyDecision deny rule, and forbidden export fields tightened.
- Frontend reviewer: focus visibility, sticky side-nav overflow, top-nav labels, and directory-fragment validation fixed.

## Validation

- `npm run check:protocol`
- `python3 scripts/check_docs_site.py`
- `python3 scripts/check_protocol_wording.py`
- `node --check demo/assets/app.js`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new v0.1 specification site with expanded navigation and more detailed protocol reference pages.
  * Introduced several new spec pages covering terminology, protocol objects, lifecycle, policy decisions, contribution evidence, learning proposals, outcome reports, security, and versioning.

* **Bug Fixes**
  * Improved site link handling so documentation links are validated across the full docs site.
  * Updated responsive styling for better reading and navigation on smaller screens.

* **Documentation**
  * Refreshed landing-page content and routing to make the spec easier to browse and follow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->