### PR TITLE
[codex] Add docs site implementer guides

### DIFF
--- a/demo/guides/evidence-learning.html
+++ b/demo/guides/evidence-learning.html
@@ -1,0 +1,124 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Evidence and Learning Guide | Jarvis v0.1</title>
+    <meta
+      name="description"
+      content="Jarvis v0.1 guide for Contribution, EvidenceManifest export, LearningRecord, MemoryProposal, SkillProposal, and OutcomeReport."
+    />
+    <link rel="icon" href="../assets/favicon.svg?v=guides1" type="image/svg+xml" />
+    <link rel="stylesheet" href="../assets/styles.css?v=guides1" />
+  </head>
+  <body>
+    <a class="skip-link" href="#main-content">Skip to content</a>
+    <main class="shell spec-page">
+      <header class="topbar">
+        <a class="brand" href="../" aria-label="Jarvis documentation home">
+          <span class="brand-mark">J</span>
+          <span><strong>Jarvis</strong><small>evidence and learning</small></span>
+        </a>
+        <nav class="topnav" aria-label="Guide navigation">
+          <a href="../">Home</a>
+          <a href="../spec/">Spec</a>
+          <a href="../openapi/">OpenAPI</a>
+          <a href="../conformance/">Conformance</a>
+          <a href="./" aria-current="location">Guides</a>
+        </nav>
+        <span class="status-chip">v0.1.0</span>
+      </header>
+
+      <section class="spec-hero">
+        <div>
+          <p class="kicker">Evidence and governed learning</p>
+          <h1>Useful work leaves proof and governed improvement.</h1>
+          <p>
+            Contribution records who did what. EvidenceManifest exports
+            portable proof. LearningRecord captures accepted learning for the
+            human, agent, or pair. MemoryProposal and SkillProposal remain
+            proposals until governed review accepts them. OutcomeReport brings
+            terminal-source feedback into the learning loop.
+          </p>
+        </div>
+        <a class="command primary" href="./examples.html#evidence-learning">Open example</a>
+      </section>
+
+      <section class="spec-layout">
+        <nav class="spec-side" aria-label="Implementer guide pages">
+          <a href="./">Overview</a>
+          <a href="./implementer.html">Implementer guide</a>
+          <a href="./existing-agent.html">Existing-agent compatibility</a>
+          <a href="./request-review-takeover.html">Request, Review, Takeover</a>
+          <a href="./evidence-learning.html" aria-current="page">Evidence and Learning</a>
+          <a href="./extensions.html">Extensions</a>
+          <a href="./protocol-errors.html">Protocol errors</a>
+          <a href="./examples.html">Protocol examples</a>
+        </nav>
+
+        <div class="spec-main" id="main-content">
+          <article class="spec-panel">
+            <h2>Must store and emit</h2>
+            <div class="field-grid">
+              <div class="field-card">
+                <h3>Contribution</h3>
+                <p>Store contributor_refs for human, agent, service, tool, or shared contributors. Shared Contribution preserves individual contributor refs.</p>
+              </div>
+              <div class="field-card">
+                <h3>EvidenceManifest</h3>
+                <p>Export only from valid terminal WorkSession states and include event-backed evidence_item_refs, policy_decision_refs, request_refs, review_refs, takeover_refs, and contribution_refs.</p>
+              </div>
+              <div class="field-card">
+                <h3>LearningRecord</h3>
+                <p>Store subject_type as human, agent, or pair, with source_event_refs and review_state.</p>
+              </div>
+              <div class="field-card">
+                <h3>OutcomeReport</h3>
+                <p>Accept post-session feedback only for terminal source WorkSession state and require learning_record_refs.</p>
+              </div>
+            </div>
+          </article>
+
+          <article class="spec-panel">
+            <h2>Must reject</h2>
+            <ul>
+              <li>EvidenceManifest export with forbidden host-private fields.</li>
+              <li>EvidenceManifest export from a non-terminal source WorkSession.</li>
+              <li>Mutation of sealed WorkSession or sealed EvidenceManifest records.</li>
+              <li>MemoryProposal self-confirmed from model or tool output.</li>
+              <li>SkillProposal activation without review.</li>
+              <li>SkillProposal tool-access expansion without Policy review.</li>
+              <li>OutcomeReport without LearningRecord reference.</li>
+              <li>OutcomeReport whose source WorkSession is not terminal.</li>
+            </ul>
+          </article>
+
+          <article class="spec-panel">
+            <h2>Learning loop</h2>
+            <pre class="code-sample"><code>WorkSession completed
+  -> EvidenceManifest exported
+  -> OutcomeReport submitted
+  -> LearningRecord accepted
+  -> MemoryProposal or SkillProposal remains governed
+  -> future WorkSession carries accepted learning forward</code></pre>
+          </article>
+
+          <article class="spec-panel">
+            <h2>Host boundary</h2>
+            <p>Hosts own UI, auth, storage, runtime behavior, model routing, tool execution, billing, scoring, payment, deployment, monitoring, and host workflow.</p>
+            <p>Jarvis owns Contribution, EvidenceManifest, LearningRecord, MemoryProposal, SkillProposal, and OutcomeReport protocol records.</p>
+          </article>
+
+          <article class="spec-panel" id="sources">
+            <h2>Source contracts</h2>
+            <div class="source-list">
+              <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/13-contribution-evidence-learning.md">Source: evidence and learning</a>
+              <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/examples/protocol-records.md">Source: protocol record examples</a>
+              <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/conformance/failure-modes.md">Source: failure modes</a>
+            </div>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/demo/guides/evidence-learning.html
+++ b/demo/guides/evidence-learning.html
@@ -24,7 +24,7 @@
           <a href="../spec/">Spec</a>
           <a href="../openapi/">OpenAPI</a>
           <a href="../conformance/">Conformance</a>
-          <a href="./" aria-current="location">Guides</a>
+          <a href="./">Guides</a>
         </nav>
         <span class="status-chip">v0.1.0</span>
       </header>
@@ -96,11 +96,11 @@
           <article class="spec-panel">
             <h2>Learning loop</h2>
             <pre class="code-sample"><code>WorkSession completed
-  -> EvidenceManifest exported
-  -> OutcomeReport submitted
-  -> LearningRecord accepted
-  -> MemoryProposal or SkillProposal remains governed
-  -> future WorkSession carries accepted learning forward</code></pre>
+  -&gt; EvidenceManifest exported
+  -&gt; OutcomeReport submitted
+  -&gt; LearningRecord accepted
+  -&gt; MemoryProposal or SkillProposal remains governed
+  -&gt; future WorkSession carries accepted learning forward</code></pre>
           </article>
 
           <article class="spec-panel">

