### PR TITLE
[codex] Link live agent proof reference harness

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -487,6 +487,12 @@ python3 scripts/check_example_evidence_packs.py</code></pre>
             </a>
             <a
               class="command"
+              href="https://github.com/Flow-Research/jarvis-live-agent-proof"
+            >
+              Live Agent Harness
+            </a>
+            <a
+              class="command"
               href="https://github.com/Flow-Research/jarvis/blob/main/scripts/check_implementation_proof.py"
             >
               Proof Validator
@@ -513,6 +519,11 @@ python3 scripts/check_example_evidence_packs.py</code></pre>
             <span>04</span>
             <h3>Publish compatibility proof</h3>
             <p>Export an evidence pack and implementation proof without claiming certification or official-host status.</p>
+          </article>
+          <article>
+            <span>05</span>
+            <h3>Run external proof harnesses</h3>
+            <p>Execute live framework proof outside Jarvis, then commit only sanitized traces and protocol exports.</p>
           </article>
         </div>
       </section>

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@ implementation-proof work without changing normative protocol rules.
 - [post-v0.1-sdk-helper-tooling/README.md](./planning/post-v0.1-sdk-helper-tooling/README.md)
 - [examples/implementation-proof/native-coding-agent/README.md](./examples/implementation-proof/native-coding-agent/README.md)
 - [examples/implementation-proof/live-agent-frameworks/README.md](./examples/implementation-proof/live-agent-frameworks/README.md)
+- [External live-agent proof harness](https://github.com/Flow-Research/jarvis-live-agent-proof)
 
 ## Planning Archive
 
@@ -65,6 +66,7 @@ defining host-owned execution.
 - [examples/evidence-packs/existing-agent-takeover/README.md](./examples/evidence-packs/existing-agent-takeover/README.md)
 - [examples/implementation-proof/native-coding-agent/README.md](./examples/implementation-proof/native-coding-agent/README.md)
 - [examples/implementation-proof/live-agent-frameworks/README.md](./examples/implementation-proof/live-agent-frameworks/README.md)
+- [External live-agent proof harness](https://github.com/Flow-Research/jarvis-live-agent-proof)
 
 ## OpenAPI
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -29,6 +29,10 @@ adapters, wrappers, SDK implementation, or host workflow.
   live external-host proof for LangGraph, DeepAgents, and AgentScope mapped
   into Jarvis protocol records.
 
+Runnable external proof harness:
+
+- [Flow-Research/jarvis-live-agent-proof](https://github.com/Flow-Research/jarvis-live-agent-proof)
+
 ## Validation
 
 Validate evidence packs from the repository root:

--- a/docs/examples/implementation-proof/README.md
+++ b/docs/examples/implementation-proof/README.md
@@ -12,6 +12,11 @@ Jarvis records protocol state. Hosts own native execution.
   live external-host proof for LangGraph, DeepAgents, and AgentScope with
   OpenAI model execution mapped into Jarvis protocol records.
 
+The runnable host-side harness for the live framework proof stays outside this
+repository:
+
+- [Flow-Research/jarvis-live-agent-proof](https://github.com/Flow-Research/jarvis-live-agent-proof)
+
 ## Boundary
 
 Implementation proof records do not define runtime behavior, host UI, storage,

--- a/docs/examples/implementation-proof/live-agent-frameworks/README.md
+++ b/docs/examples/implementation-proof/live-agent-frameworks/README.md
@@ -35,6 +35,17 @@ keep only portable proof evidence.
 - [agentscope_trace.json](./agentscope_trace.json)
 - [agentscope_protocol_export.json](./agentscope_protocol_export.json)
 
+## Runnable Harness
+
+The host-side live harness lives outside Jarvis:
+
+- [Flow-Research/jarvis-live-agent-proof](https://github.com/Flow-Research/jarvis-live-agent-proof)
+
+That repository owns live framework execution for proof runs. Jarvis keeps only
+the sanitized traces, protocol exports, validation rules, and evidence records.
+The harness does not become a Jarvis runtime, adapter, wrapper, host, or
+official implementation.
+
 ## Boundary
 
 This proof does not add runtime behavior to Jarvis.

--- a/scripts/check_docs_site.py
+++ b/scripts/check_docs_site.py
@@ -206,6 +206,8 @@ def github_target_exists(value: str) -> bool:
     parsed = urlparse(value)
     if parsed.netloc == "github.com" and parsed.path == "/Flow-Research/jarvis":
         return True
+    if parsed.netloc == "github.com" and parsed.path == "/Flow-Research/jarvis-live-agent-proof":
+        return True
     if parsed.netloc == "github.com" and parsed.path.startswith(BLOB_PREFIX):
         target = parsed.path.removeprefix(BLOB_PREFIX)
         return (ROOT / target).exists()


### PR DESCRIPTION
## Summary

Links the external live-agent proof harness from the Jarvis docs and docs site.

## Protocol Surface

This change does not alter protocol objects, OpenAPI schemas, conformance fixtures, SDK helpers, or implementation-proof artifacts.

## Boundary Check

Jarvis keeps only sanitized traces, protocol exports, validation rules, and evidence records. The live harness remains outside Jarvis at `Flow-Research/jarvis-live-agent-proof` and owns live framework execution for proof runs.

## Validation

- `python3 scripts/check_implementation_proof.py`
- `python3 scripts/check_markdown_links.py`
- `python3 scripts/check_docs_site.py`
- `python3 scripts/check_protocol_wording.py`
- `git diff --check`
- `npm run check:protocol`