--- a/demo/guides/examples.html
+++ b/demo/guides/examples.html
@@ -1,0 +1,422 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Protocol Examples | Jarvis v0.1</title>
+    <meta
+      name="description"
+      content="Jarvis v0.1 protocol-only examples for WorkSession flow, PolicyDecision, Request, Review, Takeover, EvidenceManifest, and OutcomeReport learning."
+    />
+    <link rel="icon" href="../assets/favicon.svg?v=guides1" type="image/svg+xml" />
+    <link rel="stylesheet" href="../assets/styles.css?v=guides1" />
+  </head>
+  <body>
+    <a class="skip-link" href="#main-content">Skip to content</a>
+    <main class="shell spec-page">
+      <header class="topbar">
+        <a class="brand" href="../" aria-label="Jarvis documentation home">
+          <span class="brand-mark">J</span>
+          <span><strong>Jarvis</strong><small>protocol examples</small></span>
+        </a>
+        <nav class="topnav" aria-label="Guide navigation">
+          <a href="../">Home</a>
+          <a href="../spec/">Spec</a>
+          <a href="../openapi/">OpenAPI</a>
+          <a href="../conformance/">Conformance</a>
+          <a href="./" aria-current="location">Guides</a>
+        </nav>
+        <span class="status-chip">v0.1.0</span>
+      </header>
+
+      <section class="spec-hero">
+        <div>
+          <p class="kicker">Protocol-only examples</p>
+          <h1>Use v0.1 records to prove the collaboration loop.</h1>
+          <p>
+            These examples show protocol records only. They do not implement
+            agent runtime behavior, adapters, wrappers, model routing, tool
+            execution, auth provider, storage backend, UI, billing, scoring,
+            payment, deployment, or host workflow.
+          </p>
+        </div>
+        <a class="command primary" href="https://github.com/Flow-Research/jarvis/blob/main/docs/examples/protocol-records.md">Full source examples</a>
+      </section>
+
+      <section class="spec-layout">
+        <nav class="spec-side" aria-label="Implementer guide pages">
+          <a href="./">Overview</a>
+          <a href="./implementer.html">Implementer guide</a>
+          <a href="./existing-agent.html">Existing-agent compatibility</a>
+          <a href="./request-review-takeover.html">Request, Review, Takeover</a>
+          <a href="./evidence-learning.html">Evidence and Learning</a>
+          <a href="./extensions.html">Extensions</a>
+          <a href="./protocol-errors.html">Protocol errors</a>
+          <a href="./examples.html" aria-current="page">Protocol examples</a>
+        </nav>
+
+        <div class="spec-main" id="main-content">
+          <article class="spec-panel" id="minimal-worksession">
+            <h2>Minimal WorkSession record flow</h2>
+            <pre class="code-sample"><code>{
+  "object_type": "WorkSession",
+  "record": {
+    "id": "ws-golden-001",
+    "protocol_version": "v0.1",
+    "created_by_actor_id": "actor-human-golden",
+    "objective": "Produce an evidence-backed answer with human review and governed learning.",
+    "human_worker_id": "worker-human-golden",
+    "agent_worker_id": "worker-agent-golden",
+    "policy_id": "policy-golden-bounded",
+    "status": "completed",
+    "revision": 11,
+    "last_event_hash": "hash:event-worksession-completed",
+    "event_log_ref": "event-log:ws-golden-001",
+    "created_at": "2026-06-16T10:01:00Z",
+    "updated_at": "2026-06-16T10:25:00Z",
+    "source_ref": "source:golden-path-fixture",
+    "context_manifest_ref": "context:task-brief",
+    "contribution_ledger_ref": "ledger:ws-golden-001",
+    "evidence_manifest_ref": "evidence-manifest-golden",
+    "learning_record_refs": [
+      "learning-golden-pair"
+    ]
+  }
+}</code></pre>
+          </article>
+
+          <article class="spec-panel" id="policy-decision">
+            <h2>PolicyDecision before AgentWorker action</h2>
+            <pre class="code-sample"><code>{
+  "object_type": "PolicyDecision",
+  "record": {
+    "id": "pd-golden-source-denied",
+    "work_session_id": "ws-golden-001",
+    "actor_id": "actor-agent-golden",
+    "policy_id": "policy-golden-bounded",
+    "requested_action": {
+      "action": "fetch_external_source",
+      "target_ref": "source:external-reference",
+      "scope_ref": "scope:external-source"
+    },
+    "normalized_action_hash": "hash:action-fetch-external-source",
+    "risk_class": "medium",
+    "result": "deny",
+    "reason": "Policy requires HumanWorker review before external source collection.",
+    "created_at": "2026-06-16T10:04:00Z",
+    "data_sensitivity": "public",
+    "denied_grant_refs": [
+      "grant:external-source-read"
+    ],
+    "request_id": "req-golden-source"
+  }
+}</code></pre>
+          </article>
+
+          <article class="spec-panel" id="request-review">
+            <h2>Scoped Request and Review resolution</h2>
+            <pre class="code-sample"><code>{
+  "object_type": "Request",
+  "record": {
+    "id": "req-golden-source",
+    "protocol_version": "v0.1",
+    "work_session_id": "ws-golden-001",
+    "requester_actor_id": "actor-agent-golden",
+    "requester_worker_id": "worker-agent-golden",
+    "target_human_worker_id": "worker-human-golden",
+    "policy_decision_id": "pd-golden-source-denied",
+    "type": "permission",
+    "blocking_scope": "action",
+    "reason_code": "policy_denied",
+    "reason_summary": "External source access is outside current Policy until HumanWorker review.",
+    "requested_action": {
+      "action": "fetch_external_source",
+      "target_ref": "source:external-reference",
+      "scope_ref": "scope:external-source"
+    },
+    "requested_outcome": "Approve external source collection for this WorkSession only.",
+    "risk_class": "medium",
+    "human_decision_needed": "Approve, narrow, deny, correct, or take over the blocked action.",
+    "options": [
+      {
+        "id": "option-approve-current-session",
+        "label": "Approve current WorkSession scope",
+        "effect": "AgentWorker collects the referenced source for this WorkSession only.",
+        "risk_class": "medium",
+        "scope_ref": "scope:external-source"
+      },
+      {
+        "id": "option-deny",
+        "label": "Deny external collection",
+        "effect": "AgentWorker continues with existing evidence and records the limitation.",
+        "risk_class": "low",
+        "scope_ref": "scope:local-worksession"
+      }
+    ],
+    "default_if_no_response": {
+      "action": "continue_with_limited_evidence",
+      "reason": "The blocked action remains stopped and the WorkSession records an evidence limitation.",
+      "limitation_ref": "limitation:external-source-not-reviewed"
+    },
+    "status": "approved",
+    "created_at": "2026-06-16T10:05:00Z",
+    "expires_at": "2026-06-16T10:35:00Z",
+    "missing_permission_or_context": "Policy grant for external source collection",
+    "policy_refs": [
+      "policy-golden-bounded"
+    ],
+    "data_sensitivity": "public",
+    "recommended_option": "option-approve-current-session",
+    "resolved_at": "2026-06-16T10:08:00Z",
+    "resolved_by_review_id": "review-golden-source-approval"
+  }
+}</code></pre>
+            <pre class="code-sample"><code>{
+  "object_type": "Review",
+  "record": {
+    "id": "review-golden-source-approval",
+    "work_session_id": "ws-golden-001",
+    "reviewer_actor_id": "actor-human-golden",
+    "reviewer_worker_id": "worker-human-golden",
+    "target_ref": "request:req-golden-source",
+    "decision": "approve",
+    "created_at": "2026-06-16T10:08:00Z",
+    "comments": "Approved for the referenced source and current WorkSession only.",
+    "approval_scope": {
+      "request_id": "req-golden-source",
+      "review_id": "review-golden-source-approval",
+      "policy_decision_id": "pd-golden-source-denied",
+      "request_revision": 3,
+      "request_event_hash": "hash:event-request-created",
+      "normalized_action_hash": "hash:action-fetch-external-source",
+      "approved_action": {
+        "action": "fetch_external_source",
+        "target_ref": "source:external-reference",
+        "scope_ref": "scope:external-source"
+      },
+      "allowed_scope": {
+        "scope_ref": "scope:external-source",
+        "grant_refs": [
+          "grant:review-approved-external-source"
+        ]
+      },
+      "denied_scope": {
+        "scope_ref": "scope:all-other-external-sources"
+      },
+      "expires_at": "2026-06-16T10:35:00Z",
+      "max_uses": 1,
+      "applies_to_work_session_id": "ws-golden-001",
+      "applies_to_actor_id": "actor-agent-golden"
+    }
+  }
+}</code></pre>
+          </article>
+
+          <article class="spec-panel" id="takeover">
+            <h2>Takeover and reconciliation</h2>
+            <pre class="code-sample"><code>{
+  "object_type": "Takeover",
+  "record": {
+    "id": "takeover-final-submission",
+    "work_session_id": "ws-takeover-001",
+    "requested_by_actor_id": "actor-agent-takeover",
+    "controlling_actor_id": "actor-human-takeover",
+    "request_id": "req-takeover-final",
+    "affected_scope": {
+      "blocking_scope": "final_submission",
+      "scope_ref": "scope:final-output",
+      "normalized_action_hash": "hash:action-final-submission",
+      "artifact_refs": [
+        "artifact:final-draft"
+      ]
+    },
+    "reason": "HumanWorker completed direct control and returned reconciliation refs.",
+    "lock_epoch": 2,
+    "state": "resumed",
+    "created_at": "2026-06-17T10:12:00Z",
+    "resumed_by_actor_id": "actor-human-takeover",
+    "reconciliation_notes": "HumanWorker edited final claim and approved AgentWorker continuation inside reconciled scope.",
+    "reconciliation_refs": [
+      "artifact:final-draft-human-edited",
+      "event:event-takeover-resumed"
+    ],
+    "resolved_at": "2026-06-17T10:12:00Z"
+  }
+}</code></pre>
+          </article>
+
+          <article class="spec-panel" id="evidence-learning">
+            <h2>Contribution and EvidenceManifest export</h2>
+            <pre class="code-sample"><code>{
+  "object_type": "Contribution",
+  "record": {
+    "id": "contribution-golden-shared-answer",
+    "work_session_id": "ws-golden-001",
+    "contributor_type": "shared",
+    "contributor_refs": [
+      {
+        "worker_id": "worker-human-golden",
+        "actor_id": "actor-human-golden",
+        "contribution_role": "human"
+      },
+      {
+        "worker_id": "worker-agent-golden",
+        "actor_id": "actor-agent-golden",
+        "contribution_role": "agent"
+      }
+    ],
+    "contribution_type": "artifact",
+    "event_refs": [
+      "event-evidence-captured",
+      "event-contribution-recorded"
+    ],
+    "created_at": "2026-06-16T10:16:00Z",
+    "artifact_refs": [
+      "artifact:reviewed-answer"
+    ],
+    "review_refs": [
+      "review-golden-source-approval"
+    ],
+    "evidence_refs": [
+      "evidence-source-summary"
+    ],
+    "confidence": 0.92,
+    "limitations": [
+      "limitation:none-recorded"
+    ]
+  }
+}</code></pre>
+            <pre class="code-sample"><code>{
+  "evidence_manifest": {
+    "id": "evidence-manifest-golden",
+    "work_session_id": "ws-golden-001",
+    "generated_by_actor_id": "actor-human-golden",
+    "objective": "Produce an evidence-backed answer with human review and governed learning.",
+    "event_chain_root": "hash:event-worksession-completed",
+    "evidence_item_refs": [
+      {
+        "id": "evidence-source-summary",
+        "work_session_id": "ws-golden-001",
+        "source_event_refs": [
+          "event-evidence-captured"
+        ],
+        "captured_by_actor_id": "actor-agent-golden",
+        "evidence_type": "source_summary",
+        "artifact_ref": "artifact:source-summary",
+        "content_hash": "hash:source-summary",
+        "trust_label": "reviewed",
+        "redaction_state": "redacted",
+        "captured_at": "2026-06-16T10:12:00Z",
+        "limitation_refs": [
+          "limitation:none-recorded"
+        ]
+      }
+    ],
+    "policy_decision_refs": [
+      "pd-golden-source-denied",
+      "pd-golden-source-approved"
+    ],
+    "request_refs": [
+      "req-golden-source"
+    ],
+    "review_refs": [
+      "review-golden-source-approval"
+    ],
+    "takeover_refs": [],
+    "contribution_refs": [
+      "contribution-golden-shared-answer"
+    ],
+    "export_profile": {
+      "profile": "portable_evidence_manifest",
+      "version": "v0.1",
+      "redaction_profile_ref": "redaction:portable-safe"
+    },
+    "generated_at": "2026-06-16T10:26:00Z",
+    "artifact_refs": [
+      "artifact:reviewed-answer",
+      "artifact:source-summary"
+    ],
+    "limitation_refs": [
+      "limitation:none-recorded"
+    ],
+    "redaction_refs": [
+      "redaction:portable-safe"
+    ]
+  }
+}</code></pre>
+          </article>
+
+          <article class="spec-panel" id="outcome-learning">
+            <h2>OutcomeReport to LearningRecord</h2>
+            <pre class="code-sample"><code>{
+  "object_type": "OutcomeReport",
+  "record": {
+    "id": "outcome-report-golden",
+    "work_session_id": "ws-golden-001",
+    "source_ref": "source:completed-worksession:ws-golden-001",
+    "reporter_ref": "reporter:fixture-evaluator",
+    "accepted_by_actor_id": "actor-human-golden",
+    "outcome": "accepted",
+    "learning_record_refs": [
+      "learning-golden-pair"
+    ],
+    "received_at": "2026-06-16T10:30:00Z",
+    "external_system_ref": "external:evaluation-system",
+    "reporter_actor_id": "actor-human-golden",
+    "reason": "Post-session feedback confirms the bounded Request and Review loop improved future source collection.",
+    "reviewer_feedback_refs": [
+      "feedback:bounded-source-loop-accepted"
+    ]
+  }
+}</code></pre>
+            <pre class="code-sample"><code>{
+  "object_type": "LearningRecord",
+  "record": {
+    "id": "learning-golden-pair",
+    "work_session_id": "ws-golden-001",
+    "created_by_actor_id": "actor-human-golden",
+    "subject_type": "pair",
+    "subject_ref": "pair:worker-human-golden+worker-agent-golden",
+    "lesson_type": "bounded_external_source_approval",
+    "source_event_refs": [
+      "event-request-created",
+      "event-review-approved",
+      "event-evidence-captured"
+    ],
+    "review_state": "accepted",
+    "scope": "scope:future-source-collection",
+    "created_at": "2026-06-16T10:18:00Z",
+    "proposed_change": {
+      "pattern": "Ask for bounded external source approval before collecting evidence outside local context."
+    },
+    "memory_proposal_refs": [
+      "memory-proposal-golden"
+    ],
+    "skill_proposal_refs": [
+      "skill-proposal-golden"
+    ]
+  }
+}</code></pre>
+          </article>
+
+          <article class="spec-panel">
+            <h2>Host boundary</h2>
+            <p>Hosts own UI, auth, storage, runtime behavior, model routing, tool execution, billing, scoring, payment, deployment, monitoring, and host workflow.</p>
+            <p>Examples show protocol records only.</p>
+          </article>
+
+          <article class="spec-panel" id="sources">
+            <h2>Source contracts</h2>
+            <div class="source-list">
+              <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/examples/protocol-records.md">Source: protocol record examples</a>
+              <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/examples/evidence-packs/existing-agent-review/README.md">Source: review evidence pack</a>
+              <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/examples/evidence-packs/existing-agent-takeover/README.md">Source: takeover evidence pack</a>
+              <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/conformance/fixtures/valid/golden-path.json">Source: golden-path fixture</a>
+              <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/conformance/fixtures/valid/takeover-path.json">Source: takeover-path fixture</a>
+            </div>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/demo/guides/examples.html
+++ b/demo/guides/examples.html
@@ -24,7 +24,7 @@
           <a href="../spec/">Spec</a>
           <a href="../openapi/">OpenAPI</a>
           <a href="../conformance/">Conformance</a>
-          <a href="./" aria-current="location">Guides</a>
+          <a href="./">Guides</a>
         </nav>
         <span class="status-chip">v0.1.0</span>
       </header>

--- a/demo/guides/existing-agent.html
+++ b/demo/guides/existing-agent.html
@@ -1,0 +1,122 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Existing-Agent Compatibility | Jarvis v0.1</title>
+    <meta
+      name="description"
+      content="Jarvis v0.1 guide for integrating existing agents through protocol records without rewriting native execution."
+    />
+    <link rel="icon" href="../assets/favicon.svg?v=guides1" type="image/svg+xml" />
+    <link rel="stylesheet" href="../assets/styles.css?v=guides1" />
+  </head>
+  <body>
+    <a class="skip-link" href="#main-content">Skip to content</a>
+    <main class="shell spec-page">
+      <header class="topbar">
+        <a class="brand" href="../" aria-label="Jarvis documentation home">
+          <span class="brand-mark">J</span>
+          <span><strong>Jarvis</strong><small>existing agents</small></span>
+        </a>
+        <nav class="topnav" aria-label="Guide navigation">
+          <a href="../">Home</a>
+          <a href="../spec/">Spec</a>
+          <a href="../openapi/">OpenAPI</a>
+          <a href="../conformance/">Conformance</a>
+          <a href="./" aria-current="location">Guides</a>
+        </nav>
+        <span class="status-chip">v0.1.0</span>
+      </header>
+
+      <section class="spec-hero">
+        <div>
+          <p class="kicker">Existing-agent compatibility</p>
+          <h1>Existing agents keep native execution.</h1>
+          <p>
+            A compatible host maps native human-agent work into Jarvis records.
+            Jarvis does not replace the agent, rewrite the agent, route models,
+            execute tools, own adapters, own wrappers, or own host integration
+            code.
+          </p>
+        </div>
+        <a class="command primary" href="./examples.html">Open record flow</a>
+      </section>
+
+      <section class="spec-layout">
+        <nav class="spec-side" aria-label="Implementer guide pages">
+          <a href="./">Overview</a>
+          <a href="./implementer.html">Implementer guide</a>
+          <a href="./existing-agent.html" aria-current="page">Existing-agent compatibility</a>
+          <a href="./request-review-takeover.html">Request, Review, Takeover</a>
+          <a href="./evidence-learning.html">Evidence and Learning</a>
+          <a href="./extensions.html">Extensions</a>
+          <a href="./protocol-errors.html">Protocol errors</a>
+          <a href="./examples.html">Protocol examples</a>
+        </nav>
+
+        <div class="spec-main" id="main-content">
+          <article class="spec-panel">
+            <h2>Mapping contract</h2>
+            <div class="field-grid">
+              <div class="field-card">
+                <h3>Native human participant</h3>
+                <p>Map to HumanWorker and Actor records with protocol authority and contribution scope.</p>
+              </div>
+              <div class="field-card">
+                <h3>Native agent session</h3>
+                <p>Map to AgentWorker and Actor records. The native agent keeps its own runtime and tools.</p>
+              </div>
+              <div class="field-card">
+                <h3>Native task scope</h3>
+                <p>Map to WorkSession, Policy, PolicyDecision, Request, Review, Takeover, Contribution, EvidenceManifest, and LearningRecord records.</p>
+              </div>
+              <div class="field-card">
+                <h3>Native feedback</h3>
+                <p>Map post-session result, reviewer feedback, or external evaluation to OutcomeReport and governed LearningRecord refs.</p>
+              </div>
+            </div>
+          </article>
+
+          <article class="spec-panel">
+            <h2>What the host must emit</h2>
+            <ul>
+              <li>Worker and Actor refs for the protocol-visible human and agent.</li>
+              <li>WorkSession state with objective, Policy, revision, and last_event_hash.</li>
+              <li>PolicyDecision before every AgentWorker action that affects WorkSession state.</li>
+              <li>Request when policy blocks or human judgment is required.</li>
+              <li>Review or Takeover when human judgment resolves the blocked scope.</li>
+              <li>Contribution and EvidenceManifest refs before portable export.</li>
+              <li>LearningRecord, MemoryProposal, SkillProposal, and OutcomeReport records only through governed review paths.</li>
+            </ul>
+          </article>
+
+          <article class="spec-panel">
+            <h2>Rejected implementation claims</h2>
+            <ul>
+              <li>Jarvis-compatible does not mean Jarvis-certified.</li>
+              <li>Jarvis-compatible does not mean official Jarvis host.</li>
+              <li>Jarvis-compatible does not prove production adoption.</li>
+              <li>Jarvis-compatible does not give the native agent a Jarvis-owned runtime.</li>
+            </ul>
+          </article>
+
+          <article class="spec-panel">
+            <h2>Host boundary</h2>
+            <p>Hosts own UI, auth, storage, runtime behavior, model routing, tool execution, billing, scoring, payment, deployment, monitoring, and host workflow.</p>
+            <p>Jarvis owns protocol records for governed collaboration, portable evidence, and shared learning.</p>
+          </article>
+
+          <article class="spec-panel" id="sources">
+            <h2>Source contracts</h2>
+            <div class="source-list">
+              <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/examples/existing-agent-compatibility.md">Source: existing-agent compatibility example</a>
+              <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/examples/implementation-proof/native-coding-agent/README.md">Source: native coding-agent proof</a>
+              <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/16-positioning-adoption-lock.md">Source: positioning and adoption lock</a>
+            </div>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/demo/guides/existing-agent.html
+++ b/demo/guides/existing-agent.html
@@ -24,7 +24,7 @@
           <a href="../spec/">Spec</a>
           <a href="../openapi/">OpenAPI</a>
           <a href="../conformance/">Conformance</a>
-          <a href="./" aria-current="location">Guides</a>
+          <a href="./">Guides</a>
         </nav>
         <span class="status-chip">v0.1.0</span>
       </header>

--- a/demo/guides/extensions.html
+++ b/demo/guides/extensions.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Extension Guide | Jarvis v0.1</title>
+    <meta
+      name="description"
+      content="Jarvis v0.1 extension guide for version negotiation, capability negotiation, namespace rules, and rejected extension behavior."
+    />
+    <link rel="icon" href="../assets/favicon.svg?v=guides1" type="image/svg+xml" />
+    <link rel="stylesheet" href="../assets/styles.css?v=guides1" />
+  </head>
+  <body>
+    <a class="skip-link" href="#main-content">Skip to content</a>
+    <main class="shell spec-page">
+      <header class="topbar">
+        <a class="brand" href="../" aria-label="Jarvis documentation home">
+          <span class="brand-mark">J</span>
+          <span><strong>Jarvis</strong><small>extensions</small></span>
+        </a>
+        <nav class="topnav" aria-label="Guide navigation">
+          <a href="../">Home</a>
+          <a href="../spec/">Spec</a>
+          <a href="../openapi/">OpenAPI</a>
+          <a href="../conformance/">Conformance</a>
+          <a href="./" aria-current="location">Guides</a>
+        </nav>
+        <span class="status-chip">v0.1.0</span>
+      </header>
+
+      <section class="spec-hero">
+        <div>
+          <p class="kicker">Extensions</p>
+          <h1>Extensions add namespaced protocol data without overriding core fields.</h1>
+          <p>
+            Jarvis v0.1 preserves compatibility through protocol version
+            negotiation, capability negotiation, and namespaced extension
+            records. Extensions do not add host runtime behavior to Jarvis and
+            do not override core protocol fields.
+          </p>
+        </div>
+        <a class="command primary" href="../spec/versioning-extensions.html">Open spec page</a>
+      </section>
+
+      <section class="spec-layout">
+        <nav class="spec-side" aria-label="Implementer guide pages">
+          <a href="./">Overview</a>
+          <a href="./implementer.html">Implementer guide</a>
+          <a href="./existing-agent.html">Existing-agent compatibility</a>
+          <a href="./request-review-takeover.html">Request, Review, Takeover</a>
+          <a href="./evidence-learning.html">Evidence and Learning</a>
+          <a href="./extensions.html" aria-current="page">Extensions</a>
+          <a href="./protocol-errors.html">Protocol errors</a>
+          <a href="./examples.html">Protocol examples</a>
+        </nav>
+
+        <div class="spec-main" id="main-content">
+          <article class="spec-panel">
+            <h2>Extension rules</h2>
+            <ul>
+              <li>Extensions MUST use a namespace owned by the extension author.</li>
+              <li>Extensions MUST NOT override core Jarvis fields.</li>
+              <li>Extensions MUST NOT weaken required headers, Actor authority, WorkSession revision, previous event hash, Request resolution, Takeover lock epochs, export redaction, or governed learning.</li>
+              <li>Unsupported required capabilities reject as <code>unsupported_capability</code>.</li>
+              <li>Invalid extension namespace rejects as <code>invalid_extension_namespace</code>.</li>
+              <li>Core field override rejects as <code>extension_core_field_override</code>.</li>
+            </ul>
+          </article>
+
+          <article class="spec-panel">
+            <h2>Implementation duties</h2>
+            <div class="field-grid">
+              <div class="field-card">
+                <h3>Must store</h3>
+                <p>Store declared protocol version, declared capabilities, extension namespace, and extension refs when accepted.</p>
+              </div>
+              <div class="field-card">
+                <h3>Must validate</h3>
+                <p>Validate protocol version, capability support, namespace ownership, and closed-schema core field protection.</p>
+              </div>
+              <div class="field-card">
+                <h3>Must reject</h3>
+                <p>Reject silent downgrade, unsupported required capability, invalid namespace, and extension core field override.</p>
+              </div>
+              <div class="field-card">
+                <h3>Host boundary</h3>
+                <p>Hosts own UI, auth, storage, runtime behavior, model routing, tool execution, billing, scoring, payment, deployment, monitoring, and host workflow.</p>
+              </div>
+            </div>
+          </article>
+
+          <article class="spec-panel" id="sources">
+            <h2>Source contracts</h2>
+            <div class="source-list">
+              <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/15-openapi-communication-binding.md">Source: OpenAPI communication binding</a>
+              <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/14-protocol-lock.md">Source: protocol lock</a>
+              <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/11-core-protocol-objects.md">Source: core protocol objects</a>
+            </div>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/demo/guides/extensions.html
+++ b/demo/guides/extensions.html
@@ -24,7 +24,7 @@
           <a href="../spec/">Spec</a>
           <a href="../openapi/">OpenAPI</a>
           <a href="../conformance/">Conformance</a>
-          <a href="./" aria-current="location">Guides</a>
+          <a href="./">Guides</a>
         </nav>
         <span class="status-chip">v0.1.0</span>
       </header>

--- a/demo/guides/implementer.html
+++ b/demo/guides/implementer.html
@@ -24,7 +24,7 @@
           <a href="../spec/">Spec</a>
           <a href="../openapi/">OpenAPI</a>
           <a href="../conformance/">Conformance</a>
-          <a href="./" aria-current="location">Guides</a>
+          <a href="./">Guides</a>
         </nav>
         <span class="status-chip">v0.1.0</span>
       </header>

--- a/demo/guides/implementer.html
+++ b/demo/guides/implementer.html
@@ -1,0 +1,128 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Implementer Guide | Jarvis v0.1</title>
+    <meta
+      name="description"
+      content="Jarvis v0.1 implementer guide for protocol storage, event emission, validation, rejection, and export obligations."
+    />
+    <link rel="icon" href="../assets/favicon.svg?v=guides1" type="image/svg+xml" />
+    <link rel="stylesheet" href="../assets/styles.css?v=guides1" />
+  </head>
+  <body>
+    <a class="skip-link" href="#main-content">Skip to content</a>
+    <main class="shell spec-page">
+      <header class="topbar">
+        <a class="brand" href="../" aria-label="Jarvis documentation home">
+          <span class="brand-mark">J</span>
+          <span><strong>Jarvis</strong><small>implementer guide</small></span>
+        </a>
+        <nav class="topnav" aria-label="Guide navigation">
+          <a href="../">Home</a>
+          <a href="../spec/">Spec</a>
+          <a href="../openapi/">OpenAPI</a>
+          <a href="../conformance/">Conformance</a>
+          <a href="./" aria-current="location">Guides</a>
+        </nav>
+        <span class="status-chip">v0.1.0</span>
+      </header>
+
+      <section class="spec-hero">
+        <div>
+          <p class="kicker">Implementer guide</p>
+          <h1>Store, emit, validate, reject, and export protocol state.</h1>
+          <p>
+            A compatible implementation records Jarvis protocol behavior around
+            host-owned execution. The implementation does not become a Jarvis
+            runtime, adapter, wrapper, model router, tool executor, UI, auth
+            provider, storage backend, billing system, scoring system, payment
+            system, deployment system, or host workflow engine.
+          </p>
+        </div>
+        <a class="command primary" href="./examples.html">Open examples</a>
+      </section>
+
+      <section class="spec-layout">
+        <nav class="spec-side" aria-label="Implementer guide pages">
+          <a href="./">Overview</a>
+          <a href="./implementer.html" aria-current="page">Implementer guide</a>
+          <a href="./existing-agent.html">Existing-agent compatibility</a>
+          <a href="./request-review-takeover.html">Request, Review, Takeover</a>
+          <a href="./evidence-learning.html">Evidence and Learning</a>
+          <a href="./extensions.html">Extensions</a>
+          <a href="./protocol-errors.html">Protocol errors</a>
+          <a href="./examples.html">Protocol examples</a>
+        </nav>
+
+        <div class="spec-main" id="main-content">
+          <article class="spec-panel">
+            <h2>Implementation duties</h2>
+            <div class="field-grid">
+              <div class="field-card">
+                <h3>Must store</h3>
+                <p>Store Worker, Actor, WorkSession, JarvisEvent, Policy, PolicyDecision, Request, Review, Takeover, Contribution, EvidenceManifest, LearningRecord, MemoryProposal, SkillProposal, and OutcomeReport records.</p>
+              </div>
+              <div class="field-card">
+                <h3>Must emit</h3>
+                <p>Emit append-only events for accepted WorkSession-scoped state changes and preserve Actor, revision, and previous event hash linkage.</p>
+              </div>
+              <div class="field-card">
+                <h3>Must validate</h3>
+                <p>Validate mutation headers, read headers, Actor authority, path/body identity, actor/body identity, required fields, enum values, and forbidden export fields.</p>
+              </div>
+              <div class="field-card">
+                <h3>Must reject</h3>
+                <p>Reject missing PolicyDecision, unresolved Request, missing Review or Takeover resolution, stale Takeover continuation, sealed WorkSession mutation, sealed EvidenceManifest mutation, silent memory mutation, and silent skill activation.</p>
+              </div>
+            </div>
+          </article>
+
+          <article class="spec-panel">
+            <h2>Mutation header contract</h2>
+            <p>Every WorkSession-scoped mutating operation MUST include:</p>
+            <pre class="code-sample"><code>Jarvis-Protocol-Version
+Jarvis-Actor-Id
+Jarvis-Idempotency-Key
+Jarvis-Request-Timestamp
+Jarvis-Expected-WorkSession-Revision
+Jarvis-Previous-Event-Hash</code></pre>
+            <p>Worker registration, Actor registration, and OutcomeReport submission are non-WorkSession protocol mutations. They require protocol version, Actor id, idempotency key, and request timestamp.</p>
+          </article>
+
+          <article class="spec-panel">
+            <h2>Operation order</h2>
+            <ol>
+              <li>Register Worker and Actor refs.</li>
+              <li>Create WorkSession under human-defined Policy.</li>
+              <li>Record PolicyDecision before an AgentWorker action becomes accepted protocol state.</li>
+              <li>Create Request when the AgentWorker is blocked.</li>
+              <li>Resolve Request through Review or Takeover.</li>
+              <li>Record Contribution, EvidenceManifest refs, governed LearningRecord, and governed proposals.</li>
+              <li>Submit OutcomeReport after the source WorkSession is terminal.</li>
+            </ol>
+          </article>
+
+          <article class="spec-panel">
+            <h2>Host boundary</h2>
+            <ul>
+              <li>Hosts own UI, auth, storage, runtime behavior, model routing, tool execution, billing, scoring, payment, deployment, monitoring, and host workflow.</li>
+              <li>Jarvis records protocol state and portable evidence.</li>
+              <li>Protocol helpers validate records; they do not run the work.</li>
+            </ul>
+          </article>
+
+          <article class="spec-panel" id="sources">
+            <h2>Source contracts</h2>
+            <div class="source-list">
+              <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/15-openapi-communication-binding.md">Source: OpenAPI communication binding</a>
+              <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/11-core-protocol-objects.md">Source: core protocol objects</a>
+              <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/conformance/checklist.md">Source: conformance checklist</a>
+            </div>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/demo/guides/index.html
+++ b/demo/guides/index.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Implementer Guides | Jarvis v0.1</title>
+    <meta
+      name="description"
+      content="Jarvis v0.1 implementer guides for protocol storage, emission, validation, rejection, examples, extensions, and errors."
+    />
+    <link rel="icon" href="../assets/favicon.svg?v=guides1" type="image/svg+xml" />
+    <link rel="stylesheet" href="../assets/styles.css?v=guides1" />
+  </head>
+  <body>
+    <a class="skip-link" href="#main-content">Skip to content</a>
+    <main class="shell spec-page">
+      <header class="topbar">
+        <a class="brand" href="../" aria-label="Jarvis documentation home">
+          <span class="brand-mark">J</span>
+          <span><strong>Jarvis</strong><small>implementer guides</small></span>
+        </a>
+        <nav class="topnav" aria-label="Guide navigation">
+          <a href="../">Home</a>
+          <a href="../spec/">Spec</a>
+          <a href="../openapi/">OpenAPI</a>
+          <a href="../conformance/">Conformance</a>
+          <a href="./" aria-current="page">Guides</a>
+        </nav>
+        <span class="status-chip">v0.1.0</span>
+      </header>
+
+      <section class="spec-hero">
+        <div>
+          <p class="kicker">Implementation without runtime drift</p>
+          <h1>Implement Jarvis as protocol records.</h1>
+          <p>
+            Compatible implementations store, emit, validate, reject, export,
+            and preserve Jarvis records. Hosts own runtime behavior, adapters,
+            wrappers, UI, auth, storage, model routing, tool execution, billing,
+            scoring, payment, deployment, monitoring, and host workflow.
+          </p>
+        </div>
+        <div class="inline-actions">
+          <a class="command primary" href="./implementer.html">Start guide</a>
+          <a class="command" href="./examples.html">Record examples</a>
+        </div>
+      </section>
+
+      <section class="spec-layout">
+        <nav class="spec-side" aria-label="Implementer guide pages">
+          <a href="./" aria-current="page">Overview</a>
+          <a href="./implementer.html">Implementer guide</a>
+          <a href="./existing-agent.html">Existing-agent compatibility</a>
+          <a href="./request-review-takeover.html">Request, Review, Takeover</a>
+          <a href="./evidence-learning.html">Evidence and Learning</a>
+          <a href="./extensions.html">Extensions</a>
+          <a href="./protocol-errors.html">Protocol errors</a>
+          <a href="./examples.html">Protocol examples</a>
+        </nav>
+
+        <div class="spec-main" id="main-content">
+          <article class="spec-panel">
+            <h2>Guide contract</h2>
+            <div class="rule-grid">
+              <div class="rule-card">
+                <h3>Store</h3>
+                <p>Persist protocol records with stable ids, Actor refs, WorkSession refs, revision, and event-hash lineage.</p>
+              </div>
+              <div class="rule-card">
+                <h3>Emit</h3>
+                <p>Emit JarvisEvent-backed state when policy, Request, Review, Takeover, Contribution, Evidence, or Learning changes.</p>
+              </div>
+              <div class="rule-card">
+                <h3>Validate</h3>
+                <p>Validate headers, Actor authority, body/path ids, WorkSession revision, previous event hash, and protocol object shape.</p>
+              </div>
+              <div class="rule-card">
+                <h3>Reject</h3>
+                <p>Reject missing PolicyDecision, unresolved Request, stale Takeover continuation, forbidden export fields, and silent learning mutation.</p>
+              </div>
+            </div>
+          </article>
+
+          <article class="spec-panel">
+            <h2>Guide pages</h2>
+            <div class="link-table" aria-label="Implementer guide links">
+              <a href="./implementer.html"><span>Implementer guide</span><small>Storage, emission, validation, rejection, and export duties</small></a>
+              <a href="./existing-agent.html"><span>Existing-agent compatibility</span><small>Map native agent work into Jarvis records</small></a>
+              <a href="./request-review-takeover.html"><span>Request, Review, Takeover</span><small>Scoped blockers, human judgment, ApprovalScope, and lock epochs</small></a>
+              <a href="./evidence-learning.html"><span>Evidence and Learning</span><small>Contribution, EvidenceManifest, LearningRecord, proposals, and OutcomeReport</small></a>
+              <a href="./extensions.html"><span>Extensions</span><small>Capability negotiation and extension namespace rules</small></a>
+              <a href="./protocol-errors.html"><span>Protocol errors</span><small>Error envelope, rejection ids, and forbidden fields</small></a>
+              <a href="./examples.html"><span>Protocol examples</span><small>Minimal v0.1 record flow examples</small></a>
+            </div>
+          </article>
+
+          <article class="spec-panel">
+            <h2>Boundary</h2>
+            <ul>
+              <li>Guides define protocol implementation obligations.</li>
+              <li>Guides do not define runtime behavior.</li>
+              <li>Guides do not define adapters, wrappers, model routing, tool execution, auth provider, storage backend, UI, billing, scoring, payment, deployment, or host workflow.</li>
+              <li>Hosts own UI, auth, storage, runtime behavior, model routing, tool execution, billing, scoring, payment, deployment, monitoring, and host workflow.</li>
+              <li>Hosts own implementation behavior. Jarvis owns the portable collaboration record.</li>
+            </ul>
+          </article>
+
+          <article class="spec-panel" id="sources">
+            <h2>Source contracts</h2>
+            <div class="source-list">
+              <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/examples/protocol-records.md">Source: protocol record examples</a>
+              <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/examples/existing-agent-compatibility.md">Source: existing-agent compatibility</a>
+              <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/15-openapi-communication-binding.md">Source: OpenAPI binding</a>
+            </div>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/demo/guides/protocol-errors.html
+++ b/demo/guides/protocol-errors.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Protocol Errors Guide | Jarvis v0.1</title>
+    <meta
+      name="description"
+      content="Jarvis v0.1 protocol errors guide for rejection ids, error envelope fields, and forbidden host-private response fields."
+    />
+    <link rel="icon" href="../assets/favicon.svg?v=guides1" type="image/svg+xml" />
+    <link rel="stylesheet" href="../assets/styles.css?v=guides1" />
+  </head>
+  <body>
+    <a class="skip-link" href="#main-content">Skip to content</a>
+    <main class="shell spec-page">
+      <header class="topbar">
+        <a class="brand" href="../" aria-label="Jarvis documentation home">
+          <span class="brand-mark">J</span>
+          <span><strong>Jarvis</strong><small>protocol errors</small></span>
+        </a>
+        <nav class="topnav" aria-label="Guide navigation">
+          <a href="../">Home</a>
+          <a href="../spec/">Spec</a>
+          <a href="../openapi/">OpenAPI</a>
+          <a href="../conformance/">Conformance</a>
+          <a href="./" aria-current="location">Guides</a>
+        </nav>
+        <span class="status-chip">v0.1.0</span>
+      </header>
+
+      <section class="spec-hero">
+        <div>
+          <p class="kicker">Protocol errors</p>
+          <h1>Every rejection returns a public protocol error.</h1>
+          <p>
+            Compatible implementations reject invalid protocol operations with
+            stable error ids and a portable error envelope. Error responses
+            exclude host-private fields, credentials, secrets, raw runtime
+            state, auth tokens, session cookies, provider secrets, and private
+            keys.
+          </p>
+        </div>
+        <a class="command primary" href="../conformance/failure-modes.html">Open failure modes</a>
+      </section>
+
+      <section class="spec-layout">
+        <nav class="spec-side" aria-label="Implementer guide pages">
+          <a href="./">Overview</a>
+          <a href="./implementer.html">Implementer guide</a>
+          <a href="./existing-agent.html">Existing-agent compatibility</a>
+          <a href="./request-review-takeover.html">Request, Review, Takeover</a>
+          <a href="./evidence-learning.html">Evidence and Learning</a>
+          <a href="./extensions.html">Extensions</a>
+          <a href="./protocol-errors.html" aria-current="page">Protocol errors</a>
+          <a href="./examples.html">Protocol examples</a>
+        </nav>
+
+        <div class="spec-main" id="main-content">
+          <article class="spec-panel">
+            <h2>Error envelope</h2>
+            <pre class="code-sample"><code>{
+  "error_id": "missing_policy_decision",
+  "protocol_version": "v0.1",
+  "object_type": "PolicyDecision",
+  "field": "policy_decision_id",
+  "reason": "AgentWorker action requires PolicyDecision before accepted protocol state.",
+  "remediation": "Record PolicyDecision before accepting the AgentWorker action.",
+  "trace_id": "trace:example"
+}</code></pre>
+          </article>
+
+          <article class="spec-panel">
+            <h2>Required rejection surfaces</h2>
+            <div class="schema-list">
+              <span>missing_protocol_version</span>
+              <span>unsupported_protocol_version</span>
+              <span>missing_actor</span>
+              <span>missing_idempotency_key</span>
+              <span>missing_request_timestamp</span>
+              <span>stale_request_timestamp</span>
+              <span>missing_expected_work_session_revision</span>
+              <span>missing_previous_event_hash</span>
+              <span>invalid_previous_event_hash</span>
+              <span>missing_policy_decision</span>
+              <span>missing_review_resolution</span>
+              <span>missing_takeover_resolution</span>
+              <span>stale_takeover_continuation</span>
+              <span>forbidden_host_private_field</span>
+              <span>sealed_work_session_mutation</span>
+              <span>sealed_evidence_mutation</span>
+              <span>outcome_report_without_learning_record</span>
+              <span>outcome_report_requires_terminal_source</span>
+            </div>
+          </article>
+
+          <article class="spec-panel">
+            <h2>Must validate and reject</h2>
+            <ul>
+              <li>Return the required public envelope fields: error_id, protocol_version, object_type, field, reason, remediation, and trace_id.</li>
+              <li>Do not include host-private response fields.</li>
+              <li>Use fixture-backed rejection ids when a fixture proves the behavior.</li>
+              <li>Use checklist-only rejection ids without claiming fixture coverage.</li>
+            </ul>
+          </article>
+
+          <article class="spec-panel">
+            <h2>Host boundary</h2>
+            <p>Hosts own UI, auth, storage, runtime behavior, model routing, tool execution, billing, scoring, payment, deployment, monitoring, and host workflow.</p>
+            <p>Jarvis owns public protocol errors and rejection semantics.</p>
+          </article>
+
+          <article class="spec-panel" id="sources">
+            <h2>Source contracts</h2>
+            <div class="source-list">
+              <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/15-openapi-communication-binding.md">Source: OpenAPI communication binding</a>
+              <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/conformance/failure-modes.md">Source: failure modes</a>
+              <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/openapi/jarvis-openapi.yaml">Source: OpenAPI YAML</a>
+            </div>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/demo/guides/protocol-errors.html
+++ b/demo/guides/protocol-errors.html
@@ -24,7 +24,7 @@
           <a href="../spec/">Spec</a>
           <a href="../openapi/">OpenAPI</a>
           <a href="../conformance/">Conformance</a>
-          <a href="./" aria-current="location">Guides</a>
+          <a href="./">Guides</a>
         </nav>
         <span class="status-chip">v0.1.0</span>
       </header>

--- a/demo/guides/request-review-takeover.html
+++ b/demo/guides/request-review-takeover.html
@@ -1,0 +1,117 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Request, Review, Takeover Guide | Jarvis v0.1</title>
+    <meta
+      name="description"
+      content="Jarvis v0.1 guide for scoped Request blockers, Review resolution, ApprovalScope, Takeover lock epochs, and rejection behavior."
+    />
+    <link rel="icon" href="../assets/favicon.svg?v=guides1" type="image/svg+xml" />
+    <link rel="stylesheet" href="../assets/styles.css?v=guides1" />
+  </head>
+  <body>
+    <a class="skip-link" href="#main-content">Skip to content</a>
+    <main class="shell spec-page">
+      <header class="topbar">
+        <a class="brand" href="../" aria-label="Jarvis documentation home">
+          <span class="brand-mark">J</span>
+          <span><strong>Jarvis</strong><small>control plane</small></span>
+        </a>
+        <nav class="topnav" aria-label="Guide navigation">
+          <a href="../">Home</a>
+          <a href="../spec/">Spec</a>
+          <a href="../openapi/">OpenAPI</a>
+          <a href="../conformance/">Conformance</a>
+          <a href="./" aria-current="location">Guides</a>
+        </nav>
+        <span class="status-chip">v0.1.0</span>
+      </header>
+
+      <section class="spec-hero">
+        <div>
+          <p class="kicker">Request, Review, Takeover</p>
+          <h1>Blocked scope resolves through human judgment.</h1>
+          <p>
+            Request is a structured scoped deferral. It is not chat,
+            notification, or authority. Review grants, narrows, denies, answers,
+            corrects, or requires revision. Takeover transfers control of the
+            affected scope and protects resumption with lock_epoch.
+          </p>
+        </div>
+        <a class="command primary" href="./examples.html#request-review">Open example</a>
+      </section>
+
+      <section class="spec-layout">
+        <nav class="spec-side" aria-label="Implementer guide pages">
+          <a href="./">Overview</a>
+          <a href="./implementer.html">Implementer guide</a>
+          <a href="./existing-agent.html">Existing-agent compatibility</a>
+          <a href="./request-review-takeover.html" aria-current="page">Request, Review, Takeover</a>
+          <a href="./evidence-learning.html">Evidence and Learning</a>
+          <a href="./extensions.html">Extensions</a>
+          <a href="./protocol-errors.html">Protocol errors</a>
+          <a href="./examples.html">Protocol examples</a>
+        </nav>
+
+        <div class="spec-main" id="main-content">
+          <article class="spec-panel">
+            <h2>Must store</h2>
+            <ul>
+              <li>Request records with id, protocol_version, work_session_id, requester_actor_id, requester_worker_id, target_human_worker_id, policy_decision_id, type, status, blocking_scope, reason_code, reason_summary, requested_action, requested_outcome, risk_class, human_decision_needed, options, default_if_no_response, created_at, expires_at, and resolver refs when resolved or closed.</li>
+              <li>Review records with reviewer_actor_id, target_ref, decision, created_at, comments, and ApprovalScope when authority is granted.</li>
+              <li>Takeover records with requested_by_actor_id, controlling_actor_id, affected_scope, request_id, reason, state, lock_epoch, created_at, reconciliation refs, and resolved_at.</li>
+            </ul>
+          </article>
+
+          <article class="spec-panel">
+            <h2>Must validate and reject</h2>
+            <div class="field-grid">
+              <div class="field-card">
+                <h3>Request</h3>
+                <p>Reject Request resolution without Review or Takeover. Reject unresolved Request at terminal WorkSession export.</p>
+              </div>
+              <div class="field-card">
+                <h3>ApprovalScope</h3>
+                <p>Reject approval outside normalized_action_hash, applies_to_work_session_id, applies_to_actor_id, max_uses, and expires_at.</p>
+              </div>
+              <div class="field-card">
+                <h3>Takeover</h3>
+                <p>Reject stale AgentWorker continuation when attempted_lock_epoch is older than the active lock_epoch.</p>
+              </div>
+              <div class="field-card">
+                <h3>Mutation gate</h3>
+                <p>Reject missing mutating headers, stale WorkSession revision, previous event hash mismatch, actor/body mismatch, and unauthorized Actor.</p>
+              </div>
+            </div>
+          </article>
+
+          <article class="spec-panel">
+            <h2>Lifecycle</h2>
+            <pre class="code-sample"><code>PolicyDecision denies or flags action
+  -> Request created with blocking_scope
+  -> HumanWorker Review or Takeover
+  -> Request status records resolver ref
+  -> AgentWorker resumes only inside approved or reconciled scope</code></pre>
+          </article>
+
+          <article class="spec-panel">
+            <h2>Host boundary</h2>
+            <p>Hosts own UI, auth, storage, runtime behavior, model routing, tool execution, billing, scoring, payment, deployment, monitoring, and host workflow.</p>
+            <p>Jarvis owns Request, Review, ApprovalScope, and Takeover protocol records.</p>
+          </article>
+
+          <article class="spec-panel" id="sources">
+            <h2>Source contracts</h2>
+            <div class="source-list">
+              <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/12-request-protocol.md">Source: Request protocol</a>
+              <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/11-core-protocol-objects.md">Source: core protocol objects</a>
+              <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/conformance/failure-modes.md">Source: failure modes</a>
+            </div>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/demo/guides/request-review-takeover.html
+++ b/demo/guides/request-review-takeover.html
@@ -24,7 +24,7 @@
           <a href="../spec/">Spec</a>
           <a href="../openapi/">OpenAPI</a>
           <a href="../conformance/">Conformance</a>
-          <a href="./" aria-current="location">Guides</a>
+          <a href="./">Guides</a>
         </nav>
         <span class="status-chip">v0.1.0</span>
       </header>
@@ -90,10 +90,10 @@
           <article class="spec-panel">
             <h2>Lifecycle</h2>
             <pre class="code-sample"><code>PolicyDecision denies or flags action
-  -> Request created with blocking_scope
-  -> HumanWorker Review or Takeover
-  -> Request status records resolver ref
-  -> AgentWorker resumes only inside approved or reconciled scope</code></pre>
+  -&gt; Request created with blocking_scope
+  -&gt; HumanWorker Review or Takeover
+  -&gt; Request status records resolver ref
+  -&gt; AgentWorker resumes only inside approved or reconciled scope</code></pre>
           </article>
 
           <article class="spec-panel">

--- a/demo/index.html
+++ b/demo/index.html
@@ -27,7 +27,7 @@
           <a href="#spec">Spec</a>
           <a href="./openapi/">OpenAPI</a>
           <a href="./conformance/">Conformance</a>
-          <a href="#guides">Guides</a>
+          <a href="./guides/">Guides</a>
           <a href="#examples">Examples</a>
           <a href="#sdk">SDK</a>
           <a href="#implementation">Implementation</a>
@@ -66,6 +66,7 @@
             >
               Conformance
             </a>
+            <a class="command" href="./guides/">Guides</a>
             <a class="command" href="#implementation">Implementation Path</a>
             <a class="command" href="#walkthrough-controls">Run Walkthrough</a>
             <a class="command ghost" href="https://github.com/Flow-Research/jarvis">
@@ -353,17 +354,17 @@
           <article>
             <h3>Protocol Records</h3>
             <p>Concrete Worker, Actor, WorkSession, Request, Review, Contribution, EvidenceManifest, and LearningRecord examples.</p>
-            <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/examples/protocol-records.md">Read record examples</a>
+            <a href="./guides/examples.html">Read record examples</a>
           </article>
           <article>
             <h3>Existing Agent Compatibility</h3>
             <p>How an existing agent participates through Jarvis records without being rewritten as a Jarvis agent.</p>
-            <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/examples/existing-agent-compatibility.md">Read compatibility example</a>
+            <a href="./guides/existing-agent.html">Read compatibility guide</a>
           </article>
           <article>
             <h3>Compatible Host Mapping</h3>
             <p>How a host maps native collaboration events into Jarvis protocol records while keeping implementation private.</p>
-            <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/examples/compatible-host-mapping.md">Read host mapping</a>
+            <a href="./conformance/compatible-host-mapping.html">Read host mapping</a>
           </article>
           <article>
             <h3>Evidence Packs</h3>
@@ -378,25 +379,35 @@
           <p class="kicker">Implementer guides</p>
           <h2 id="guides-title">Implementer guides define protocol obligations.</h2>
           <p>
-            Guides explain what compatible implementations store, emit,
-            validate, reject, export, and preserve. They do not define host UI,
-            runtime behavior, model routing, tool execution, or storage.
+            Implementer guides define what compatible implementations MUST
+            store, emit, validate, reject, export, and preserve. They do not
+            define host UI, auth, storage, runtime behavior, model routing,
+            tool execution, billing, scoring, payment, deployment, monitoring,
+            or host workflow.
           </p>
         </div>
         <div class="guide-grid" aria-label="Implementer guide links">
-          <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/examples/existing-agent-compatibility.md">
+          <a href="./guides/implementer.html">
+            <span>Implementer guide</span>
+            <small>Store, emit, validate, reject, and export protocol records.</small>
+          </a>
+          <a href="./guides/existing-agent.html">
             <span>Existing-agent compatibility</span>
             <small>Map native agent work into Jarvis records without rewriting the agent.</small>
           </a>
-          <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/12-request-protocol.md">
+          <a href="./guides/request-review-takeover.html">
             <span>Request, Review, ApprovalScope, and Takeover</span>
             <small>Use scoped blockers, human judgment, ApprovalScope, and takeover lock epochs.</small>
           </a>
-          <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/13-contribution-evidence-learning.md">
+          <a href="./guides/evidence-learning.html">
             <span>Evidence and Learning</span>
             <small>Record contribution, export evidence, and carry governed learning forward.</small>
           </a>
-          <a href="https://github.com/Flow-Research/jarvis/blob/main/docs/protocol/15-openapi-communication-binding.md">
+          <a href="./guides/extensions.html">
+            <span>Extensions</span>
+            <small>Use version, capability, and namespace rules without overriding core fields.</small>
+          </a>
+          <a href="./guides/protocol-errors.html">
             <span>Protocol errors</span>
             <small>Return stable error ids and portable error envelopes.</small>
           </a>
@@ -591,7 +602,7 @@ python3 scripts/check_example_evidence_packs.py</code></pre>
             <div class="node host" data-node="host">
               <span>Host</span>
               <strong>owns implementation</strong>
-              <small>UI storage tools execution</small>
+              <small>UI, storage, tool execution</small>
             </div>
 
             <div class="node request" data-node="request">

--- a/scripts/check_docs_site.py
+++ b/scripts/check_docs_site.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """Validate the static Jarvis docs site links and local assets."""
 
+import json
+import sys
 from html.parser import HTMLParser
 from pathlib import Path
 from urllib.parse import urlparse
-import sys
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -62,6 +63,73 @@ CONFORMANCE_SOURCE_REFS = {
         "docs/conformance/compatibility-mapping.md",
     ),
 }
+GUIDE_SOURCE_REFS = {
+    SITE_ROOT / "guides" / "index.html": (
+        "docs/examples/protocol-records.md",
+        "docs/examples/existing-agent-compatibility.md",
+        "docs/protocol/15-openapi-communication-binding.md",
+    ),
+    SITE_ROOT / "guides" / "implementer.html": (
+        "docs/protocol/15-openapi-communication-binding.md",
+        "docs/protocol/11-core-protocol-objects.md",
+        "docs/conformance/checklist.md",
+    ),
+    SITE_ROOT / "guides" / "existing-agent.html": (
+        "docs/examples/existing-agent-compatibility.md",
+        "docs/examples/implementation-proof/native-coding-agent/README.md",
+        "docs/protocol/16-positioning-adoption-lock.md",
+    ),
+    SITE_ROOT / "guides" / "request-review-takeover.html": (
+        "docs/protocol/12-request-protocol.md",
+        "docs/protocol/11-core-protocol-objects.md",
+        "docs/conformance/failure-modes.md",
+    ),
+    SITE_ROOT / "guides" / "evidence-learning.html": (
+        "docs/protocol/13-contribution-evidence-learning.md",
+        "docs/examples/protocol-records.md",
+        "docs/conformance/failure-modes.md",
+    ),
+    SITE_ROOT / "guides" / "extensions.html": (
+        "docs/protocol/15-openapi-communication-binding.md",
+        "docs/protocol/14-protocol-lock.md",
+        "docs/protocol/11-core-protocol-objects.md",
+    ),
+    SITE_ROOT / "guides" / "protocol-errors.html": (
+        "docs/protocol/15-openapi-communication-binding.md",
+        "docs/conformance/failure-modes.md",
+        "docs/openapi/jarvis-openapi.yaml",
+    ),
+    SITE_ROOT / "guides" / "examples.html": (
+        "docs/examples/protocol-records.md",
+        "docs/examples/evidence-packs/existing-agent-review/README.md",
+        "docs/examples/evidence-packs/existing-agent-takeover/README.md",
+        "docs/conformance/fixtures/valid/golden-path.json",
+        "docs/conformance/fixtures/valid/takeover-path.json",
+    ),
+}
+GUIDE_BOUNDARY_REQUIRED_TEXT = (
+    "Hosts own",
+    "runtime",
+    "model routing",
+    "tool execution",
+    "auth",
+    "storage",
+    "UI",
+    "billing",
+    "scoring",
+    "payment",
+    "deployment",
+    "host workflow",
+)
+GUIDE_INDEX_LINKS = (
+    "./implementer.html",
+    "./existing-agent.html",
+    "./request-review-takeover.html",
+    "./evidence-learning.html",
+    "./extensions.html",
+    "./protocol-errors.html",
+    "./examples.html",
+)
 
 
 class SiteParser(HTMLParser):
@@ -70,7 +138,10 @@ class SiteParser(HTMLParser):
         self.ids: set[str] = set()
         self.refs: list[tuple[str, str, str]] = []
         self.source_list_refs: list[tuple[str, str, str]] = []
+        self.code_samples: list[str] = []
         self._source_list_depth = 0
+        self._code_sample_depth = 0
+        self._current_code_sample: list[str] = []
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         attr_map = {key: value for key, value in attrs if value is not None}
@@ -78,6 +149,11 @@ class SiteParser(HTMLParser):
         in_source_list = self._source_list_depth > 0 or "source-list" in classes
         if in_source_list and tag not in VOID_TAGS:
             self._source_list_depth += 1
+        if tag == "pre" and "code-sample" in classes and self._code_sample_depth == 0:
+            self._code_sample_depth = 1
+            self._current_code_sample = []
+        elif self._code_sample_depth > 0 and tag not in VOID_TAGS:
+            self._code_sample_depth += 1
         if "id" in attr_map:
             self.ids.add(attr_map["id"])
         for attr in ("href", "src"):
@@ -89,6 +165,15 @@ class SiteParser(HTMLParser):
     def handle_endtag(self, tag: str) -> None:
         if self._source_list_depth > 0:
             self._source_list_depth -= 1
+        if self._code_sample_depth > 0:
+            self._code_sample_depth -= 1
+            if self._code_sample_depth == 0:
+                self.code_samples.append("".join(self._current_code_sample).strip())
+                self._current_code_sample = []
+
+    def handle_data(self, data: str) -> None:
+        if self._code_sample_depth > 0:
+            self._current_code_sample.append(data)
 
 
 def clean_ref(value: str) -> str:
@@ -132,9 +217,212 @@ def github_target_exists(value: str) -> bool:
 
 def required_site_text(path: Path, failures: list[str]) -> str:
     if not path.exists():
-        failures.append(f"{path.relative_to(ROOT)}: missing conformance site page")
+        failures.append(f"{path.relative_to(ROOT)}: missing required site page")
         return ""
     return path.read_text(encoding="utf-8")
+
+
+def page_hrefs(parsed: dict[Path, SiteParser], path: Path) -> set[str]:
+    parser = parsed.get(path)
+    if parser is None:
+        return set()
+    return {
+        clean_ref(value)
+        for _tag, attr, value in parser.refs
+        if attr == "href"
+    }
+
+
+def has_field_path(record: object, path: tuple[str, ...]) -> bool:
+    current = record
+    for part in path:
+        if not isinstance(current, dict) or part not in current:
+            return False
+        current = current[part]
+    return current is not None
+
+
+def validate_examples_json_samples(
+    path: Path,
+    parser: SiteParser | None,
+    failures: list[str],
+) -> None:
+    if parser is None:
+        failures.append(f"{path.relative_to(ROOT)}: missing parsed examples page")
+        return
+
+    parsed_samples = []
+    for index, sample in enumerate(parser.code_samples, start=1):
+        try:
+            parsed_samples.append(json.loads(sample))
+        except json.JSONDecodeError as exc:
+            failures.append(
+                f"{path.relative_to(ROOT)}: code sample {index} is not valid JSON: {exc.msg}"
+            )
+
+    by_object_type = {
+        sample.get("object_type"): sample
+        for sample in parsed_samples
+        if isinstance(sample, dict) and isinstance(sample.get("object_type"), str)
+    }
+    evidence_samples = [
+        sample for sample in parsed_samples
+        if isinstance(sample, dict) and isinstance(sample.get("evidence_manifest"), dict)
+    ]
+
+    required_object_paths = {
+        "WorkSession": (
+            ("record", "id"),
+            ("record", "protocol_version"),
+            ("record", "created_by_actor_id"),
+            ("record", "human_worker_id"),
+            ("record", "agent_worker_id"),
+            ("record", "policy_id"),
+            ("record", "status"),
+            ("record", "revision"),
+            ("record", "last_event_hash"),
+            ("record", "created_at"),
+            ("record", "updated_at"),
+        ),
+        "PolicyDecision": (
+            ("record", "id"),
+            ("record", "work_session_id"),
+            ("record", "actor_id"),
+            ("record", "policy_id"),
+            ("record", "requested_action"),
+            ("record", "normalized_action_hash"),
+            ("record", "risk_class"),
+            ("record", "result"),
+            ("record", "created_at"),
+            ("record", "request_id"),
+        ),
+        "Request": (
+            ("record", "id"),
+            ("record", "protocol_version"),
+            ("record", "work_session_id"),
+            ("record", "requester_actor_id"),
+            ("record", "requester_worker_id"),
+            ("record", "target_human_worker_id"),
+            ("record", "policy_decision_id"),
+            ("record", "type"),
+            ("record", "status"),
+            ("record", "blocking_scope"),
+            ("record", "reason_code"),
+            ("record", "reason_summary"),
+            ("record", "requested_action"),
+            ("record", "requested_outcome"),
+            ("record", "risk_class"),
+            ("record", "human_decision_needed"),
+            ("record", "options"),
+            ("record", "default_if_no_response"),
+            ("record", "created_at"),
+            ("record", "expires_at"),
+            ("record", "resolved_at"),
+            ("record", "resolved_by_review_id"),
+        ),
+        "Review": (
+            ("record", "id"),
+            ("record", "work_session_id"),
+            ("record", "reviewer_actor_id"),
+            ("record", "reviewer_worker_id"),
+            ("record", "target_ref"),
+            ("record", "decision"),
+            ("record", "created_at"),
+            ("record", "approval_scope"),
+            ("record", "approval_scope", "request_id"),
+            ("record", "approval_scope", "review_id"),
+            ("record", "approval_scope", "request_revision"),
+            ("record", "approval_scope", "request_event_hash"),
+            ("record", "approval_scope", "normalized_action_hash"),
+            ("record", "approval_scope", "approved_action"),
+            ("record", "approval_scope", "allowed_scope"),
+            ("record", "approval_scope", "denied_scope"),
+            ("record", "approval_scope", "expires_at"),
+            ("record", "approval_scope", "max_uses"),
+            ("record", "approval_scope", "applies_to_work_session_id"),
+            ("record", "approval_scope", "applies_to_actor_id"),
+        ),
+        "Takeover": (
+            ("record", "id"),
+            ("record", "work_session_id"),
+            ("record", "requested_by_actor_id"),
+            ("record", "controlling_actor_id"),
+            ("record", "request_id"),
+            ("record", "affected_scope"),
+            ("record", "affected_scope", "artifact_refs"),
+            ("record", "reason"),
+            ("record", "lock_epoch"),
+            ("record", "state"),
+            ("record", "created_at"),
+            ("record", "resumed_by_actor_id"),
+            ("record", "reconciliation_refs"),
+            ("record", "resolved_at"),
+        ),
+        "Contribution": (
+            ("record", "id"),
+            ("record", "work_session_id"),
+            ("record", "contributor_refs"),
+            ("record", "contributor_type"),
+            ("record", "contribution_type"),
+            ("record", "event_refs"),
+            ("record", "created_at"),
+        ),
+        "OutcomeReport": (
+            ("record", "id"),
+            ("record", "work_session_id"),
+            ("record", "source_ref"),
+            ("record", "reporter_ref"),
+            ("record", "accepted_by_actor_id"),
+            ("record", "outcome"),
+            ("record", "learning_record_refs"),
+            ("record", "received_at"),
+        ),
+        "LearningRecord": (
+            ("record", "id"),
+            ("record", "work_session_id"),
+            ("record", "created_by_actor_id"),
+            ("record", "subject_type"),
+            ("record", "subject_ref"),
+            ("record", "lesson_type"),
+            ("record", "source_event_refs"),
+            ("record", "review_state"),
+            ("record", "scope"),
+            ("record", "created_at"),
+        ),
+    }
+
+    for object_type, required_paths in required_object_paths.items():
+        sample = by_object_type.get(object_type)
+        if sample is None:
+            failures.append(f"{path.relative_to(ROOT)}: missing JSON sample for {object_type}")
+            continue
+        for field_path in required_paths:
+            if not has_field_path(sample, field_path):
+                joined = ".".join(field_path)
+                failures.append(f"{path.relative_to(ROOT)}: {object_type} sample missing {joined}")
+
+    if not evidence_samples:
+        failures.append(f"{path.relative_to(ROOT)}: missing EvidenceManifest JSON sample")
+        return
+    evidence_sample = evidence_samples[0]
+    for field_path in (
+        ("evidence_manifest", "id"),
+        ("evidence_manifest", "work_session_id"),
+        ("evidence_manifest", "generated_by_actor_id"),
+        ("evidence_manifest", "objective"),
+        ("evidence_manifest", "event_chain_root"),
+        ("evidence_manifest", "evidence_item_refs"),
+        ("evidence_manifest", "policy_decision_refs"),
+        ("evidence_manifest", "request_refs"),
+        ("evidence_manifest", "review_refs"),
+        ("evidence_manifest", "takeover_refs"),
+        ("evidence_manifest", "contribution_refs"),
+        ("evidence_manifest", "export_profile"),
+        ("evidence_manifest", "generated_at"),
+    ):
+        if not has_field_path(evidence_sample, field_path):
+            joined = ".".join(field_path)
+            failures.append(f"{path.relative_to(ROOT)}: EvidenceManifest sample missing {joined}")
 
 
 def main() -> int:
@@ -151,24 +439,38 @@ def main() -> int:
             f"{OPENAPI_SITE_COPY.relative_to(ROOT)}: OpenAPI site snapshot differs from docs/openapi/jarvis-openapi.yaml"
         )
 
-    for path, source_refs in CONFORMANCE_SOURCE_REFS.items():
-        if not path.exists():
-            failures.append(f"{path.relative_to(ROOT)}: missing conformance site page")
-            continue
-        page_text = path.read_text(encoding="utf-8")
-        if 'class="skip-link" href="#main-content"' not in page_text:
-            failures.append(f"{path.relative_to(ROOT)}: missing skip link")
-        if 'id="main-content"' not in page_text:
-            failures.append(f"{path.relative_to(ROOT)}: missing main content target")
-        page_refs = {clean_ref(value) for _tag, _attr, value in parsed[path].source_list_refs}
-        for source_ref in source_refs:
-            source_path = ROOT / source_ref
-            if not source_path.exists():
-                failures.append(f"{source_ref}: missing conformance source contract")
+    for page_group, source_ref_map in (
+        ("conformance", CONFORMANCE_SOURCE_REFS),
+        ("guide", GUIDE_SOURCE_REFS),
+    ):
+        for path, source_refs in source_ref_map.items():
+            if not path.exists():
+                failures.append(f"{path.relative_to(ROOT)}: missing {page_group} site page")
                 continue
-            source_url = f"{SOURCE_BASE}{source_ref}"
-            if source_url not in page_refs:
-                failures.append(f"{path.relative_to(ROOT)}: missing source contract link {source_ref}")
+            page_text = path.read_text(encoding="utf-8")
+            page_parser = parsed[path]
+            if not any(
+                tag == "a" and attr == "href" and value == "#main-content"
+                for tag, attr, value in page_parser.refs
+            ):
+                failures.append(f"{path.relative_to(ROOT)}: missing skip link")
+            if "main-content" not in page_parser.ids:
+                failures.append(f"{path.relative_to(ROOT)}: missing main content target")
+            if page_group == "guide":
+                for required_boundary_text in GUIDE_BOUNDARY_REQUIRED_TEXT:
+                    if required_boundary_text not in page_text:
+                        failures.append(
+                            f"{path.relative_to(ROOT)}: missing guide boundary text {required_boundary_text}"
+                        )
+            page_refs = {clean_ref(value) for _tag, _attr, value in page_parser.source_list_refs}
+            for source_ref in source_refs:
+                source_path = ROOT / source_ref
+                if not source_path.exists():
+                    failures.append(f"{source_ref}: missing {page_group} source contract")
+                    continue
+                source_url = f"{SOURCE_BASE}{source_ref}"
+                if source_url not in page_refs:
+                    failures.append(f"{path.relative_to(ROOT)}: missing source contract link {source_ref}")
 
     conformance_index = required_site_text(SITE_ROOT / "conformance" / "index.html", failures)
     for required_text in ("Fixture-backed proof", "Checklist-only proof"):
@@ -252,6 +554,145 @@ def main() -> int:
     ):
         if required_text not in fixtures_page:
             failures.append(f"demo/conformance/fixtures.html: missing {required_text}")
+
+    required_site_text(SITE_ROOT / "index.html", failures)
+    home_hrefs = page_hrefs(parsed, SITE_ROOT / "index.html")
+    for guide_link in (
+        "./guides/",
+        "./guides/implementer.html",
+        "./guides/existing-agent.html",
+        "./guides/request-review-takeover.html",
+        "./guides/evidence-learning.html",
+        "./guides/extensions.html",
+        "./guides/protocol-errors.html",
+        "./guides/examples.html",
+    ):
+        if guide_link not in home_hrefs:
+            failures.append(f"demo/index.html: missing guide link {guide_link}")
+
+    guide_index = required_site_text(SITE_ROOT / "guides" / "index.html", failures)
+    guide_index_hrefs = page_hrefs(parsed, SITE_ROOT / "guides" / "index.html")
+    for guide_link in GUIDE_INDEX_LINKS:
+        if guide_link not in guide_index_hrefs:
+            failures.append(f"demo/guides/index.html: missing guide index link {guide_link}")
+    for required_text in (
+        "Implementer guide",
+        "Existing-agent compatibility",
+        "Request, Review, Takeover",
+        "Evidence and Learning",
+        "Extensions",
+        "Protocol errors",
+        "Protocol examples",
+    ):
+        if required_text not in guide_index:
+            failures.append(f"demo/guides/index.html: missing {required_text}")
+
+    implementer_page = required_site_text(SITE_ROOT / "guides" / "implementer.html", failures)
+    for required_text in (
+        "Must store",
+        "Must emit",
+        "Must validate",
+        "Must reject",
+        "Jarvis-Expected-WorkSession-Revision",
+        "Jarvis-Previous-Event-Hash",
+        "PolicyDecision before an AgentWorker action",
+        "Hosts own UI, auth, storage, runtime behavior, model routing, tool execution",
+    ):
+        if required_text not in implementer_page:
+            failures.append(f"demo/guides/implementer.html: missing {required_text}")
+
+    existing_agent_guide = required_site_text(SITE_ROOT / "guides" / "existing-agent.html", failures)
+    for required_text in (
+        "Existing agents keep native execution",
+        "Jarvis does not replace the agent",
+        "Worker and Actor refs",
+        "PolicyDecision before every AgentWorker action",
+        "Jarvis-compatible does not mean Jarvis-certified",
+    ):
+        if required_text not in existing_agent_guide:
+            failures.append(f"demo/guides/existing-agent.html: missing {required_text}")
+
+    control_guide = required_site_text(SITE_ROOT / "guides" / "request-review-takeover.html", failures)
+    for required_text in (
+        "Request is a structured scoped deferral",
+        "ApprovalScope",
+        "lock_epoch",
+        "missing mutating headers",
+        "stale AgentWorker continuation",
+        "Request created with blocking_scope",
+    ):
+        if required_text not in control_guide:
+            failures.append(f"demo/guides/request-review-takeover.html: missing {required_text}")
+
+    evidence_guide = required_site_text(SITE_ROOT / "guides" / "evidence-learning.html", failures)
+    for required_text in (
+        "Contribution",
+        "EvidenceManifest",
+        "LearningRecord",
+        "MemoryProposal",
+        "SkillProposal",
+        "OutcomeReport",
+        "OutcomeReport whose source WorkSession is not terminal",
+    ):
+        if required_text not in evidence_guide:
+            failures.append(f"demo/guides/evidence-learning.html: missing {required_text}")
+
+    extension_guide = required_site_text(SITE_ROOT / "guides" / "extensions.html", failures)
+    for required_text in (
+        "Extensions MUST use a namespace",
+        "Extensions MUST NOT override core Jarvis fields",
+        "unsupported_capability",
+        "invalid_extension_namespace",
+        "extension_core_field_override",
+    ):
+        if required_text not in extension_guide:
+            failures.append(f"demo/guides/extensions.html: missing {required_text}")
+
+    errors_guide = required_site_text(SITE_ROOT / "guides" / "protocol-errors.html", failures)
+    for required_text in (
+        "error_id",
+        "protocol_version",
+        "object_type",
+        "field",
+        "reason",
+        "remediation",
+        "trace_id",
+        "outcome_report_requires_terminal_source",
+        "Do not include host-private response fields",
+    ):
+        if required_text not in errors_guide:
+            failures.append(f"demo/guides/protocol-errors.html: missing {required_text}")
+
+    examples_guide = required_site_text(SITE_ROOT / "guides" / "examples.html", failures)
+    for required_text in (
+        "Minimal WorkSession record flow",
+        "PolicyDecision before AgentWorker action",
+        "Scoped Request and Review resolution",
+        "Takeover and reconciliation",
+        "Contribution and EvidenceManifest export",
+        "OutcomeReport to LearningRecord",
+        '"object_type": "WorkSession"',
+        '"object_type": "PolicyDecision"',
+        '"object_type": "Request"',
+        '"object_type": "Review"',
+        '"object_type": "Takeover"',
+        '"object_type": "Contribution"',
+        '"evidence_manifest"',
+        '"object_type": "OutcomeReport"',
+        '"object_type": "LearningRecord"',
+        '"work_session_id"',
+        '"policy_decision_id"',
+        '"resolved_by_review_id"',
+        '"lock_epoch"',
+        '"learning_record_refs"',
+    ):
+        if required_text not in examples_guide:
+            failures.append(f"demo/guides/examples.html: missing {required_text}")
+    validate_examples_json_samples(
+        SITE_ROOT / "guides" / "examples.html",
+        parsed.get(SITE_ROOT / "guides" / "examples.html"),
+        failures,
+    )
 
     for path, parser in parsed.items():
         for tag, attr, value in parser.refs:


### PR DESCRIPTION
## Summary

- adds public docs-site implementer guide pages under `demo/guides/`
- adds protocol-only example pages for WorkSession, PolicyDecision, Request, Review, Takeover, Contribution, EvidenceManifest, OutcomeReport, and LearningRecord
- links the home page guide/example cards to the new site pages instead of raw GitHub docs
- strengthens `check_docs_site.py` to enforce guide pages, source-contract links, host-boundary text, guide index links, and valid JSON record examples

Closes #63.

## Boundary

This change is docs-site and validation only. It does not add runtime, adapter, wrapper, model routing, tool execution, auth provider, storage backend, UI framework, billing, scoring, payment, deployment, or host workflow behavior.

## Reviewer Passes

- protocol boundary and wording reviewer: findings fixed
- docs-site UX/accessibility reviewer: findings fixed
- example correctness reviewer: findings fixed
- checker coverage reviewer: findings fixed

## Validation

```txt
npm run check:protocol
```

Passed gates:

```txt
conformance fixtures ok
openapi contract ok
markdown links ok
docs site ok
Validated 2 example evidence pack(s), 75 entries.
implementation proof ok (56 checks)
protocol wording ok
sdk boundary ok
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Guides section with several static documentation pages covering protocol examples, implementer guidance, extensions, error handling, compatibility, and learning workflows.
  * Updated the main demo page to link directly to the new local guide pages for easier navigation.
* **Bug Fixes**
  * Improved consistency of guide and example links across the documentation site.
* **Tests**
  * Expanded documentation-site checks to cover guide pages, source links, and example content structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->